### PR TITLE
Fix: Trial v.3 for Google Oauth of Clerk

### DIFF
--- a/components/providers/ConvexClerkProvider.tsx
+++ b/components/providers/ConvexClerkProvider.tsx
@@ -11,9 +11,6 @@ export function ConvexClerkProvider({ children }: { children: ReactNode }) {
     return (
         <ClerkProvider
             publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}
-            // Optional Clerk proxy — only enabled when NEXT_PUBLIC_CLERK_PROXY_URL is set.
-            // Use an absolute URL (e.g. "https://negosyo-digital.com/clerk-proxy") — relative paths
-            // break SSR because Clerk tries to resolve them against window.location.
             proxyUrl={process.env.NEXT_PUBLIC_CLERK_PROXY_URL || undefined}
             appearance={{
                 layout: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,15 +20,24 @@ const isAdminRoute = createRouteMatcher([
     '/admin(.*)',
 ]);
 
-export default clerkMiddleware(async (auth, req) => {
-    // Allow public routes
-    if (isPublicRoute(req)) {
-        return;
-    }
+export default clerkMiddleware(
+    async (auth, req) => {
+        // Allow public routes
+        if (isPublicRoute(req)) {
+            return;
+        }
 
-    // Protect all other routes
-    await auth.protect();
-});
+        // Protect all other routes
+        await auth.protect();
+    },
+    {
+        // Clerk proxy — only enabled when CLERK_PROXY_URL env var is set.
+        // Set to the absolute URL of the proxy endpoint (e.g. "https://negosyo-digital.com/clerk-proxy").
+        // Requires the Clerk custom domain (clerk.negosyo-digital.com) to be configured
+        // in the Clerk dashboard + DNS CNAME pointing to Clerk's frontend API.
+        ...(process.env.CLERK_PROXY_URL ? { proxyUrl: process.env.CLERK_PROXY_URL } : {}),
+    }
+);
 
 export const config = {
     matcher: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,14 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   staticPageGenerationTimeout: 120,
-  async rewrites() {
-    return [
-      {
-        source: '/clerk-proxy/:path*',
-        destination: 'https://clerk.negosyo-digital.com/:path*',
-      },
-    ]
-  },
   outputFileTracingIncludes: {
     '/api/generate-website': [
       // Astro template: source, config, and its own self-contained node_modules


### PR DESCRIPTION
# Latest Changes .

**Clerk proxy configuration improvements:**

* Updated the `clerkMiddleware` usage in `middleware.ts` to accept a `proxyUrl` option, which is only set if the `CLERK_PROXY_URL` environment variable is present. This ensures the proxy is enabled only when configured, and centralizes proxy logic.
* In `ConvexClerkProvider.tsx`, simplified the `proxyUrl` prop usage for `ClerkProvider` by removing outdated comments and ensuring the value is set from the `NEXT_PUBLIC_CLERK_PROXY_URL` environment variable if present.

**Configuration cleanup:**

* Removed the `clerk-proxy` rewrite rule from `next.config.ts`, as proxying is now handled directly by Clerk middleware and provider configuration, making the rewrite redundant.