### PR TITLE
Devpatch3

### DIFF
--- a/components/providers/ConvexClerkProvider.tsx
+++ b/components/providers/ConvexClerkProvider.tsx
@@ -11,9 +11,6 @@ export function ConvexClerkProvider({ children }: { children: ReactNode }) {
     return (
         <ClerkProvider
             publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}
-            // Optional Clerk proxy — only enabled when NEXT_PUBLIC_CLERK_PROXY_URL is set.
-            // Use an absolute URL (e.g. "https://negosyo-digital.com/clerk-proxy") — relative paths
-            // break SSR because Clerk tries to resolve them against window.location.
             proxyUrl={process.env.NEXT_PUBLIC_CLERK_PROXY_URL || undefined}
             appearance={{
                 layout: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,15 +20,24 @@ const isAdminRoute = createRouteMatcher([
     '/admin(.*)',
 ]);
 
-export default clerkMiddleware(async (auth, req) => {
-    // Allow public routes
-    if (isPublicRoute(req)) {
-        return;
-    }
+export default clerkMiddleware(
+    async (auth, req) => {
+        // Allow public routes
+        if (isPublicRoute(req)) {
+            return;
+        }
 
-    // Protect all other routes
-    await auth.protect();
-});
+        // Protect all other routes
+        await auth.protect();
+    },
+    {
+        // Clerk proxy — only enabled when CLERK_PROXY_URL env var is set.
+        // Set to the absolute URL of the proxy endpoint (e.g. "https://negosyo-digital.com/clerk-proxy").
+        // Requires the Clerk custom domain (clerk.negosyo-digital.com) to be configured
+        // in the Clerk dashboard + DNS CNAME pointing to Clerk's frontend API.
+        ...(process.env.CLERK_PROXY_URL ? { proxyUrl: process.env.CLERK_PROXY_URL } : {}),
+    }
+);
 
 export const config = {
     matcher: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,14 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   staticPageGenerationTimeout: 120,
-  async rewrites() {
-    return [
-      {
-        source: '/clerk-proxy/:path*',
-        destination: 'https://clerk.negosyo-digital.com/:path*',
-      },
-    ]
-  },
   outputFileTracingIncludes: {
     '/api/generate-website': [
       // Astro template: source, config, and its own self-contained node_modules


### PR DESCRIPTION
# Latest Changes ✨

**Clerk proxy configuration improvements:**

* Updated `ConvexClerkProvider` to always set `proxyUrl` based on the `NEXT_PUBLIC_CLERK_PROXY_URL` environment variable, removing commented-out documentation and ensuring the proxy URL is consistently applied.
* Modified `clerkMiddleware` in `middleware.ts` to accept a `proxyUrl` option, dynamically set from the `CLERK_PROXY_URL` environment variable, and included explanatory comments about the required Clerk custom domain and DNS setup.

**Configuration simplification:**

* Removed the custom rewrite rule for `/clerk-proxy/:path*` in `next.config.ts`, as proxy configuration is now handled directly through Clerk's configuration options.