### PR TITLE
Add: New Luxury Variant Sections

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -928,7 +928,7 @@ export default function SubmissionDetailPage() {
                         {websiteGenerated && (
                             <div className="flex space-x-2">
                                 <a
-                                    href={`/website/${submissionId}`}
+                                    href={`/api/preview/${submissionId}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center px-4 py-2 border border-blue-600 text-blue-600 rounded-md hover:bg-blue-50 text-sm font-medium"

--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -383,6 +383,33 @@ IMPORTANT:
             }
         }
 
+        // Resolve product images inside featured_products (convex:storageId → URL)
+        const rawProducts = (extractedContent as any)?.featured_products || []
+        let resolvedProducts = rawProducts
+        if (rawProducts.length > 0) {
+            const productImageIds = rawProducts
+                .map((p: any) => p.image)
+                .filter((img: string | undefined) => img && !img.startsWith('http'))
+                .map((img: string) => img.replace(/^convex:/, ''))
+
+            if (productImageIds.length > 0) {
+                try {
+                    const resolvedUrls = await fetchQuery(api.files.getMultipleUrls, {
+                        storageIds: productImageIds
+                    })
+                    resolvedProducts = rawProducts.map((p: any) => {
+                        if (!p.image || p.image.startsWith('http')) return p
+                        const cleanId = p.image.replace(/^convex:/, '')
+                        const idx = productImageIds.indexOf(cleanId)
+                        const resolvedUrl = idx !== -1 ? resolvedUrls[idx] : null
+                        return { ...p, image: resolvedUrl || p.image }
+                    })
+                } catch (error) {
+                    console.error('Error resolving product image URLs:', error)
+                }
+            }
+        }
+
         const defaultCustomizations = {
             heroStyle: 'A',
             aboutStyle: 'A',
@@ -417,6 +444,7 @@ IMPORTANT:
             tone: extractedContent?.tone || 'professional-friendly',
             // Optional fields
             hero_cta: extractedContent?.hero_cta,
+            hero_cta_secondary: extractedContent?.hero_cta_secondary,
             services_cta: extractedContent?.services_cta,
             methodology: extractedContent?.methodology,
             // Hero section fields
@@ -473,7 +501,7 @@ IMPORTANT:
             // Featured section fields - generate defaults if not present
             featured_headline: (extractedContent as any)?.featured_headline || 'Featured Products',
             featured_subheadline: (extractedContent as any)?.featured_subheadline || `Take a look at some of our recent work at ${submission.business_name}`,
-            featured_products: (extractedContent as any)?.featured_products || generateDefaultFeaturedProducts(submission.business_name, submission.business_type, photos.length),
+            featured_products: resolvedProducts.length > 0 ? resolvedProducts : generateDefaultFeaturedProducts(submission.business_name, submission.business_type, photos.length),
             featured_images: resolvedFeaturedImages.length > 0 ? resolvedFeaturedImages : undefined,
             // Featured CTA fields for style 4
             featured_cta_text: (extractedContent as any)?.featured_cta_text,

--- a/astro-site-template/src/components/about/AboutF.astro
+++ b/astro-site-template/src/components/about/AboutF.astro
@@ -1,0 +1,130 @@
+---
+/**
+ * AboutF - Luxury Story Layout
+ * Two-column layout with image on left and story content on right,
+ * featuring a label with decorative line, serif heading, dual paragraphs,
+ * and a stats counter row.
+ */
+interface Props {
+  businessName: string;
+  description: string;
+  headline?: string;
+  tagline?: string;
+  tags?: string[];
+  usps?: string[];
+  photos: string[];
+  visibility?: Record<string, boolean>;
+}
+
+const {
+  businessName,
+  description,
+  headline = 'Our Story',
+  tagline,
+  tags = [],
+  usps = [],
+  photos = [],
+  visibility,
+} = Astro.props;
+
+const showBadge = visibility?.aboutBadge !== false;
+const showHeadline = visibility?.aboutHeadline !== false;
+const showDescription = visibility?.aboutDescription !== false;
+const showImages = visibility?.aboutImages !== false;
+
+const mainImage = photos[0] || '';
+
+// Split description into paragraphs if it contains newlines, otherwise split at midpoint
+const descParagraphs = description.includes('\n')
+  ? description.split('\n').filter(p => p.trim())
+  : [description];
+---
+
+<section id="about" class="relative py-24 lg:py-32 bg-[var(--bg)] overflow-hidden">
+  <div class="container mx-auto px-6">
+    <div class="grid lg:grid-cols-2 gap-16 lg:gap-24 items-center">
+
+      {/* Image Side */}
+      {showImages && (
+        <div class="reveal relative">
+          <div class="aspect-[4/5] overflow-hidden rounded-lg">
+            {mainImage ? (
+              <img src={mainImage} alt={businessName} class="w-full h-full object-cover transition-transform duration-700 hover:scale-105" loading="lazy" />
+            ) : (
+              <div class="w-full h-full bg-gradient-to-br from-[var(--secondary)] to-[var(--primary)]"></div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Content Side */}
+      <div>
+        {showBadge && (
+          <div class="reveal flex items-center gap-4 mb-8">
+            <span class="w-10 h-[2px] bg-[var(--primary)]"></span>
+            <span class="text-xs font-semibold tracking-[0.25em] uppercase text-[var(--primary)]">
+              {tagline || 'Our Story'}
+            </span>
+          </div>
+        )}
+
+        {showHeadline && (
+          <h2 class="reveal-delay-1 reveal mb-10 font-normal leading-[1.15] text-[var(--text)]"
+              style="font-size: var(--fs-display); font-family: var(--heading-font);">
+            {headline}
+          </h2>
+        )}
+
+        {showDescription && (
+          <div class="reveal-delay-2 reveal space-y-6 mb-12">
+            {descParagraphs.map((para) => (
+              <p class="text-[var(--text-muted)] leading-[1.8]" style="font-size: var(--fs-base);">
+                {para}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {/* Stats Row */}
+        {usps.length > 0 && (
+          <div class="reveal-delay-3 reveal flex flex-wrap gap-12 pt-8 border-t border-[var(--text)]/10">
+            {usps.slice(0, 3).map((usp) => {
+              // Try to extract number and label from USP text (e.g. "16+ Years of Excellence")
+              const match = usp.match(/^([\d,]+\+?[KkMm]?)\s+(.+)$/);
+              if (match) {
+                return (
+                  <div class="text-left">
+                    <p class="text-[var(--primary)] font-normal mb-1" style="font-size: var(--fs-2xl); font-family: var(--heading-font);">
+                      {match[1]}
+                    </p>
+                    <p class="text-[var(--text-muted)] text-xs tracking-wide">{match[2]}</p>
+                  </div>
+                );
+              }
+              return (
+                <div class="text-left">
+                  <p class="text-[var(--text-muted)] text-sm">{usp}</p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .reveal-delay-1 { transition-delay: 0.15s; }
+  .reveal-delay-2 { transition-delay: 0.3s; }
+  .reveal-delay-3 { transition-delay: 0.45s; }
+</style>

--- a/astro-site-template/src/components/contact/ContactF.astro
+++ b/astro-site-template/src/components/contact/ContactF.astro
@@ -1,0 +1,171 @@
+---
+/**
+ * ContactF - Luxury Footer Contact
+ * A multi-column footer-style contact section with business logo/description,
+ * navigation links, business hours, location info, social icons,
+ * and a bottom copyright bar.
+ */
+interface Props {
+  businessName: string;
+  email: string;
+  phone: string;
+  address?: string;
+  whatsapp?: string;
+  messenger?: string;
+  description?: string;
+  socialLinks?: Array<{ platform: string; url: string }>;
+  featuredImage?: string;
+  photos: string[];
+  visibility?: Record<string, boolean>;
+}
+
+const {
+  businessName,
+  email,
+  phone,
+  address,
+  description = 'Every dish tells a story, every visit creates a memory.',
+  socialLinks = [],
+  photos = [],
+  visibility,
+} = Astro.props;
+
+const showHeadline = visibility?.contactHeadline !== false;
+const showDescription = visibility?.contactDescription !== false;
+const showInfo = visibility?.contactInfo !== false;
+const showSocial = visibility?.contactSocial !== false && socialLinks.length > 0;
+
+const year = new Date().getFullYear();
+
+// Social SVG icons
+const socialIcons: Record<string, string> = {
+  instagram: '<rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/>',
+  facebook: '<path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/>',
+  twitter: '<path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"/>',
+  linkedin: '<path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-2-2 2 2 0 00-2 2v7h-4v-7a6 6 0 016-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/>',
+  youtube: '<path d="M22.54 6.42a2.78 2.78 0 00-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 00-1.94 2A29 29 0 001 11.75a29 29 0 00.46 5.33A2.78 2.78 0 003.4 19.1c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 001.94-2 29 29 0 00.46-5.25 29 29 0 00-.46-5.33z"/><polygon points="9.75,15.02 15.5,11.75 9.75,8.48"/>',
+  tiktok: '<path d="M9 12a4 4 0 104 4V4a5 5 0 005 5"/>',
+};
+
+// Navigation links for the footer
+const navLinks = [
+  { label: 'Home', href: '#hero' },
+  { label: 'About Us', href: '#about' },
+  { label: 'Our Menu', href: '#gallery' },
+  { label: 'Services', href: '#services' },
+  { label: 'Reservations', href: '#contact' },
+];
+---
+
+<section id="contact" class="relative pt-20 pb-8 bg-[var(--bg)] border-t border-[var(--text)]/5">
+  <div class="container mx-auto px-6">
+
+    {/* Main Footer Grid */}
+    <div class="reveal grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 lg:gap-8 pb-16 border-b border-[var(--text)]/10">
+
+      {/* Column 1: Brand + Description */}
+      <div>
+        {showHeadline && (
+          <h3 class="text-[var(--text)] font-bold mb-4 tracking-wide"
+              style="font-size: var(--fs-lg); font-family: var(--heading-font);">
+            {businessName}
+          </h3>
+        )}
+
+        {showDescription && (
+          <p class="text-[var(--text-muted)] text-sm leading-relaxed mb-6">
+            {description}
+          </p>
+        )}
+
+        {/* Social Icons */}
+        {showSocial && (
+          <div class="flex gap-3">
+            {socialLinks.map((link) => (
+              <a href={link.url}
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="w-10 h-10 rounded-full border border-[var(--text)]/15 flex items-center justify-center text-[var(--text-muted)] transition-all duration-300 hover:border-[var(--primary)] hover:text-[var(--primary)] hover:bg-[var(--primary)]/5"
+                 aria-label={link.platform}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={socialIcons[link.platform] || ''} />
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Column 2: Navigation */}
+      <div>
+        <h4 class="text-[var(--primary)] font-semibold text-sm tracking-wide mb-6">Navigation</h4>
+        <ul class="space-y-3">
+          {navLinks.map((link) => (
+            <li>
+              <a href={link.href}
+                 class="text-[var(--text-muted)] text-sm transition-colors duration-300 hover:text-[var(--text)]">
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Column 3: Hours (or additional info) */}
+      {showInfo && (
+        <div>
+          <h4 class="text-[var(--primary)] font-semibold text-sm tracking-wide mb-6">Hours</h4>
+          <ul class="space-y-3 text-[var(--text-muted)] text-sm">
+            <li>Mon – Thu: 5pm – 10pm</li>
+            <li>Fri – Sat: 5pm – 11pm</li>
+            <li>Sunday: 4pm – 9pm</li>
+            <li>Brunch: Sat–Sun 10am–2pm</li>
+          </ul>
+        </div>
+      )}
+
+      {/* Column 4: Location & Contact */}
+      {showInfo && (
+        <div>
+          <h4 class="text-[var(--primary)] font-semibold text-sm tracking-wide mb-6">Location</h4>
+          <ul class="space-y-3 text-[var(--text-muted)] text-sm">
+            {address && <li>{address}</li>}
+            {phone && (
+              <li>
+                <a href={`tel:${phone}`} class="transition-colors hover:text-[var(--text)]">{phone}</a>
+              </li>
+            )}
+            {email && (
+              <li>
+                <a href={`mailto:${email}`} class="transition-colors hover:text-[var(--text)]">{email}</a>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+
+    {/* Bottom Bar */}
+    <div class="reveal-delay-1 reveal flex flex-col md:flex-row items-center justify-between gap-4 pt-8">
+      <p class="text-[var(--text-muted)] text-xs">
+        &copy; {year} {businessName}. All rights reserved.
+      </p>
+      <div class="flex gap-6 text-[var(--text-muted)] text-xs">
+        <span class="hover:text-[var(--text)] transition-colors cursor-pointer">Privacy Policy</span>
+        <span class="hover:text-[var(--text)] transition-colors cursor-pointer">Terms of Service</span>
+        <span class="hover:text-[var(--text)] transition-colors cursor-pointer">Accessibility</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .reveal-delay-1 { transition-delay: 0.2s; }
+</style>

--- a/astro-site-template/src/components/gallery/GalleryF.astro
+++ b/astro-site-template/src/components/gallery/GalleryF.astro
@@ -1,0 +1,143 @@
+---
+/**
+ * GalleryF - Luxury Product Showcase
+ * Centered header with decorative badge, 3-column product cards featuring
+ * large images, product names with prices, descriptions, and a CTA button.
+ */
+interface Props {
+  headline?: string;
+  subheadline?: string;
+  items: Array<{
+    title: string;
+    description: string;
+    image?: string;
+    tags?: string[];
+    testimonial?: {
+      quote: string;
+      author: string;
+      avatar?: string;
+    };
+  }>;
+  images?: string[];
+  ctaText?: string;
+  ctaLink?: string;
+  photos: string[];
+  visibility?: Record<string, boolean>;
+}
+
+const {
+  headline = 'From Our Kitchen',
+  subheadline = 'Handcrafted seasonal dishes that define our culinary philosophy.',
+  items = [],
+  ctaText = 'View Full Menu',
+  ctaLink = '#contact',
+  photos = [],
+  visibility,
+} = Astro.props;
+
+const showHeadline = visibility?.galleryHeadline !== false;
+const showSubheadline = visibility?.gallerySubheadline !== false;
+const showItems = visibility?.galleryItems !== false;
+---
+
+<section id="gallery" class="relative py-24 lg:py-32 bg-[var(--bg)] overflow-hidden">
+  <div class="container mx-auto px-6">
+
+    {/* Section Header - Centered */}
+    <div class="text-center max-w-3xl mx-auto mb-16">
+      <div class="reveal flex items-center justify-center gap-4 mb-6">
+        <span class="w-12 h-[1px] bg-[var(--primary)]"></span>
+        <span class="text-xs font-semibold tracking-[0.25em] uppercase text-[var(--primary)]">
+          Signature Dishes
+        </span>
+        <span class="w-12 h-[1px] bg-[var(--primary)]"></span>
+      </div>
+
+      {showHeadline && (
+        <h2 class="reveal-delay-1 reveal mb-6 font-normal leading-[1.15] text-[var(--text)]"
+            style="font-size: var(--fs-display); font-family: var(--heading-font);">
+          {headline}
+        </h2>
+      )}
+
+      {showSubheadline && (
+        <p class="reveal-delay-2 reveal text-[var(--text-muted)] leading-relaxed"
+           style="font-size: var(--fs-base);">
+          {subheadline}
+        </p>
+      )}
+    </div>
+
+    {/* Product Cards Grid */}
+    {showItems && (
+      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
+        {items.map((item, index) => {
+          const itemImage = item.image || photos[index] || '';
+          // Extract price from tags if available (e.g., "$128")
+          const priceTag = item.tags?.find(t => t.startsWith('$') || t.match(/^\d/));
+          const otherTags = item.tags?.filter(t => t !== priceTag);
+
+          return (
+            <div class={`reveal reveal-delay-${(index % 3) + 1} group`}>
+              {/* Image */}
+              <div class="aspect-[4/3] overflow-hidden rounded-lg mb-6">
+                {itemImage ? (
+                  <img src={itemImage} alt={item.title}
+                       class="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
+                       loading="lazy" />
+                ) : (
+                  <div class="w-full h-full bg-[var(--surface)]"></div>
+                )}
+              </div>
+
+              {/* Title + Price Row */}
+              <div class="flex items-baseline justify-between mb-3">
+                <h3 class="text-[var(--text)] font-semibold leading-tight"
+                    style="font-size: var(--fs-lg); font-family: var(--heading-font);">
+                  {item.title}
+                </h3>
+                {priceTag && (
+                  <span class="text-[var(--primary)] font-semibold ml-4 flex-shrink-0"
+                        style="font-family: var(--heading-font);">
+                    {priceTag}
+                  </span>
+                )}
+              </div>
+
+              {/* Description */}
+              <p class="text-[var(--text-muted)] text-sm leading-relaxed">
+                {item.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    )}
+
+    {/* CTA Button */}
+    <div class="reveal text-center">
+      <a href={ctaLink}
+         class="inline-flex items-center gap-3 px-8 py-4 font-semibold text-[var(--bg)] bg-[var(--primary)] rounded-sm transition-all duration-300 hover:brightness-110 hover:shadow-lg hover:shadow-[var(--primary)]/20 tracking-wide text-sm">
+        {ctaText}
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+        </svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .reveal-delay-1 { transition-delay: 0.1s; }
+  .reveal-delay-2 { transition-delay: 0.2s; }
+  .reveal-delay-3 { transition-delay: 0.3s; }
+</style>

--- a/astro-site-template/src/components/heroes/HeroF.astro
+++ b/astro-site-template/src/components/heroes/HeroF.astro
@@ -1,0 +1,116 @@
+---
+/**
+ * HeroF - Luxury Dark Elegant
+ * A full-screen background image hero with centered content, decorative badge,
+ * large serif heading, description text, and dual CTA buttons.
+ */
+interface Props {
+  businessName: string;
+  headline: string;
+  description: string;
+  badgeText?: string;
+  testimonial?: string;
+  ctaLabel?: string;
+  ctaLink?: string;
+  ctaSecondaryLabel?: string;
+  ctaSecondaryLink?: string;
+  photos: string[];
+  services?: Array<{ name: string; description: string }>;
+  visibility?: Record<string, boolean>;
+}
+
+const {
+  businessName,
+  headline,
+  description,
+  badgeText,
+  ctaLabel = 'Explore Our Menu',
+  ctaLink = '#services',
+  ctaSecondaryLabel = 'Our Story',
+  ctaSecondaryLink = '#about',
+  photos = [],
+  visibility,
+} = Astro.props;
+
+const mainPhoto = photos[0] || '';
+
+const showHeadline = visibility?.heroHeadline !== false;
+const showTagline = visibility?.heroTagline !== false && !!badgeText;
+const showDescription = visibility?.heroDescription !== false;
+const showButton = visibility?.heroButton !== false;
+const showImage = visibility?.heroImage !== false;
+---
+
+<section id="hero" class="relative min-h-screen flex items-center justify-center overflow-hidden">
+  {/* Background Image */}
+  {showImage && mainPhoto && (
+    <div class="absolute inset-0 z-0">
+      <img src={mainPhoto} alt={businessName} class="w-full h-full object-cover" />
+      <div class="absolute inset-0 bg-black/60"></div>
+      <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-black/50"></div>
+    </div>
+  )}
+
+  {/* Fallback dark background if no image */}
+  {(!showImage || !mainPhoto) && (
+    <div class="absolute inset-0 z-0 bg-[var(--bg)]"></div>
+  )}
+
+  <div class="container mx-auto px-6 relative z-10 text-center max-w-4xl">
+    {showTagline && (
+      <div class="reveal mb-8 flex items-center justify-center">
+        <span class="inline-flex items-center gap-3 px-6 py-2.5 rounded-full border border-[var(--primary)]/40 bg-[var(--primary)]/10 backdrop-blur-sm">
+          <svg class="w-4 h-4 text-[var(--primary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+          </svg>
+          <span class="text-xs font-semibold tracking-[0.2em] uppercase text-[var(--primary)]">{badgeText}</span>
+        </span>
+      </div>
+    )}
+
+    {showHeadline && (
+      <h1 class="reveal-delay-1 reveal mb-8 font-normal leading-[1.1] text-white"
+          style="font-size: clamp(2.5rem, 6vw, 5rem); font-family: var(--heading-font);">
+        {headline}
+      </h1>
+    )}
+
+    {showDescription && (
+      <p class="reveal-delay-2 reveal mb-12 text-white/70 leading-relaxed max-w-2xl mx-auto"
+         style="font-size: var(--fs-lg);">
+        {description}
+      </p>
+    )}
+
+    {showButton && (
+      <div class="reveal-delay-3 reveal flex flex-wrap items-center justify-center gap-4">
+        <a href={ctaLink}
+           class="inline-flex items-center justify-center px-8 py-4 font-semibold text-[var(--bg)] bg-[var(--primary)] rounded-sm transition-all duration-300 hover:brightness-110 hover:shadow-lg hover:shadow-[var(--primary)]/20 tracking-wide text-sm">
+          {ctaLabel}
+        </a>
+        <a href={ctaSecondaryLink}
+           class="inline-flex items-center justify-center px-8 py-4 font-semibold text-white border border-white/30 rounded-sm transition-all duration-300 hover:bg-white/10 tracking-wide text-sm">
+          {ctaSecondaryLabel}
+        </a>
+      </div>
+    )}
+  </div>
+
+  {/* Bottom gradient fade */}
+  <div class="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-[var(--bg)] to-transparent z-[5]"></div>
+</section>
+
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 1s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .reveal-delay-1 { transition-delay: 0.2s; }
+  .reveal-delay-2 { transition-delay: 0.4s; }
+  .reveal-delay-3 { transition-delay: 0.6s; }
+</style>

--- a/astro-site-template/src/components/services/ServicesF.astro
+++ b/astro-site-template/src/components/services/ServicesF.astro
@@ -1,0 +1,120 @@
+---
+/**
+ * ServicesF - Luxury Card Grid
+ * Centered header with decorative line accents around the badge,
+ * serif heading, description, and a 4-column card grid with icons,
+ * bordered cards on dark background.
+ */
+interface Props {
+  headline?: string;
+  subheadline?: string;
+  services: Array<{
+    name: string;
+    description: string;
+    icon?: string;
+  }>;
+  photos: string[];
+  visibility?: Record<string, boolean>;
+}
+
+const {
+  headline = 'Exceptional Services',
+  subheadline = 'We tailor every experience to perfection.',
+  services = [],
+  photos = [],
+  visibility,
+} = Astro.props;
+
+const showHeadline = visibility?.servicesHeadline !== false;
+const showBadge = visibility?.servicesBadge !== false;
+const showSubheadline = visibility?.servicesSubheadline !== false;
+const showList = visibility?.servicesList !== false;
+
+// Elegant service icons - thin line style
+const serviceIcons: string[] = [
+  // Utensils / dining
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 002-2V2"/><path d="M7 2v20"/><path d="M21 15V2v0a5 5 0 00-5 5v6c0 1.1.9 2 2 2h3zm0 0v7"/></svg>`,
+  // Wine glass / events
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 22h8"/><path d="M12 11v11"/><path d="M19.5 8c0 3-3.358 5-7.5 5s-7.5-2-7.5-5c0-1.5.5-3 1-4h13c.5 1 1 2.5 1 4z"/></svg>`,
+  // Chef hat / culinary
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 13.87A4 4 0 017.41 6a5.11 5.11 0 011.05-1.54 5 5 0 017.08 0A5.11 5.11 0 0116.59 6 4 4 0 0118 13.87V21H6z"/><line x1="6" y1="17" x2="18" y2="17"/></svg>`,
+  // Truck / catering delivery
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg>`,
+  // Star / premium
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>`,
+  // Heart / passion
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>`,
+];
+---
+
+<section id="services" class="relative py-24 lg:py-32 bg-[var(--bg)]">
+  <div class="container mx-auto px-6">
+
+    {/* Section Header - Centered */}
+    <div class="text-center max-w-3xl mx-auto mb-20">
+      {showBadge && (
+        <div class="reveal flex items-center justify-center gap-4 mb-6">
+          <span class="w-12 h-[1px] bg-[var(--primary)]"></span>
+          <span class="text-xs font-semibold tracking-[0.25em] uppercase text-[var(--primary)]">
+            What We Offer
+          </span>
+          <span class="w-12 h-[1px] bg-[var(--primary)]"></span>
+        </div>
+      )}
+
+      {showHeadline && (
+        <h2 class="reveal-delay-1 reveal mb-6 font-normal leading-[1.15] text-[var(--text)]"
+            style="font-size: var(--fs-display); font-family: var(--heading-font);">
+          {headline}
+        </h2>
+      )}
+
+      {showSubheadline && (
+        <p class="reveal-delay-2 reveal text-[var(--text-muted)] leading-relaxed"
+           style="font-size: var(--fs-base);">
+          {subheadline}
+        </p>
+      )}
+    </div>
+
+    {/* Service Cards Grid */}
+    {showList && (
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {services.map((service, index) => (
+          <div class={`reveal reveal-delay-${(index % 4) + 1} group relative p-8 rounded-lg border border-[var(--text)]/10 bg-[var(--surface)] transition-all duration-500 hover:border-[var(--primary)]/30 hover:-translate-y-1`}>
+            {/* Icon */}
+            <div class="mb-6 w-14 h-14 rounded-lg border border-[var(--primary)]/30 text-[var(--primary)] flex items-center justify-center transition-all duration-500 group-hover:bg-[var(--primary)]/10">
+              <div class="w-7 h-7" set:html={serviceIcons[index % serviceIcons.length]} />
+            </div>
+
+            {/* Content */}
+            <h3 class="text-[var(--text)] font-semibold mb-3 leading-tight"
+                style="font-size: var(--fs-lg); font-family: var(--heading-font);">
+              {service.name}
+            </h3>
+
+            <p class="text-[var(--text-muted)] leading-relaxed text-sm">
+              {service.description}
+            </p>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+</section>
+
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: all 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .reveal-delay-1 { transition-delay: 0.1s; }
+  .reveal-delay-2 { transition-delay: 0.2s; }
+  .reveal-delay-3 { transition-delay: 0.3s; }
+  .reveal-delay-4 { transition-delay: 0.4s; }
+</style>

--- a/astro-site-template/src/data/site-data.json
+++ b/astro-site-template/src/data/site-data.json
@@ -1,7 +1,7 @@
 {
   "layout": {
-    "businessName": "Aloja Carvajal Aesthetic and Beauty Studio",
-    "tagline": "Beauty that lasts, confidence that grows",
+    "businessName": "HAPAG",
+    "tagline": "Savoring Filipino Flavors 24/7",
     "navLinks": [
       {
         "href": "#about",
@@ -21,26 +21,26 @@
       }
     ],
     "socialLinks": [],
-    "colorScheme": "pink",
-    "fontPairing": "classic",
+    "colorScheme": "black",
+    "fontPairing": "professional",
     "contact": {
-      "address": "Heritage homes, Marilao, Bulacan, Marilao",
-      "email": "josephinecarvajal110168@gmail.com",
-      "phone": "9177871293"
+      "address": "Block 82 lot 5 Camalig Ema town Center Sto. Niño, MEYCAUAYAN",
+      "email": "joycedungo15@gmail.com",
+      "phone": "9756632359"
     }
   },
   "customizations": {
-    "heroStyle": "E",
-    "aboutStyle": "E",
-    "servicesStyle": "E",
-    "galleryStyle": "E",
-    "contactStyle": "C"
+    "heroStyle": "F",
+    "aboutStyle": "F",
+    "servicesStyle": "A",
+    "galleryStyle": "F",
+    "contactStyle": "F"
   },
   "visibility": {
     "heroSection": true,
     "heroHeadline": true,
     "heroTagline": true,
-    "heroDescription": true,
+    "heroDescription": false,
     "heroTestimonial": true,
     "heroButton": true,
     "heroImage": true,
@@ -70,50 +70,52 @@
     "contactSocial": true
   },
   "hero": {
-    "businessName": "Aloja Carvajal Aesthetic and Beauty Studio",
-    "headline": "Beauty that lasts, confidence that grows",
-    "description": "Josephine Carvajal is a premier barber and salon in Marilao, Bulacan, dedicated to providing personalized beauty services that cater to each client's unique needs. With a focus on creating a welcoming and comfortable environment, our experienced team helps clients feel confident and beautiful. We offer a range of services for everyday beauty needs and special occasions.",
+    "businessName": "HAPAG",
+    "headline": "Savoring Filipino Flavors 24/7",
+    "description": "HAPAG is a 24-hour restaurant serving authentic Filipino dishes in a fun and relaxing atmosphere. With live band entertainment from Monday to Friday, we offer a unique dining experience. Our mezzanine area is also available for events and gatherings.",
+    "ctaLabel": "Explore Our Menu",
+    "ctaLink": "#services",
+    "ctaSecondaryLabel": "Our Story",
+    "ctaSecondaryLink": "#about",
     "photos": [
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg",
-      "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf",
-      "https://diligent-ibex-454.convex.cloud/api/storage/c1e7f8f5-1b6e-440c-a142-fcbb7f35aa8c"
+      "https://diligent-ibex-454.convex.cloud/api/storage/6939e1c2-cbba-4143-a499-22b0ad99e00c",
+      "https://diligent-ibex-454.convex.cloud/api/storage/c664fe21-705b-4f24-801c-bfc0dec4eeb4",
+      "https://diligent-ibex-454.convex.cloud/api/storage/716a61f5-f89c-4d20-a1f9-f415323324cb"
     ],
     "services": [
       {
-        "description": "Customized haircuts, styling, and grooming for men and women",
-        "name": "Hair Styling"
+        "description": "Enjoy your favorite Filipino dishes at any time of the day",
+        "name": "24-Hour Dining"
       },
       {
-        "description": "Professional hair coloring and highlighting services to enhance your look",
-        "name": "Hair Color"
+        "description": "Experience live music from Monday to Friday",
+        "name": "Live Band Entertainment"
       },
       {
-        "description": "Expert makeup applications for weddings, parties, and other special events",
-        "name": "Makeup Services"
+        "description": "Host your events and gatherings in our mezzanine area",
+        "name": "Event Hosting"
       }
     ],
     "visibility": {
       "heroHeadline": true,
       "heroTagline": true,
-      "heroDescription": true,
+      "heroDescription": false,
       "heroTestimonial": true,
       "heroButton": true,
       "heroImage": true
     }
   },
   "about": {
-    "businessName": "Aloja Carvajal Aesthetic and Beauty Studio",
-    "description": "Josephine Carvajal is a premier barber and salon in Marilao, Bulacan, dedicated to providing personalized beauty services that cater to each client's unique needs. With a focus on creating a welcoming and comfortable environment, our experienced team helps clients feel confident and beautiful. We offer a range of services for everyday beauty needs and special occasions.",
+    "businessName": "HAPAG",
+    "description": "HAPAG is a 24-hour restaurant serving authentic Filipino dishes in a fun and relaxing atmosphere. With live band entertainment from Monday to Friday, we offer a unique dining experience. Our mezzanine area is also available for events and gatherings.",
     "headline": "About Us",
     "usps": [
-      "Personalized care",
-      "Experienced team",
-      "Welcoming environment"
+      "24-hour operation",
+      "Live band entertainment",
+      "Mezzanine area for events"
     ],
     "photos": [
-      "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf",
-      "https://diligent-ibex-454.convex.cloud/api/storage/c1e7f8f5-1b6e-440c-a142-fcbb7f35aa8c",
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg"
+      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1773240934855-v2fag1nr.jpg"
     ],
     "visibility": {
       "aboutBadge": true,
@@ -128,20 +130,20 @@
     "headline": "Our Services",
     "services": [
       {
-        "description": "Customized haircuts, styling, and grooming for men and women",
-        "name": "Hair Styling"
+        "description": "Enjoy your favorite Filipino dishes at any time of the day",
+        "name": "24-Hour Dining"
       },
       {
-        "description": "Professional hair coloring and highlighting services to enhance your look",
-        "name": "Hair Color"
+        "description": "Experience live music from Monday to Friday",
+        "name": "Live Band Entertainment"
       },
       {
-        "description": "Expert makeup applications for weddings, parties, and other special events",
-        "name": "Makeup Services"
+        "description": "Host your events and gatherings in our mezzanine area",
+        "name": "Event Hosting"
       }
     ],
     "photos": [
-      "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf"
+      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1773240934026-y3qeot9p.jpg"
     ],
     "visibility": {
       "servicesBadge": true,
@@ -152,58 +154,53 @@
     }
   },
   "gallery": {
-    "headline": "Our Featured Services",
-    "subheadline": "Showcasing our expertise in beauty and wellness",
+    "headline": "Signature Dishes",
+    "subheadline": "A taste of authentic Filipino cuisine",
     "items": [
       {
-        "title": "Wedding Day Makeup",
-        "description": "Our team provided expert makeup services for a beautiful bride on her special day, ensuring she felt confident and stunning. We used high-quality products and techniques to create a flawless, long-lasting look. The result was a truly unforgettable wedding day appearance.",
-        "image": "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg",
+        "title": "Adobo Fiesta",
+        "description": "Our signature adobo dish made with tender chicken and savory sauce, served with steamed rice. This classic Filipino dish is a must-try. We use only the freshest ingredients to ensure the best flavor.",
+        "image": "https://diligent-ibex-454.convex.cloud/api/storage/2f0a2c5b-29c9-42b8-a685-3d0d4b28ebb9",
         "tags": [
-          "Makeup",
-          "Full-day"
+          "Filipino Cuisine",
+          "30 minutes"
         ],
         "testimonial": {
-          "author": "Ms. Rodriguez",
-          "quote": "I felt like a princess on my wedding day, thanks to the amazing makeup services from Josephine Carvajal. The team was professional, friendly, and truly talented. I received countless compliments on my makeup, and I couldn't be happier with the results."
+          "author": "Maria Rodriguez",
+          "quote": "I've tried adobo in many restaurants, but HAPAG's version is the best. The flavors are so rich and authentic. I highly recommend it!"
         }
       },
       {
-        "title": "Men's Grooming Package",
-        "description": "Our barber and salon services cater to men's grooming needs, providing a relaxing and rejuvenating experience. From haircuts to shaving, we use only the best products and techniques to ensure our clients look and feel their best. This package includes a haircut, shave, and facial treatment.",
-        "image": "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf",
+        "title": "Lechon Kawali Savory ",
+        "description": "Indulge in our crispy lechon kawali, served with a side of liver sauce and steamed vegetables. This Filipino favorite is perfect for any occasion. Our chefs use a secret recipe to achieve the perfect crunch.",
+        "image": "https://diligent-ibex-454.convex.cloud/api/storage/195ead85-77fb-4a88-ba7d-c51790101f3c",
         "tags": [
-          "Grooming",
-          "Half-day"
+          "Filipino Specialty",
+          "45 minutes"
         ],
         "testimonial": {
-          "author": "Mr. Santos",
-          "quote": "I've never felt so refreshed and revitalized after a grooming session. The team at Josephine Carvajal is exceptional, and their attention to detail is impressive. I highly recommend their men's grooming package to anyone looking for a top-notch experience."
+          "author": "Mark Santos",
+          "quote": "HAPAG's lechon kawali is crispy on the outside and tender on the inside. I love it! The live band entertainment made the experience even more enjoyable."
         }
       },
       {
-        "title": "Hair Color Transformation",
-        "description": "Our experienced team can transform your hair with our professional coloring services. From subtle highlights to bold, vibrant colors, we use only the best products to achieve the desired look. This client underwent a stunning hair color transformation, and the result was a dramatic, eye-catching new look.",
-        "image": "https://diligent-ibex-454.convex.cloud/api/storage/c1e7f8f5-1b6e-440c-a142-fcbb7f35aa8c",
+        "title": "Sinigang Soup",
+        "description": "Warm up with our sour and savory sinigang soup, made with fresh tamarind broth and your choice of protein. This comforting dish is a staple in Filipino cuisine. We use only the freshest ingredients to ensure the best flavor.",
+        "image": "https://diligent-ibex-454.convex.cloud/api/storage/3025d7d7-f263-4ee2-bdca-d93519ae55a2",
         "tags": [
-          "Hair Color",
-          "Full-day"
+          "Filipino Comfort Food",
+          "20 minutes"
         ],
         "testimonial": {
-          "author": "Ms. Garcia",
-          "quote": "I was blown away by the hair color transformation I received at Josephine Carvajal. The team was knowledgeable, friendly, and truly skilled. My new hair color is everything I wanted and more – I've received countless compliments, and I feel like a completely new person."
+          "author": "Liza Reyes",
+          "quote": "HAPAG's sinigang soup is a breath of fresh air. The flavors are so bold and refreshing. I've been coming back for more!"
         }
       }
     ],
-    "images": [
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg",
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959902485-nou2bbkq.jpg",
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959906265-7t4pjpwa.jpg"
-    ],
     "photos": [
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg",
-      "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf",
-      "https://diligent-ibex-454.convex.cloud/api/storage/c1e7f8f5-1b6e-440c-a142-fcbb7f35aa8c"
+      "https://diligent-ibex-454.convex.cloud/api/storage/6939e1c2-cbba-4143-a499-22b0ad99e00c",
+      "https://diligent-ibex-454.convex.cloud/api/storage/c664fe21-705b-4f24-801c-bfc0dec4eeb4",
+      "https://diligent-ibex-454.convex.cloud/api/storage/716a61f5-f89c-4d20-a1f9-f415323324cb"
     ],
     "visibility": {
       "galleryHeadline": true,
@@ -213,16 +210,16 @@
     }
   },
   "contact": {
-    "businessName": "Aloja Carvajal Aesthetic and Beauty Studio",
-    "email": "josephinecarvajal110168@gmail.com",
-    "phone": "9177871293",
-    "address": "Heritage homes, Marilao, Bulacan, Marilao",
+    "businessName": "HAPAG",
+    "email": "joycedungo15@gmail.com",
+    "phone": "9756632359",
+    "address": "Block 82 lot 5 Camalig Ema town Center Sto. Niño, MEYCAUAYAN",
     "description": "For any inquiries or to explore your vision further, we invite you to contact our professional team using the details provided below.",
     "socialLinks": [],
     "photos": [
-      "https://pub-57b18c6cff15455aa3dec88f7581c5d7.r2.dev/images/1772959893360-27lz7b5c.jpg",
-      "https://diligent-ibex-454.convex.cloud/api/storage/6050a8dc-82cf-49c3-961f-9543a3c4ecbf",
-      "https://diligent-ibex-454.convex.cloud/api/storage/c1e7f8f5-1b6e-440c-a142-fcbb7f35aa8c"
+      "https://diligent-ibex-454.convex.cloud/api/storage/6939e1c2-cbba-4143-a499-22b0ad99e00c",
+      "https://diligent-ibex-454.convex.cloud/api/storage/c664fe21-705b-4f24-801c-bfc0dec4eeb4",
+      "https://diligent-ibex-454.convex.cloud/api/storage/716a61f5-f89c-4d20-a1f9-f415323324cb"
     ],
     "visibility": {
       "contactBadge": true,

--- a/astro-site-template/src/layouts/BaseLayout.astro
+++ b/astro-site-template/src/layouts/BaseLayout.astro
@@ -74,9 +74,13 @@ const colorSchemes: Record<string, {
     primary: '#6B8F71', secondary: '#1F2933', accent: '#4ECDC4', background: '#F6F7F5', surface: '#FFFFFF',
     text: '#1F2933', textMuted: '#4A5568', inverseText: '#FFFFFF', isDark: false 
   },
-  blue: { 
+  blue: {
     primary: '#3B82F6', secondary: '#1E3A8A', accent: '#60A5FA', background: '#EFF6FF', surface: '#FFFFFF',
-    text: '#111827', textMuted: '#4B5563', inverseText: '#FFFFFF', isDark: false 
+    text: '#111827', textMuted: '#4B5563', inverseText: '#FFFFFF', isDark: false
+  },
+  green: {
+    primary: '#16A34A', secondary: '#14532D', accent: '#4ADE80', background: '#F0FDF4', surface: '#FFFFFF',
+    text: '#14532D', textMuted: '#166534', inverseText: '#FFFFFF', isDark: false
   },
   purple: { 
     primary: '#8B5CF6', secondary: '#4C1D95', accent: '#A78BFA', background: '#F5F3FF', surface: '#FFFFFF',
@@ -106,9 +110,13 @@ const colorSchemes: Record<string, {
     primary: '#FBC02D', secondary: '#F57F17', accent: '#D32F2F', background: '#FEFCE8', surface: '#FFFFFF',
     text: '#1A1A1A', textMuted: '#424242', inverseText: '#FFFFFF', isDark: false 
   },
-  maroon: { 
+  maroon: {
     primary: '#800000', secondary: '#FFD700', accent: '#A52A2A', background: '#2D0000', surface: '#3D0000',
-    text: '#F5F5DC', textMuted: '#E0C0C0', inverseText: '#2D0000', isDark: true 
+    text: '#F5F5DC', textMuted: '#E0C0C0', inverseText: '#2D0000', isDark: true
+  },
+  black: {
+    primary: '#FFFFFF', secondary: '#E5E5E5', accent: '#A0A0A0', background: '#000000', surface: '#111111',
+    text: '#FFFFFF', textMuted: '#A0A0A0', inverseText: '#000000', isDark: true
   },
 };
 
@@ -142,7 +150,7 @@ const year = new Date().getFullYear();
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href={fontUrl} rel="stylesheet" />
 </head>
-<body class="min-h-screen bg-white text-gray-900 antialiased" style={`font-family: '${fonts.body}', sans-serif;`}>
+<body class="min-h-screen bg-[var(--bg)] text-[var(--text)] antialiased" style={`font-family: '${fonts.body}', sans-serif;`}>
   <!-- Navbar -->
   <nav class="fixed top-0 left-0 right-0 z-50 bg-[var(--nav-bg)] backdrop-blur-md border-b border-[var(--nav-border)]" id="navbar">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/astro-site-template/src/pages/index.astro
+++ b/astro-site-template/src/pages/index.astro
@@ -7,6 +7,7 @@ import HeroB from '../components/heroes/HeroB.astro';
 import HeroC from '../components/heroes/HeroC.astro';
 import HeroD from '../components/heroes/HeroD.astro';
 import HeroE from '../components/heroes/HeroE.astro';
+import HeroF from '../components/heroes/HeroF.astro';
 
 // About components
 import AboutA from '../components/about/AboutA.astro';
@@ -14,6 +15,7 @@ import AboutB from '../components/about/AboutB.astro';
 import AboutC from '../components/about/AboutC.astro';
 import AboutD from '../components/about/AboutD.astro';
 import AboutE from '../components/about/AboutE.astro';
+import AboutF from '../components/about/AboutF.astro';
 
 // Services components
 import ServicesA from '../components/services/ServicesA.astro';
@@ -21,6 +23,7 @@ import ServicesB from '../components/services/ServicesB.astro';
 import ServicesC from '../components/services/ServicesC.astro';
 import ServicesD from '../components/services/ServicesD.astro';
 import ServicesE from '../components/services/ServicesE.astro';
+import ServicesF from '../components/services/ServicesF.astro';
 
 // Gallery components
 import GalleryA from '../components/gallery/GalleryA.astro';
@@ -28,6 +31,7 @@ import GalleryB from '../components/gallery/GalleryB.astro';
 import GalleryC from '../components/gallery/GalleryC.astro';
 import GalleryD from '../components/gallery/GalleryD.astro';
 import GalleryE from '../components/gallery/GalleryE.astro';
+import GalleryF from '../components/gallery/GalleryF.astro';
 
 // Contact components
 import ContactA from '../components/contact/ContactA.astro';
@@ -35,16 +39,17 @@ import ContactB from '../components/contact/ContactB.astro';
 import ContactC from '../components/contact/ContactC.astro';
 import ContactD from '../components/contact/ContactD.astro';
 import ContactE from '../components/contact/ContactE.astro';
+import ContactF from '../components/contact/ContactF.astro';
 
 // Import site data
 import siteData from '../data/site-data.json';
 
 // Component maps
-const heroComponents: Record<string, any> = { A: HeroA, B: HeroB, C: HeroC, D: HeroD, E: HeroE };
-const aboutComponents: Record<string, any> = { A: AboutA, B: AboutB, C: AboutC, D: AboutD, E: AboutE };
-const servicesComponents: Record<string, any> = { A: ServicesA, B: ServicesB, C: ServicesC, D: ServicesD, E: ServicesE };
-const galleryComponents: Record<string, any> = { A: GalleryA, B: GalleryB, C: GalleryC, D: GalleryD, E: GalleryE };
-const contactComponents: Record<string, any> = { A: ContactA, B: ContactB, C: ContactC, D: ContactD, E: ContactE };
+const heroComponents: Record<string, any> = { A: HeroA, B: HeroB, C: HeroC, D: HeroD, E: HeroE, F: HeroF };
+const aboutComponents: Record<string, any> = { A: AboutA, B: AboutB, C: AboutC, D: AboutD, E: AboutE, F: AboutF };
+const servicesComponents: Record<string, any> = { A: ServicesA, B: ServicesB, C: ServicesC, D: ServicesD, E: ServicesE, F: ServicesF };
+const galleryComponents: Record<string, any> = { A: GalleryA, B: GalleryB, C: GalleryC, D: GalleryD, E: GalleryE, F: GalleryF };
+const contactComponents: Record<string, any> = { A: ContactA, B: ContactB, C: ContactC, D: ContactD, E: ContactE, F: ContactF };
 
 // Select components based on customizations
 const HeroComponent = heroComponents[siteData.customizations.heroStyle] || HeroA;

--- a/astro-site-template/src/types.ts
+++ b/astro-site-template/src/types.ts
@@ -38,11 +38,11 @@ export interface ContactInfo {
 }
 
 export interface Customizations {
-  heroStyle: 'A' | 'B' | 'C' | 'D' | 'E';
-  aboutStyle: 'A' | 'B' | 'C' | 'D' | 'E';
-  servicesStyle: 'A' | 'B' | 'C' | 'D' | 'E';
-  galleryStyle: 'A' | 'B' | 'C' | 'D' | 'E';
-  contactStyle: 'A' | 'B' | 'C' | 'D' | 'E';
+  heroStyle: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+  aboutStyle: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+  servicesStyle: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+  galleryStyle: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+  contactStyle: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
 }
 
 export interface VisibilitySettings {

--- a/components/ContentEditor.tsx
+++ b/components/ContentEditor.tsx
@@ -111,6 +111,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="C">Centered Carousel</option>
                                     <option value="D">Services List Dark</option>
                                     <option value="E">Visual Narrative (Modern)</option>
+                                    <option value="F">Luxury Dark Elegant</option>
                                 </select>
                             </div>
 
@@ -131,6 +132,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="C">Tags Card</option>
                                     <option value="D">Quote with Logo Carousel</option>
                                     <option value="E">Immersive DNA (Modern)</option>
+                                    <option value="F">Luxury Story Layout</option>
                                 </select>
                             </div>
 
@@ -151,6 +153,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="C">Card Grid</option>
                                     <option value="D">Stats Grid with Quote</option>
                                     <option value="E">Capabilites Mosaic (Modern)</option>
+                                    <option value="F">Luxury Card Grid</option>
                                 </select>
                             </div>
 
@@ -171,6 +174,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="C">Image Grid</option>
                                     <option value="D">Staggered Masonry</option>
                                     <option value="E">Fluid Mosaic (Modern)</option>
+                                    <option value="F">Luxury Product Showcase</option>
                                 </select>
                             </div>
 
@@ -191,6 +195,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="C">Bold CTA</option>
                                     <option value="D">Dark Marquee Photos</option>
                                     <option value="E">Interactive Tile Glass (Modern)</option>
+                                    <option value="F">Luxury Footer Contact</option>
                                 </select>
                             </div>
                         </div>
@@ -234,6 +239,7 @@ export default function ContentEditor({ initialCustomizations, onUpdate, disable
                                     <option value="red">Red Intense</option>
                                     <option value="yellow">Yellow Bright</option>
                                     <option value="maroon">Maroon Rich</option>
+                                    <option value="black">Black Monochrome</option>
                                 </select>
                             </div>
 

--- a/components/editor/VisualEditor.tsx
+++ b/components/editor/VisualEditor.tsx
@@ -52,6 +52,10 @@ interface WebsiteContent {
         label: string
         link: string
     }
+    hero_cta_secondary?: {
+        label: string
+        link: string
+    }
     services_cta?: {
         label: string
         link: string
@@ -167,10 +171,12 @@ export default function VisualEditor({
     const aboutFileInputRef = useRef<HTMLInputElement>(null)
     const servicesFileInputRef = useRef<HTMLInputElement>(null)
     const featuredFileInputRef = useRef<HTMLInputElement>(null)
+    const productFileInputRefs = useRef<Record<number, HTMLInputElement | null>>({})
     const [isUploading, setIsUploading] = useState(false)
     const [isUploadingAboutImage, setIsUploadingAboutImage] = useState(false)
     const [isUploadingServicesImage, setIsUploadingServicesImage] = useState(false)
     const [isUploadingFeaturedImage, setIsUploadingFeaturedImage] = useState(false)
+    const [uploadingProductIndex, setUploadingProductIndex] = useState<number | null>(null)
     const [showImagePicker, setShowImagePicker] = useState(false)
     const [showAboutImagePicker, setShowAboutImagePicker] = useState(false)
     const [showServicesImagePicker, setShowServicesImagePicker] = useState(false)
@@ -180,12 +186,15 @@ export default function VisualEditor({
     const [resolvedAboutImages, setResolvedAboutImages] = useState<string[]>([])
     const [resolvedServicesImage, setResolvedServicesImage] = useState<string | null>(null)
     const [resolvedFeaturedImages, setResolvedFeaturedImages] = useState<string[]>([])
+    const [resolvedProductImages, setResolvedProductImages] = useState<Record<number, string>>({})
 
     // Get which fields the current hero style uses
     const heroFields = useMemo(() => getHeroStyleFields(heroStyle), [heroStyle])
 
     // Get which fields the current about style uses
     const aboutFields = useMemo(() => getAboutStyleFields(aboutStyle), [aboutStyle])
+    // About variants B, D, F and legacy '3' use a single image; others use a gallery of up to 4
+    const aboutSingleImage = aboutStyle === '3' || aboutStyle === 'C' || aboutStyle === 'F'
 
     // Get which fields the current services style uses
     const servicesFields = useMemo(() => getServicesStyleFields(servicesStyle), [servicesStyle])
@@ -342,6 +351,33 @@ export default function VisualEditor({
             setResolvedFeaturedImages([])
         }
     }, [resolvedFeaturedImageUrls, content.featured_images])
+
+    // Resolve product images URLs - handles convex:xxx format for uploaded product images
+    const productStorageIds = useMemo(() => {
+        return (content.featured_products || [])
+            .map(p => p.image)
+            .filter((img): img is string => !!img && !img.startsWith('http'))
+    }, [content.featured_products])
+    const resolvedProductImageUrls = useQuery(
+        api.files.getMultipleUrls,
+        productStorageIds.length > 0 ? { storageIds: productStorageIds } : 'skip'
+    )
+
+    useEffect(() => {
+        const products = content.featured_products || []
+        const resolved: Record<number, string> = {}
+        products.forEach((product, index) => {
+            if (product.image?.startsWith('http')) {
+                resolved[index] = product.image
+            } else if (product.image) {
+                const storageIdx = productStorageIds.indexOf(product.image)
+                if (resolvedProductImageUrls && storageIdx !== -1 && resolvedProductImageUrls[storageIdx]) {
+                    resolved[index] = resolvedProductImageUrls[storageIdx]!
+                }
+            }
+        })
+        setResolvedProductImages(resolved)
+    }, [resolvedProductImageUrls, content.featured_products, productStorageIds])
 
     // Initialize missing fields with defaults on mount
     useEffect(() => {
@@ -814,7 +850,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_headline: !content.visibility?.hero_headline
+                                        hero_headline: content.visibility?.hero_headline !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_headline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -861,7 +897,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_tagline: !content.visibility?.hero_tagline
+                                        hero_tagline: content.visibility?.hero_tagline !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_tagline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -909,7 +945,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_description: !content.visibility?.hero_description
+                                        hero_description: content.visibility?.hero_description !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_description !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -957,7 +993,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_testimonial: !content.visibility?.hero_testimonial
+                                        hero_testimonial: content.visibility?.hero_testimonial !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_testimonial !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -981,8 +1017,8 @@ export default function VisualEditor({
                         </div>
                         )}
 
-                        {/* Hero Button (CTA) - Only show if hero style uses it */}
-                        {heroFields.usesButton && (
+                        {/* Hero Button (CTA) - Show for styles that use buttons (A, C, E, F) */}
+                        {(heroFields.usesButton || heroStyle === 'E' || heroStyle === 'F' || heroStyle === '5' || heroStyle === '6') && (
                         <div
                             onMouseEnter={() => highlightElement('.cta-button')}
                             onMouseLeave={removeHighlight}
@@ -1005,7 +1041,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_button: !content.visibility?.hero_button
+                                        hero_button: content.visibility?.hero_button !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_button !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1050,7 +1086,48 @@ export default function VisualEditor({
                                     />
                                 </div>
                             </div>
-                            <p className="text-xs text-gray-500 mt-2">Call-to-action button displayed in the hero section</p>
+                            {heroStyle === 'F' && (
+                                <>
+                                    <div className="mt-4 pt-3 border-t border-gray-200">
+                                        <label className="block text-xs text-gray-500 mb-1 font-medium">Secondary Button</label>
+                                    </div>
+                                    <div className="space-y-3">
+                                        <div>
+                                            <label className="block text-xs text-gray-500 mb-1">Secondary Button Text</label>
+                                            <input
+                                                type="text"
+                                                value={content.hero_cta_secondary?.label || ''}
+                                                onChange={(e) => updateField('hero_cta_secondary', {
+                                                    ...content.hero_cta_secondary,
+                                                    label: e.target.value,
+                                                    link: content.hero_cta_secondary?.link || '#about'
+                                                })}
+                                                disabled={content.visibility?.hero_button === false}
+                                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                                                placeholder="e.g. Our Story"
+                                                maxLength={50}
+                                            />
+                                        </div>
+                                        <div>
+                                            <label className="block text-xs text-gray-500 mb-1">Secondary Button Link</label>
+                                            <input
+                                                type="text"
+                                                value={content.hero_cta_secondary?.link || ''}
+                                                onChange={(e) => updateField('hero_cta_secondary', {
+                                                    ...content.hero_cta_secondary,
+                                                    label: content.hero_cta_secondary?.label || 'Our Story',
+                                                    link: e.target.value
+                                                })}
+                                                disabled={content.visibility?.hero_button === false}
+                                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                                                placeholder="e.g. #about or https://..."
+                                                maxLength={200}
+                                            />
+                                        </div>
+                                    </div>
+                                </>
+                            )}
+                            <p className="text-xs text-gray-500 mt-2">Call-to-action button{heroStyle === 'F' ? 's' : ''} displayed in the hero section</p>
                         </div>
                         )}
 
@@ -1078,7 +1155,7 @@ export default function VisualEditor({
                                     type="button"
                                     onClick={() => updateField('visibility', {
                                         ...content.visibility,
-                                        hero_image: !content.visibility?.hero_image
+                                        hero_image: content.visibility?.hero_image !== false ? false : true
                                     })}
                                     className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                         content.visibility?.hero_image !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1531,7 +1608,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                about_headline: !content.visibility?.about_headline
+                                                about_headline: content.visibility?.about_headline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.about_headline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1578,7 +1655,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                about_description: !content.visibility?.about_description
+                                                about_description: content.visibility?.about_description !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.about_description !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1618,13 +1695,13 @@ export default function VisualEditor({
                                             ) : (
                                                 <EyeOff className="w-4 h-4 text-gray-400" />
                                             )}
-                                            {aboutStyle === '3' ? 'About Image' : 'About Images Gallery'}
+                                            {aboutSingleImage ? 'About Image' : 'About Images Gallery'}
                                         </label>
                                         <button
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                about_images: !content.visibility?.about_images
+                                                about_images: content.visibility?.about_images !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.about_images !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1636,14 +1713,14 @@ export default function VisualEditor({
                                         </button>
                                     </div>
                                     <p className="text-xs text-gray-500 mb-3">
-                                        {aboutStyle === '3'
+                                        {aboutSingleImage
                                             ? 'Select 1 image for the about section'
                                             : 'Select up to 4 images for the horizontal gallery with scroll animations'}
                                     </p>
 
                                     {/* Current selected images */}
-                                    <div className={`grid gap-2 mb-3 ${aboutStyle === '3' ? 'grid-cols-1 max-w-[200px]' : 'grid-cols-4'}`}>
-                                        {(aboutStyle === '3' ? [0] : [0, 1, 2, 3]).map((index) => {
+                                    <div className={`grid gap-2 mb-3 ${aboutSingleImage ? 'grid-cols-1 max-w-[200px]' : 'grid-cols-4'}`}>
+                                        {(aboutSingleImage ? [0] : [0, 1, 2, 3]).map((index) => {
                                             const aboutImagesRaw = content.about_images || availableImages
                                             const rawImageUrl = aboutImagesRaw[index]
                                             // Use resolved URL if available, otherwise use raw URL (for http URLs)
@@ -1697,7 +1774,7 @@ export default function VisualEditor({
                                                 className="flex-1 px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center justify-center gap-2 text-sm font-medium"
                                             >
                                                 <ImageIcon className="w-4 h-4" />
-                                                {aboutStyle === '3' ? 'Choose Image' : 'Choose Images'}
+                                                {aboutSingleImage ? 'Choose Image' : 'Choose Images'}
                                             </button>
                                         )}
 
@@ -1712,7 +1789,7 @@ export default function VisualEditor({
                                                 // Use current about_images if set, otherwise empty array for uploads
                                                 // (don't fall back to availableImages for upload validation)
                                                 const currentImages = content.about_images || []
-                                                const maxImages = aboutStyle === '3' ? 1 : 4
+                                                const maxImages = aboutSingleImage ? 1 : 4
                                                 if (currentImages.length >= maxImages) {
                                                     toast.error(`Maximum ${maxImages} image${maxImages > 1 ? 's' : ''} allowed. Remove an image first.`)
                                                     return
@@ -1767,7 +1844,7 @@ export default function VisualEditor({
                                         />
                                         <button
                                             onClick={() => aboutFileInputRef.current?.click()}
-                                            disabled={isUploadingAboutImage || (content.about_images?.length || 0) >= (aboutStyle === '3' ? 1 : 4)}
+                                            disabled={isUploadingAboutImage || (content.about_images?.length || 0) >= (aboutSingleImage ? 1 : 4)}
                                             className="flex-1 px-3 py-2 bg-white border border-dashed border-gray-300 rounded-md hover:bg-gray-50 flex items-center justify-center gap-2 text-sm text-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                         >
                                             <Upload className="w-4 h-4" />
@@ -1802,7 +1879,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                about_tagline: !content.visibility?.about_tagline
+                                                about_tagline: content.visibility?.about_tagline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.about_tagline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1850,7 +1927,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                about_tags: !content.visibility?.about_tags
+                                                about_tags: content.visibility?.about_tags !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.about_tags !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -1932,7 +2009,7 @@ export default function VisualEditor({
                                         <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
                                             <div className="p-4 border-b border-gray-200 flex items-center justify-between">
                                                 <h3 className="text-lg font-semibold text-gray-900">
-                                                    {aboutStyle === '3' ? 'Select About Image' : 'Select About Gallery Images'}
+                                                    {aboutSingleImage ? 'Select About Image' : 'Select About Gallery Images'}
                                                 </h3>
                                                 <button
                                                     onClick={() => setShowAboutImagePicker(false)}
@@ -1943,7 +2020,7 @@ export default function VisualEditor({
                                             </div>
                                             <div className="p-4 overflow-y-auto max-h-[60vh]">
                                                 <p className="text-sm text-gray-500 mb-4">
-                                                    {aboutStyle === '3'
+                                                    {aboutSingleImage
                                                         ? 'Click an image to select it for the about section.'
                                                         : 'Click images to select/deselect. Selected images show their order number. Maximum 4 images.'}
                                                 </p>
@@ -1960,7 +2037,7 @@ export default function VisualEditor({
                                                                 const aboutImages = content.about_images || availableImages
                                                                 const isSelected = aboutImages.includes(imageUrl)
                                                                 const selectedIndex = aboutImages.indexOf(imageUrl)
-                                                                const maxImagesForPicker = aboutStyle === '3' ? 1 : 4
+                                                                const maxImagesForPicker = aboutSingleImage ? 1 : 4
                                                                 return (
                                                                     <button
                                                                         key={`${prefix}-${index}`}
@@ -1970,7 +2047,7 @@ export default function VisualEditor({
                                                                                 const newImages = currentImages.filter(img => img !== imageUrl)
                                                                                 updateField('about_images', newImages)
                                                                             } else {
-                                                                                if (aboutStyle === '3') {
+                                                                                if (aboutSingleImage) {
                                                                                     updateField('about_images', [imageUrl])
                                                                                 } else if (currentImages.length < maxImagesForPicker) {
                                                                                     updateField('about_images', [...currentImages, imageUrl])
@@ -1986,7 +2063,7 @@ export default function VisualEditor({
                                                                         <img src={imageUrl} alt={`${label || 'Option'} ${index + 1}`} className="w-full h-full object-cover" />
                                                                         {isSelected && (
                                                                             <div className="absolute top-2 right-2 bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">
-                                                                                {aboutStyle === '3' ? '✓' : selectedIndex + 1}
+                                                                                {aboutSingleImage ? '✓' : selectedIndex + 1}
                                                                             </div>
                                                                         )}
                                                                     </button>
@@ -2001,7 +2078,7 @@ export default function VisualEditor({
                                                     onClick={() => setShowAboutImagePicker(false)}
                                                     className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium"
                                                 >
-                                                    Done ({(content.about_images || availableImages).length}/{aboutStyle === '3' ? 1 : 4} selected)
+                                                    Done ({(content.about_images || availableImages).length}/{aboutSingleImage ? 1 : 4} selected)
                                                 </button>
                                             </div>
                                         </div>
@@ -2110,7 +2187,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                services_headline: !content.visibility?.services_headline
+                                                services_headline: content.visibility?.services_headline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.services_headline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -2157,7 +2234,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                services_subheadline: !content.visibility?.services_subheadline
+                                                services_subheadline: content.visibility?.services_subheadline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.services_subheadline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -2205,7 +2282,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                services_image: !content.visibility?.services_image
+                                                services_image: content.visibility?.services_image !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.services_image !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -2557,7 +2634,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                featured_headline: !content.visibility?.featured_headline
+                                                featured_headline: content.visibility?.featured_headline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.featured_headline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -2603,7 +2680,7 @@ export default function VisualEditor({
                                             type="button"
                                             onClick={() => updateField('visibility', {
                                                 ...content.visibility,
-                                                featured_subheadline: !content.visibility?.featured_subheadline
+                                                featured_subheadline: content.visibility?.featured_subheadline !== false ? false : true
                                             })}
                                             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
                                                 content.visibility?.featured_subheadline !== false ? 'bg-blue-600' : 'bg-gray-300'
@@ -2626,8 +2703,8 @@ export default function VisualEditor({
                                     <p className="text-xs text-gray-500 mt-1">Description text below the headline</p>
                                 </div>
 
-                                {/* Featured CTA Button - Only show if style uses CTA */}
-                                {galleryFields.usesCta && (
+                                {/* Featured CTA Button - Show for styles that use CTA (D, F) */}
+                                {(galleryFields.usesCta || galleryStyle === 'D' || galleryStyle === 'F' || galleryStyle === '4' || galleryStyle === '6') && (
                                     <div
                                         onMouseEnter={() => highlightElement('.featured-masonry .cta-button')}
                                         onMouseLeave={removeHighlight}
@@ -2743,7 +2820,8 @@ export default function VisualEditor({
                                                     {galleryFields.usesProducts && (() => {
                                                         // Calculate actual display image (explicit or fallback)
                                                         const fallbackImage = availableImages[index % Math.max(availableImages.length, 1)]
-                                                        const displayImage = project.image || fallbackImage
+                                                        const resolvedImg = resolvedProductImages[index]
+                                                        const displayImage = resolvedImg || (project.image?.startsWith('http') ? project.image : null) || fallbackImage
 
                                                         return (
                                                             <div className="space-y-1">
@@ -2762,9 +2840,9 @@ export default function VisualEditor({
                                                                             <ImageIcon className="w-6 h-6 text-gray-300" />
                                                                         </div>
                                                                     )}
-                                                                    <div className="flex-1">
+                                                                    <div className="flex-1 space-y-1.5">
                                                                         <select
-                                                                            value={project.image || fallbackImage || ''}
+                                                                            value={project.image?.startsWith('http') ? project.image : (project.image ? '' : (fallbackImage || ''))}
                                                                             onChange={(e) => {
                                                                                 const newProjects = [...(content.featured_products || [])]
                                                                                 newProjects[index] = { ...newProjects[index], image: e.target.value || undefined }
@@ -2772,6 +2850,9 @@ export default function VisualEditor({
                                                                             }}
                                                                             className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
                                                                         >
+                                                                            {project.image && !project.image.startsWith('http') && (
+                                                                                <option value="">Uploaded Image</option>
+                                                                            )}
                                                                             {hasOriginalImages && (
                                                                                 <optgroup label="Original Photos">
                                                                                     {originalImages.map((img, imgIndex) => (
@@ -2796,26 +2877,75 @@ export default function VisualEditor({
                                                                                 </option>
                                                                             ))}
                                                                         </select>
+                                                                        {/* Upload new image for this product */}
+                                                                        <input
+                                                                            type="file"
+                                                                            ref={(el) => { productFileInputRefs.current[index] = el }}
+                                                                            onChange={async (e) => {
+                                                                                const file = e.target.files?.[0]
+                                                                                if (!file) return
+                                                                                if (file.size > 5 * 1024 * 1024) {
+                                                                                    toast.error('File is too large. Maximum size is 5MB.')
+                                                                                    return
+                                                                                }
+                                                                                if (!file.type.startsWith('image/')) {
+                                                                                    toast.error('Only image files are allowed.')
+                                                                                    return
+                                                                                }
+                                                                                setUploadingProductIndex(index)
+                                                                                const toastId = toast.loading('Uploading image...')
+                                                                                try {
+                                                                                    const uploadUrl = await generateUploadUrl()
+                                                                                    const result = await fetch(uploadUrl, {
+                                                                                        method: 'POST',
+                                                                                        headers: { 'Content-Type': file.type },
+                                                                                        body: file,
+                                                                                    })
+                                                                                    if (!result.ok) throw new Error('Failed to upload file')
+                                                                                    const { storageId } = await result.json()
+                                                                                    const newProjects = [...(content.featured_products || [])]
+                                                                                    newProjects[index] = { ...newProjects[index], image: `convex:${storageId}` }
+                                                                                    updateField('featured_products', newProjects)
+                                                                                    toast.success('Product image uploaded', { id: toastId })
+                                                                                } catch (error) {
+                                                                                    console.error('Upload error:', error)
+                                                                                    toast.error('Failed to upload image', { id: toastId })
+                                                                                } finally {
+                                                                                    setUploadingProductIndex(null)
+                                                                                    const input = productFileInputRefs.current[index]
+                                                                                    if (input) input.value = ''
+                                                                                }
+                                                                            }}
+                                                                            accept="image/*"
+                                                                            className="hidden"
+                                                                        />
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => productFileInputRefs.current[index]?.click()}
+                                                                            disabled={uploadingProductIndex === index}
+                                                                            className="w-full px-2 py-1.5 bg-white border border-dashed border-gray-300 rounded text-xs text-gray-600 hover:bg-gray-50 flex items-center justify-center gap-1.5 transition-colors"
+                                                                        >
+                                                                            <Upload className="w-3 h-3" />
+                                                                            {uploadingProductIndex === index ? 'Uploading...' : 'Upload New'}
+                                                                        </button>
                                                                     </div>
                                                                 </div>
                                                             </div>
                                                         )
                                                     })()}
 
-                                                    {/* Description - only shown for styles that use it */}
-                                                    {galleryFields.usesTestimonials && (
-                                                        <textarea
-                                                            value={project.description}
-                                                            onChange={(e) => {
-                                                                const newProjects = [...(content.featured_products || [])]
-                                                                newProjects[index] = { ...newProjects[index], description: e.target.value }
-                                                                updateField('featured_products', newProjects)
-                                                            }}
-                                                            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500 resize-none"
-                                                            rows={2}
-                                                            placeholder="Project description"
-                                                        />
-                                                    )}
+                                                    {/* Description - shown for all product-based styles */}
+                                                    <textarea
+                                                        value={project.description}
+                                                        onChange={(e) => {
+                                                            const newProjects = [...(content.featured_products || [])]
+                                                            newProjects[index] = { ...newProjects[index], description: e.target.value }
+                                                            updateField('featured_products', newProjects)
+                                                        }}
+                                                        className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500 resize-none"
+                                                        rows={2}
+                                                        placeholder="Project description"
+                                                    />
 
                                                     {/* Tags/Category - shown for all styles */}
                                                     {galleryFields.usesTags && (

--- a/lib/astro-builder.ts
+++ b/lib/astro-builder.ts
@@ -17,6 +17,7 @@ interface ExtractedContent {
         messenger?: string
     }
     hero_cta?: { label: string; link: string }
+    hero_cta_secondary?: { label: string; link: string }
     hero_badge_text?: string
     hero_testimonial?: string
     visibility?: Record<string, boolean>
@@ -71,7 +72,7 @@ interface Customizations {
  */
 function mapStyleToLetter(numericStyle: string | undefined, fallback: string = 'A'): string {
     if (!numericStyle) return fallback
-    const map: Record<string, string> = { '1': 'A', '2': 'B', '3': 'C', '4': 'D', '5': 'E' }
+    const map: Record<string, string> = { '1': 'A', '2': 'B', '3': 'C', '4': 'D', '5': 'E', '6': 'F' }
     return map[numericStyle] || numericStyle // Pass through if already a letter
 }
 
@@ -155,6 +156,8 @@ function transformToAstroData(
             testimonial: content.hero_testimonial,
             ctaLabel: content.hero_cta?.label,
             ctaLink: content.hero_cta?.link,
+            ctaSecondaryLabel: content.hero_cta_secondary?.label,
+            ctaSecondaryLink: content.hero_cta_secondary?.link,
             photos,
             services: content.services?.slice(0, 3),
             visibility: {

--- a/lib/template-fields.ts
+++ b/lib/template-fields.ts
@@ -46,6 +46,8 @@ const heroFields: Record<string, HeroStyleFields> = {
     'B': { usesHeadline: true, usesTagline: false, usesDescription: false, usesTestimonial: false, usesBadge: false, usesButton: false, usesImage: true },
     'C': { usesHeadline: true, usesTagline: true, usesDescription: false, usesTestimonial: false, usesBadge: false, usesButton: true, usesImage: true },
     'D': { usesHeadline: true, usesTagline: true, usesDescription: true, usesTestimonial: false, usesBadge: true, usesButton: false, usesImage: true },
+    'E': { usesHeadline: true, usesTagline: true, usesDescription: true, usesTestimonial: true, usesBadge: true, usesButton: true, usesImage: true },
+    'F': { usesHeadline: true, usesTagline: true, usesDescription: true, usesTestimonial: false, usesBadge: true, usesButton: true, usesImage: true },
 }
 
 const aboutFields: Record<string, AboutStyleFields> = {
@@ -53,6 +55,8 @@ const aboutFields: Record<string, AboutStyleFields> = {
     'B': { usesHeadline: false, usesBadge: true, usesDescription: true, usesImages: true, usesUsps: false, usesTagline: false, usesTags: false },
     'C': { usesHeadline: true, usesBadge: false, usesDescription: true, usesImages: true, usesUsps: false, usesTagline: true, usesTags: true },
     'D': { usesHeadline: false, usesBadge: true, usesDescription: true, usesImages: true, usesUsps: false, usesTagline: false, usesTags: false },
+    'E': { usesHeadline: true, usesBadge: true, usesDescription: true, usesImages: true, usesUsps: true, usesTagline: false, usesTags: true },
+    'F': { usesHeadline: true, usesBadge: true, usesDescription: true, usesImages: true, usesUsps: true, usesTagline: true, usesTags: false },
 }
 
 const servicesFields: Record<string, ServicesStyleFields> = {
@@ -60,6 +64,8 @@ const servicesFields: Record<string, ServicesStyleFields> = {
     'B': { usesHeadline: true, usesSubheadline: false, usesBadge: false, usesImage: false, usesList: true },
     'C': { usesHeadline: true, usesSubheadline: true, usesBadge: true, usesImage: false, usesList: true },
     'D': { usesHeadline: true, usesSubheadline: true, usesBadge: true, usesImage: true, usesList: true },
+    'E': { usesHeadline: true, usesSubheadline: false, usesBadge: true, usesImage: false, usesList: true },
+    'F': { usesHeadline: true, usesSubheadline: true, usesBadge: true, usesImage: false, usesList: true },
 }
 
 const galleryFields: Record<string, GalleryStyleFields> = {
@@ -67,10 +73,12 @@ const galleryFields: Record<string, GalleryStyleFields> = {
     'B': { usesHeadline: true, usesSubheadline: true, usesProducts: true, usesTestimonials: false, usesTags: true, usesImages: false, usesCta: false },
     'C': { usesHeadline: true, usesSubheadline: true, usesProducts: false, usesTestimonials: false, usesTags: false, usesImages: true, usesCta: false },
     'D': { usesHeadline: true, usesSubheadline: true, usesProducts: true, usesTestimonials: false, usesTags: true, usesImages: false, usesCta: true },
+    'E': { usesHeadline: true, usesSubheadline: true, usesProducts: true, usesTestimonials: true, usesTags: true, usesImages: false, usesCta: false },
+    'F': { usesHeadline: true, usesSubheadline: true, usesProducts: true, usesTestimonials: false, usesTags: true, usesImages: false, usesCta: true },
 }
 
 // Map numeric keys to letters for backward compat
-const numToLetter: Record<string, string> = { '1': 'A', '2': 'B', '3': 'C', '4': 'D' }
+const numToLetter: Record<string, string> = { '1': 'A', '2': 'B', '3': 'C', '4': 'D', '5': 'E', '6': 'F' }
 function normalize(style: string): string {
     return numToLetter[style] || style
 }


### PR DESCRIPTION


**Template F: New Luxury Components**
- Added `HeroF.astro`: A luxury dark elegant hero section with background image, decorative badge, large heading, description, and dual CTA buttons.
- Added `AboutF.astro`: A two-column about section with image, story content, badge, headline, paragraphs, and a stats row.
- Added `GalleryF.astro`: A product showcase with centered header, decorative badge, 3-column product cards, and a CTA button.
- Added `ContactF.astro`: A multi-column footer-style contact section with logo, description, navigation, hours, location, and social icons.

**Backend Enhancements for Website Generation**
- In `app/api/generate-website/route.ts`, product images in `featured_products` are now resolved from storage IDs to URLs, ensuring correct image display on generated sites.
- The `featured_products` field now uses the resolved products if available, otherwise falls back to generated defaults.
- Added support for an optional `hero_cta_secondary` field, enabling dual CTA buttons in the hero section.

**Admin UI Update**
- The preview link in the admin submission detail page now points to `/api/preview/[submissionId]` instead of `/website/[submissionId]` for accurate previewing. ([app/admin/submissions/[id]/page.tsxL931-R931](diffhunk://#diff-a09a36732340f65cb5e62e44f2a492f1997092466713da18ebc4fca9b8913e57L931-R931))