### PR TITLE
Fix: Query Reloading of All Records for Vercel Deployment

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -68,7 +68,8 @@ export default function AdminDashboard() {
     const itemsPerPage = 5
     const [backfilling, setBackfilling] = useState(false)
     const [backfillResult, setBackfillResult] = useState<{ updatedSubmissions: number; updatedWebsites: number } | null>(null)
-    const isBackfillNeeded = useQuery(api.admin.checkBackfillNeeded)
+    // Safely handle checkBackfillNeeded query with error fallback
+    const isBackfillNeeded = useQuery(api.admin.checkBackfillNeeded) ?? false
     const backfillWebsiteUrls = useMutation(api.admin.backfillWebsiteUrls)
 
     // Delete submission state

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
         <link rel="icon" href="/logo.png" />
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#00FF66" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="apple-mobile-web-app-title" content="Negosyo Digital" />
         <link rel="apple-touch-icon" href="/logo.png" />

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -802,31 +802,37 @@ export const markPayoutPaid = mutation({
 export const checkBackfillNeeded = query({
     args: {},
     handler: async (ctx) => {
-        const targetStatuses = ['deployed', 'pending_payment', 'paid', 'completed'] as const;
+        try {
+            const targetStatuses = ['deployed', 'pending_payment', 'paid', 'completed'] as const;
 
-        for (const status of targetStatuses) {
-            const submissions = await ctx.db
-                .query('submissions')
-                .withIndex('by_status', (q) => q.eq('status', status))
-                .collect();
-
-            for (const submission of submissions) {
-                const website = await ctx.db
-                    .query('generatedWebsites')
-                    .withIndex('by_submissionId', (q) => q.eq('submissionId', submission._id))
+            for (const status of targetStatuses) {
+                // Use .first() to get one result at a time instead of .collect() to avoid memory issues
+                let submission = await ctx.db
+                    .query('submissions')
+                    .withIndex('by_status', (q) => q.eq('status', status))
                     .first();
 
-                if (!submission.websiteUrl && website?.publishedUrl) {
-                    return true;
-                }
+                if (submission) {
+                    const website = await ctx.db
+                        .query('generatedWebsites')
+                        .withIndex('by_submissionId', (q) => q.eq('submissionId', submission._id))
+                        .first();
 
-                if (website && !website.publishedUrl && submission.websiteUrl) {
-                    return true;
+                    if (!submission.websiteUrl && website?.publishedUrl) {
+                        return true;
+                    }
+
+                    if (website && !website.publishedUrl && submission.websiteUrl) {
+                        return true;
+                    }
                 }
             }
-        }
 
-        return false;
+            return false;
+        } catch (error) {
+            console.error('Error in checkBackfillNeeded:', error);
+            return false;
+        }
     },
 });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  staticPageGenerationTimeout: 120,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
# Latest Changes ✨

**Backend robustness and efficiency:**
- Improved the `checkBackfillNeeded` query in `convex/admin.ts` to use `.first()` instead of `.collect()`, reducing memory usage by fetching only a single submission per status. Added a try/catch block to log errors and ensure the function returns `false` on failure. [[1]](diffhunk://#diff-c139679cee42e94b8bc300a602bddc55b29aa9b7270de7be3fc060574f65c93dR805-R815) [[2]](diffhunk://#diff-c139679cee42e94b8bc300a602bddc55b29aa9b7270de7be3fc060574f65c93dR832-R835)

**Frontend error handling:**
- Updated `AdminDashboard` in `app/admin/page.tsx` to safely handle the result of `useQuery(api.admin.checkBackfillNeeded)` by providing a fallback to `false` if the query fails or is undefined.

**Configuration and metadata updates:**
- Added `staticPageGenerationTimeout: 120` to `next.config.ts` to allow more time for static page generation, which can help prevent build timeouts.
- Changed the meta tag in `app/layout.tsx` from `apple-mobile-web-app-capable` to `mobile-web-app-capable` for improved cross-platform compatibility.