### PR TITLE
Add: Check Condition for Admin in Training Production

### DIFF
--- a/app/certification-quiz/page.tsx
+++ b/app/certification-quiz/page.tsx
@@ -130,6 +130,11 @@ export default function CertificationQuizPage() {
         if (isLoaded && !user) router.push("/login")
     }, [isLoaded, user, router])
 
+    // Redirect admins to admin dashboard — they don't need certification
+    useEffect(() => {
+        if (creator && creator.role === 'admin') router.push("/admin")
+    }, [creator, router])
+
     if (!isLoaded || creator === undefined) {
         return (
             <div className="min-h-screen flex items-center justify-center bg-white">

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -28,7 +28,7 @@ export default function TrainingPage() {
     }, [isLoaded, user, router])
 
     useEffect(() => {
-        if (creator && creator.certifiedAt) router.push("/dashboard")
+        if (creator && (creator.certifiedAt || creator.role === 'admin')) router.push("/dashboard")
     }, [creator, router])
 
     // Trigger fade-up animations after mount


### PR DESCRIPTION
# Latest Changes 

User flow improvements:

* In `app/certification-quiz/page.tsx`, added a redirect to `/admin` for users with the `admin` role, preventing admins from accessing the certification quiz page.
* In `app/training/page.tsx`, updated the redirect logic so that admins, like certified users, are redirected to the dashboard, ensuring they do not see training content.