### PR TITLE
Patch feat: lead management, email templates, domain flow, privacy po…

### DIFF
--- a/app/admin/components/AdminLayout.tsx
+++ b/app/admin/components/AdminLayout.tsx
@@ -7,13 +7,14 @@ import Image from "next/image"
 import { useClerk } from "@clerk/nextjs"
 import { motion, AnimatePresence } from "framer-motion"
 import { 
-    LayoutDashboard, 
-    Users, 
-    CreditCard, 
-    History, 
-    Download, 
-    LogOut, 
-    Menu, 
+    LayoutDashboard,
+    Users,
+    CreditCard,
+    History,
+    Download,
+    FileText,
+    LogOut,
+    Menu,
     X,
     ChevronRight
 } from "lucide-react"
@@ -28,6 +29,11 @@ const navItems = [
         label: "Creators",
         href: "/admin/creators",
         icon: Users,
+    },
+    {
+        label: "Leads",
+        href: "/admin/leads",
+        icon: FileText,
     },
     {
         label: "Payouts",

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -1,0 +1,626 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { Id } from "@/convex/_generated/dataModel"
+import { useAdminAuth } from "@/hooks/useAdmin"
+import AdminLayout from "../components/AdminLayout"
+import {
+    Search,
+    Plus,
+    Phone,
+    Mail,
+    Globe,
+    QrCode,
+    ArrowUpRight,
+    X,
+    Pencil,
+    Trash2,
+    MoreVertical,
+} from "lucide-react"
+
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+    new: { label: "New", color: "bg-blue-100 text-blue-700" },
+    contacted: { label: "Contacted", color: "bg-amber-100 text-amber-700" },
+    qualified: { label: "Qualified", color: "bg-purple-100 text-purple-700" },
+    converted: { label: "Converted", color: "bg-green-100 text-green-700" },
+    lost: { label: "Lost", color: "bg-red-100 text-red-700" },
+}
+
+const SOURCE_ICON: Record<string, any> = {
+    website: Globe,
+    qr_code: QrCode,
+    direct: ArrowUpRight,
+}
+
+export default function AdminLeadsPage() {
+    const { isAdmin, loading: isLoading } = useAdminAuth()
+    const leads = useQuery(api.leads.getAll)
+    const createLead = useMutation(api.leads.create)
+    const updateLead = useMutation(api.leads.update)
+    const updateStatus = useMutation(api.leads.updateStatus)
+    const deleteLead = useMutation(api.leads.remove)
+
+    const [search, setSearch] = useState("")
+    const [statusFilter, setStatusFilter] = useState<string>("all")
+    // For the "Add Lead" modal — fetch all submissions so admin can pick one from a dropdown
+    const allSubmissions = useQuery(api.submissions.getAll)
+    const [showAddModal, setShowAddModal] = useState(false)
+    const [businessSearch, setBusinessSearch] = useState("")
+    const [selectedSubmission, setSelectedSubmission] = useState<any>(null)
+    const [newLead, setNewLead] = useState({
+        name: "",
+        phone: "",
+        email: "",
+        message: "",
+    })
+
+    // Edit modal state
+    const [editingLead, setEditingLead] = useState<any>(null)
+    const [editForm, setEditForm] = useState({ name: "", phone: "", email: "", message: "" })
+
+    // Delete confirmation state
+    const [deletingLead, setDeletingLead] = useState<any>(null)
+    const [deleting, setDeleting] = useState(false)
+
+    // Action dropdown state
+    const [activeActionId, setActiveActionId] = useState<string | null>(null)
+
+    // Close action dropdown when clicking outside
+    useEffect(() => {
+        if (!activeActionId) return
+        const handler = () => setActiveActionId(null)
+        document.addEventListener('click', handler)
+        return () => document.removeEventListener('click', handler)
+    }, [activeActionId])
+
+    if (isLoading) {
+        return (
+            <AdminLayout>
+                <div className="flex items-center justify-center h-64">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500" />
+                </div>
+            </AdminLayout>
+        )
+    }
+
+    if (!isAdmin) {
+        return (
+            <AdminLayout>
+                <div className="text-center py-20 text-gray-500">Admin access required</div>
+            </AdminLayout>
+        )
+    }
+
+    const filteredLeads = (leads || []).filter((lead) => {
+        const matchesSearch =
+            !search ||
+            lead.name.toLowerCase().includes(search.toLowerCase()) ||
+            lead.phone.includes(search) ||
+            (lead.email || "").toLowerCase().includes(search.toLowerCase()) ||
+            (lead.businessName || "").toLowerCase().includes(search.toLowerCase())
+        const matchesStatus = statusFilter === "all" || lead.status === statusFilter
+        return matchesSearch && matchesStatus
+    })
+
+    const statusCounts = (leads || []).reduce(
+        (acc, lead) => {
+            acc[lead.status] = (acc[lead.status] || 0) + 1
+            return acc
+        },
+        {} as Record<string, number>
+    )
+
+    // Validation helpers
+    const validateName = (name: string) => {
+        if (!name.trim()) return 'Name is required'
+        if (name.trim().length < 2) return 'Name must be at least 2 characters'
+        return null
+    }
+    const validatePhone = (phone: string) => {
+        if (!phone.trim()) return 'Phone number is required'
+        const digits = phone.replace(/[^\d+]/g, '')
+        if (digits.length < 7) return 'Phone number is too short'
+        if (digits.length > 15) return 'Phone number is too long'
+        return null
+    }
+    const validateEmail = (email: string) => {
+        if (!email) return null // optional
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return 'Invalid email format'
+        return null
+    }
+
+    const [addErrors, setAddErrors] = useState<Record<string, string>>({})
+    const [editErrors, setEditErrors] = useState<Record<string, string>>({})
+
+    const handleAddLead = async () => {
+        const errors: Record<string, string> = {}
+        const nameErr = validateName(newLead.name)
+        const phoneErr = validatePhone(newLead.phone)
+        const emailErr = validateEmail(newLead.email)
+        if (nameErr) errors.name = nameErr
+        if (phoneErr) errors.phone = phoneErr
+        if (emailErr) errors.email = emailErr
+        setAddErrors(errors)
+        if (Object.keys(errors).length > 0) return
+        try {
+            await createLead({
+                name: newLead.name,
+                phone: newLead.phone,
+                email: newLead.email || undefined,
+                message: newLead.message || undefined,
+                source: 'direct',
+                // Only link to a submission if one was selected
+                submissionId: selectedSubmission?._id as Id<"submissions"> | undefined,
+                creatorId: selectedSubmission?.creatorId as Id<"creators"> | undefined,
+            })
+            setShowAddModal(false)
+            setSelectedSubmission(null)
+            setBusinessSearch("")
+            setNewLead({ name: "", phone: "", email: "", message: "" })
+            setAddErrors({})
+        } catch (err: any) {
+            alert(err.message || "Failed to add lead")
+        }
+    }
+
+    const handleEditLead = async () => {
+        if (!editingLead) return
+        const errors: Record<string, string> = {}
+        const nameErr = validateName(editForm.name)
+        const phoneErr = validatePhone(editForm.phone)
+        const emailErr = validateEmail(editForm.email)
+        if (nameErr) errors.name = nameErr
+        if (phoneErr) errors.phone = phoneErr
+        if (emailErr) errors.email = emailErr
+        setEditErrors(errors)
+        if (Object.keys(errors).length > 0) return
+        try {
+            await updateLead({
+                id: editingLead._id,
+                name: editForm.name.trim(),
+                phone: editForm.phone.trim(),
+                email: editForm.email.trim() || undefined,
+                message: editForm.message.trim() || undefined,
+            })
+            setEditingLead(null)
+            setEditErrors({})
+        } catch (err: any) {
+            alert(err.message || "Failed to update lead")
+        }
+    }
+
+    const handleDeleteLead = async () => {
+        if (!deletingLead) return
+        setDeleting(true)
+        try {
+            await deleteLead({ id: deletingLead._id })
+            setDeletingLead(null)
+        } catch (err: any) {
+            alert(err.message || "Failed to delete lead")
+        } finally {
+            setDeleting(false)
+        }
+    }
+
+    const openEdit = (lead: any) => {
+        setEditForm({ name: lead.name, phone: lead.phone, email: lead.email || "", message: lead.message || "" })
+        setEditingLead(lead)
+        setActiveActionId(null)
+    }
+
+    const openDelete = (lead: any) => {
+        setDeletingLead(lead)
+        setActiveActionId(null)
+    }
+
+    // Filter submissions for the business picker dropdown
+    const filteredSubmissions = (allSubmissions || []).filter((s: any) =>
+        !businessSearch || s.businessName?.toLowerCase().includes(businessSearch.toLowerCase())
+    ).slice(0, 8)
+
+    return (
+        <AdminLayout>
+            <div className="p-6 lg:p-8 max-w-7xl mx-auto">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6">
+                    <div>
+                        <h1 className="text-2xl font-bold text-gray-900">Lead Management</h1>
+                        <p className="text-sm text-gray-500 mt-1">
+                            {leads?.length || 0} total leads across all submissions
+                        </p>
+                    </div>
+                    <button
+                        onClick={() => setShowAddModal(true)}
+                        className="flex items-center gap-2 px-4 py-2.5 bg-emerald-600 text-white rounded-xl font-semibold text-sm hover:bg-emerald-700 transition-colors shadow-lg shadow-emerald-500/20"
+                    >
+                        <Plus size={18} />
+                        Add Lead
+                    </button>
+                </div>
+
+                {/* Status filter pills */}
+                <div className="flex flex-wrap items-center gap-2 mb-4">
+                    <button
+                        onClick={() => setStatusFilter("all")}
+                        className={`px-3 py-1.5 rounded-full text-xs font-bold transition-colors ${statusFilter === "all" ? "bg-gray-900 text-white" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
+                    >
+                        All ({leads?.length || 0})
+                    </button>
+                    {Object.entries(STATUS_CONFIG).map(([key, config]) => (
+                        <button
+                            key={key}
+                            onClick={() => setStatusFilter(key)}
+                            className={`px-3 py-1.5 rounded-full text-xs font-bold transition-colors ${statusFilter === key ? "bg-gray-900 text-white" : `${config.color} hover:opacity-80`}`}
+                        >
+                            {config.label} ({statusCounts[key] || 0})
+                        </button>
+                    ))}
+                </div>
+
+                {/* Search */}
+                <div className="relative mb-6">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search by name, phone, email, or business..."
+                        className="w-full pl-10 pr-4 py-3 bg-white border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+                    />
+                </div>
+
+                {/* Leads Table */}
+                <div className="bg-white rounded-2xl border border-emerald-500 overflow-hidden">
+                    <div className="overflow-x-auto">
+                        <table className="w-full">
+                            <thead>
+                                <tr className="border-b border-gray-100 bg-gray-50/50">
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Lead</th>
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Contact</th>
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Business</th>
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Source</th>
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Status</th>
+                                    <th className="text-left px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Date</th>
+                                    <th className="text-right px-5 py-3 text-xs font-bold text-gray-500 uppercase tracking-wider">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {filteredLeads.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={7} className="text-center py-12 text-gray-400">
+                                            {search || statusFilter !== "all" ? "No leads match your filters" : "No leads yet"}
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    filteredLeads.map((lead) => {
+                                        const SourceIcon = SOURCE_ICON[lead.source] || ArrowUpRight
+                                        const statusCfg = STATUS_CONFIG[lead.status] || STATUS_CONFIG.new
+                                        return (
+                                            <tr key={lead._id} className="border-b border-gray-50 hover:bg-gray-50/50 transition-colors">
+                                                <td className="px-5 py-4">
+                                                    <p className="font-semibold text-gray-900 text-sm">{lead.name}</p>
+                                                    {lead.message && (
+                                                        <p className="text-xs text-gray-400 mt-0.5 truncate max-w-[200px]">{lead.message}</p>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-4">
+                                                    <div className="flex items-center gap-1.5 text-sm text-gray-700">
+                                                        <Phone size={13} className="text-gray-400" />
+                                                        {lead.phone}
+                                                    </div>
+                                                    {lead.email && (
+                                                        <div className="flex items-center gap-1.5 text-xs text-gray-500 mt-0.5">
+                                                            <Mail size={11} className="text-gray-400" />
+                                                            {lead.email}
+                                                        </div>
+                                                    )}
+                                                </td>
+                                                <td className="px-5 py-4">
+                                                    <p className="text-sm text-gray-700">{lead.businessName}</p>
+                                                    <p className="text-xs text-gray-400">{lead.creatorName}</p>
+                                                </td>
+                                                <td className="px-5 py-4">
+                                                    <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                                                        <SourceIcon size={14} />
+                                                        {lead.source.replace("_", " ")}
+                                                    </div>
+                                                </td>
+                                                <td className="px-5 py-4">
+                                                    <select
+                                                        value={lead.status}
+                                                        onChange={async (e) => {
+                                                            try {
+                                                                await updateStatus({
+                                                                    id: lead._id,
+                                                                    status: e.target.value as any,
+                                                                })
+                                                            } catch (err: any) {
+                                                                alert(err.message)
+                                                            }
+                                                        }}
+                                                        className={`text-xs font-bold px-2.5 py-1 rounded-full border-0 cursor-pointer ${statusCfg.color}`}
+                                                    >
+                                                        {Object.entries(STATUS_CONFIG).map(([key, config]) => (
+                                                            <option key={key} value={key}>{config.label}</option>
+                                                        ))}
+                                                    </select>
+                                                </td>
+                                                <td className="px-5 py-4 text-xs text-gray-400">
+                                                    {new Date(lead.createdAt).toLocaleDateString("en-US", {
+                                                        month: "short",
+                                                        day: "numeric",
+                                                        year: "numeric",
+                                                    })}
+                                                </td>
+                                                <td className="px-5 py-4 text-right">
+                                                    <div className="relative inline-block">
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.stopPropagation()
+                                                                setActiveActionId(activeActionId === lead._id ? null : lead._id)
+                                                            }}
+                                                            className="text-gray-400 hover:text-gray-600 p-1 rounded-lg hover:bg-gray-100 transition-colors"
+                                                        >
+                                                            <MoreVertical size={16} />
+                                                        </button>
+                                                        {activeActionId === lead._id && (
+                                                            <div className="absolute right-0 mt-1 w-36 bg-white border border-gray-200 rounded-xl shadow-lg z-20 overflow-hidden">
+                                                                <button
+                                                                    onClick={() => openEdit(lead)}
+                                                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                                                                >
+                                                                    <Pencil size={14} /> Edit
+                                                                </button>
+                                                                <button
+                                                                    onClick={() => openDelete(lead)}
+                                                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                                                                >
+                                                                    <Trash2 size={14} /> Delete
+                                                                </button>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        )
+                                    })
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                {/* Add Lead Modal */}
+                {showAddModal && (
+                    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+                        <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full overflow-hidden">
+                            <div className="flex items-center justify-between p-5 border-b border-gray-200">
+                                <h3 className="text-lg font-bold text-gray-900">Add New Lead</h3>
+                                <button onClick={() => setShowAddModal(false)} className="text-gray-400 hover:text-gray-600">
+                                    <X size={20} />
+                                </button>
+                            </div>
+                            <div className="p-5 space-y-4">
+                                {/* Business picker — searchable dropdown that auto-fills submissionId + creatorId */}
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Link to Business <span className="text-gray-400 normal-case font-normal">(optional)</span></label>
+                                    {selectedSubmission ? (
+                                        <div className="mt-1 flex items-center justify-between px-3 py-2.5 bg-emerald-50 border border-emerald-200 rounded-lg">
+                                            <div>
+                                                <p className="text-sm font-semibold text-gray-900">{selectedSubmission.businessName}</p>
+                                                <p className="text-xs text-gray-500">{selectedSubmission.city} · {selectedSubmission.businessType}</p>
+                                            </div>
+                                            <button onClick={() => { setSelectedSubmission(null); setBusinessSearch("") }} className="text-gray-400 hover:text-red-500">
+                                                <X size={16} />
+                                            </button>
+                                        </div>
+                                    ) : (
+                                        <div className="relative mt-1">
+                                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
+                                            <input
+                                                type="text"
+                                                value={businessSearch}
+                                                onChange={(e) => setBusinessSearch(e.target.value)}
+                                                className="w-full pl-9 pr-3 py-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                                                placeholder="Search business name..."
+                                            />
+                                            {businessSearch && filteredSubmissions.length > 0 && (
+                                                <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                                                    {filteredSubmissions.map((s: any) => (
+                                                        <button
+                                                            key={s._id}
+                                                            onClick={() => {
+                                                                setSelectedSubmission(s)
+                                                                setBusinessSearch("")
+                                                            }}
+                                                            className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b border-gray-50 last:border-0"
+                                                        >
+                                                            <p className="text-sm font-medium text-gray-900">{s.businessName}</p>
+                                                            <p className="text-xs text-gray-500">{s.city} · {s.ownerName}</p>
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            )}
+                                            {businessSearch && filteredSubmissions.length === 0 && (
+                                                <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-center">
+                                                    <p className="text-xs text-gray-400">No businesses found</p>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Name *</label>
+                                        <input
+                                            type="text"
+                                            value={newLead.name}
+                                            onChange={(e) => { setNewLead({ ...newLead, name: e.target.value }); setAddErrors((p) => ({ ...p, name: '' })) }}
+                                            className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${addErrors.name ? 'border-red-400' : 'border-gray-200'}`}
+                                            placeholder="Contact name"
+                                        />
+                                        {addErrors.name && <p className="text-xs text-red-500 mt-1">{addErrors.name}</p>}
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Phone *</label>
+                                        <input
+                                            type="text"
+                                            value={newLead.phone}
+                                            onChange={(e) => { setNewLead({ ...newLead, phone: e.target.value }); setAddErrors((p) => ({ ...p, phone: '' })) }}
+                                            className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${addErrors.phone ? 'border-red-400' : 'border-gray-200'}`}
+                                            placeholder="+63 9XX XXX XXXX"
+                                        />
+                                        {addErrors.phone && <p className="text-xs text-red-500 mt-1">{addErrors.phone}</p>}
+                                    </div>
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Email</label>
+                                    <input
+                                        type="email"
+                                        value={newLead.email}
+                                        onChange={(e) => { setNewLead({ ...newLead, email: e.target.value }); setAddErrors((p) => ({ ...p, email: '' })) }}
+                                        className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${addErrors.email ? 'border-red-400' : 'border-gray-200'}`}
+                                        placeholder="Optional"
+                                    />
+                                    {addErrors.email && <p className="text-xs text-red-500 mt-1">{addErrors.email}</p>}
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Message</label>
+                                    <textarea
+                                        value={newLead.message}
+                                        onChange={(e) => setNewLead({ ...newLead, message: e.target.value })}
+                                        className="w-full mt-1 px-3 py-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-none h-20"
+                                        placeholder="Optional notes"
+                                    />
+                                </div>
+                            </div>
+                            <div className="flex items-center justify-end gap-3 p-5 border-t border-gray-200 bg-gray-50">
+                                <button
+                                    onClick={() => { setShowAddModal(false); setSelectedSubmission(null); setBusinessSearch("") }}
+                                    className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={handleAddLead}
+                                    disabled={!newLead.name || !newLead.phone}
+                                    className="px-5 py-2.5 bg-emerald-600 text-white rounded-xl font-semibold text-sm hover:bg-emerald-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    Add Lead
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* Edit Lead Modal */}
+                {editingLead && (
+                    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setEditingLead(null)}>
+                        <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                            <div className="flex items-center justify-between p-5 border-b border-gray-200">
+                                <h3 className="text-lg font-bold text-gray-900">Edit Lead</h3>
+                                <button onClick={() => setEditingLead(null)} className="text-gray-400 hover:text-gray-600">
+                                    <X size={20} />
+                                </button>
+                            </div>
+                            <div className="p-5 space-y-4">
+                                {editingLead.businessName && editingLead.businessName !== 'Unlinked' && (
+                                    <div className="px-3 py-2 bg-gray-50 rounded-lg text-xs text-gray-500">
+                                        Linked to: <span className="font-semibold text-gray-700">{editingLead.businessName}</span>
+                                    </div>
+                                )}
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Name *</label>
+                                        <input
+                                            type="text"
+                                            value={editForm.name}
+                                            onChange={(e) => { setEditForm({ ...editForm, name: e.target.value }); setEditErrors((p) => ({ ...p, name: '' })) }}
+                                            className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${editErrors.name ? 'border-red-400' : 'border-gray-200'}`}
+                                        />
+                                        {editErrors.name && <p className="text-xs text-red-500 mt-1">{editErrors.name}</p>}
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Phone *</label>
+                                        <input
+                                            type="text"
+                                            value={editForm.phone}
+                                            onChange={(e) => { setEditForm({ ...editForm, phone: e.target.value }); setEditErrors((p) => ({ ...p, phone: '' })) }}
+                                            className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${editErrors.phone ? 'border-red-400' : 'border-gray-200'}`}
+                                        />
+                                        {editErrors.phone && <p className="text-xs text-red-500 mt-1">{editErrors.phone}</p>}
+                                    </div>
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Email</label>
+                                    <input
+                                        type="email"
+                                        value={editForm.email}
+                                        onChange={(e) => { setEditForm({ ...editForm, email: e.target.value }); setEditErrors((p) => ({ ...p, email: '' })) }}
+                                        className={`w-full mt-1 px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 ${editErrors.email ? 'border-red-400' : 'border-gray-200'}`}
+                                    />
+                                    {editErrors.email && <p className="text-xs text-red-500 mt-1">{editErrors.email}</p>}
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Message</label>
+                                    <textarea
+                                        value={editForm.message}
+                                        onChange={(e) => setEditForm({ ...editForm, message: e.target.value })}
+                                        className="w-full mt-1 px-3 py-2.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-none h-20"
+                                    />
+                                </div>
+                            </div>
+                            <div className="flex items-center justify-end gap-3 p-5 border-t border-gray-200 bg-gray-50">
+                                <button onClick={() => setEditingLead(null)} className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900">
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={handleEditLead}
+                                    disabled={!editForm.name || !editForm.phone}
+                                    className="px-5 py-2.5 bg-emerald-600 text-white rounded-xl font-semibold text-sm hover:bg-emerald-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    Save Changes
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* Delete Confirmation Modal */}
+                {deletingLead && (
+                    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setDeletingLead(null)}>
+                        <div className="bg-white rounded-2xl shadow-xl max-w-md w-full overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                            <div className="p-6 text-center">
+                                <div className="mx-auto w-14 h-14 rounded-full bg-red-100 flex items-center justify-center mb-4">
+                                    <Trash2 className="text-red-600" size={24} />
+                                </div>
+                                <h3 className="text-lg font-bold text-gray-900 mb-2">Delete Lead</h3>
+                                <p className="text-sm text-gray-500 mb-1">
+                                    Are you sure you want to delete this lead?
+                                </p>
+                                <p className="text-sm font-semibold text-gray-900 mb-1">{deletingLead.name}</p>
+                                <p className="text-xs text-gray-400">{deletingLead.phone} · {deletingLead.businessName}</p>
+                                <p className="text-xs text-red-500 mt-3">This action cannot be undone. All associated notes will also be deleted.</p>
+                            </div>
+                            <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+                                <button onClick={() => setDeletingLead(null)} className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900">
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={handleDeleteLead}
+                                    disabled={deleting}
+                                    className="px-5 py-2.5 bg-red-600 text-white rounded-xl font-semibold text-sm hover:bg-red-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    {deleting ? 'Deleting...' : 'Delete Lead'}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </AdminLayout>
+    )
+}

--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -1337,16 +1337,45 @@ export default function SubmissionDetailPage() {
                         <div className="bg-white rounded-xl p-6 border border-gray-200">
                             <div className="flex items-center justify-between mb-4">
                                 <h2 className="text-lg font-bold text-gray-900">Business Information</h2>
-                                {!isEditing && (
-                                    <button
-                                        onClick={handleEdit}
-                                        className="text-gray-400 hover:text-blue-500 transition-colors"
-                                    >
-                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                                        </svg>
-                                    </button>
-                                )}
+                                <div className="flex items-center gap-2">
+                                    {!isEditing && (
+                                        <button
+                                            onClick={() => {
+                                                const info = [
+                                                    `Business Name: ${submission.business_name}`,
+                                                    `Business Type: ${submission.business_type}`,
+                                                    `Owner Name: ${submission.owner_name}`,
+                                                    `Phone: ${submission.owner_phone}`,
+                                                    `Email: ${submission.owner_email || 'N/A'}`,
+                                                    `City: ${submission.city}`,
+                                                    `Address: ${submission.address}`,
+                                                ].join('\n')
+                                                navigator.clipboard.writeText(info)
+                                                    .then(() => {
+                                                        const btn = document.getElementById('copy-biz-info')
+                                                        if (btn) { btn.textContent = '✓'; setTimeout(() => { btn.textContent = ''; btn.innerHTML = '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>' }, 1500) }
+                                                    })
+                                            }}
+                                            id="copy-biz-info"
+                                            title="Copy business info"
+                                            className="text-gray-400 hover:text-emerald-600 transition-colors p-1"
+                                        >
+                                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                            </svg>
+                                        </button>
+                                    )}
+                                    {!isEditing && (
+                                        <button
+                                            onClick={handleEdit}
+                                            className="text-gray-400 hover:text-blue-500 transition-colors"
+                                        >
+                                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                                            </svg>
+                                        </button>
+                                    )}
+                                </div>
                             </div>
                             <div className="grid grid-cols-2 gap-4">
                                 <div>
@@ -1563,6 +1592,19 @@ export default function SubmissionDetailPage() {
                                                         {new Date(submissionData.transcriptionUpdatedAt).toLocaleString()}
                                                     </span>
                                                 )}
+                                                <button
+                                                    onClick={() => {
+                                                        navigator.clipboard.writeText(submission.transcript || '')
+                                                            .then(() => {
+                                                                const btn = document.getElementById('copy-transcript')
+                                                                if (btn) { btn.textContent = '✓ Copied'; setTimeout(() => { btn.textContent = 'Copy' }, 1500) }
+                                                            })
+                                                    }}
+                                                    id="copy-transcript"
+                                                    className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-600 px-2 py-1 rounded-full font-medium transition-colors"
+                                                >
+                                                    Copy
+                                                </button>
                                                 <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium">
                                                     Generated
                                                 </span>

--- a/app/api/send-website-email/route.ts
+++ b/app/api/send-website-email/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest) {
         const paymentConfig = getPaymentConfig()
         const paymentLink = paymentConfig.getPaymentLink(paymentToken.token)
 
-        // Send payment link email
+        // Send payment link email (includes custom domain breakdown if applicable)
         await sendPaymentLinkEmail({
             businessName: submission.businessName,
             businessOwnerName: submission.ownerName,
@@ -99,6 +99,7 @@ export async function POST(request: NextRequest) {
             paymentLink,
             referenceCode: paymentToken.referenceCode,
             platformEmail: process.env.WISE_EMAIL,
+            customDomain: (submission as any).requestedDomain || undefined,
         })
 
         // Record email sent timestamp

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -117,8 +117,8 @@ const policySections = [
   },
   {
     icon: <AlertTriangle className="w-8 h-8 text-[#00F0FF]" />,
-    title: "9. Children's Privacy",
-    content: "Negosyo Digital is not intended for use by individuals under the age of 18. We do not knowingly collect personal information from children. The app requires users to be of legal age to enter into contracts and perform field work as independent creators. If we become aware that we have collected data from a minor, we will take immediate steps to delete such information."
+    title: "9. Open Platform for All Ages",
+    content: "Negosyo Digital is open to users of all ages — including students, young entrepreneurs, and anyone who wants to help digitalize local businesses and earn from it. There are no age restrictions to use the platform or register as a Creator. We believe in empowering the next generation of Filipino digital entrepreneurs."
   },
   {
     icon: <MessageSquare className="w-8 h-8 text-[#00FF66]" />,

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -15,7 +15,7 @@ const termsSections = [
   {
     icon: <Scale className="w-8 h-8 text-[#00F0FF]" />,
     title: "1. Acceptance of Terms",
-    content: "By accessing or using the Negosyo Digital platform (including our mobile app and web portal), you agree to be strictly bound by these Terms of Service. You must be at least 18 years of age to register as a Creator."
+    content: "By accessing or using the Negosyo Digital platform (including our mobile app and web portal), you agree to be strictly bound by these Terms of Service. Users of all ages are welcome, including students and young entrepreneurs."
   },
   {
     icon: <Award className="w-8 h-8 text-[#00FF66]" />,

--- a/components/PhotoLightbox.tsx
+++ b/components/PhotoLightbox.tsx
@@ -33,15 +33,42 @@ export function PhotoLightbox({ photos, initialIndex = 0, onClose }: PhotoLightb
             onKeyDown={handleKeyDown}
             tabIndex={0}
         >
-            {/* Close Button */}
-            <button
-                onClick={onClose}
-                className="absolute top-4 right-4 text-white hover:text-gray-300 z-10"
-            >
-                <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
+            {/* Top-right controls: Download + Close */}
+            <div className="absolute top-4 right-4 z-10 flex items-center gap-3">
+                <button
+                    onClick={async (e) => {
+                        e.stopPropagation()
+                        try {
+                            const res = await fetch(photos[currentIndex])
+                            const blob = await res.blob()
+                            const url = URL.createObjectURL(blob)
+                            const a = document.createElement('a')
+                            a.href = url
+                            a.download = `photo-${currentIndex + 1}.jpg`
+                            document.body.appendChild(a)
+                            a.click()
+                            document.body.removeChild(a)
+                            URL.revokeObjectURL(url)
+                        } catch {
+                            window.open(photos[currentIndex], '_blank')
+                        }
+                    }}
+                    className="text-white hover:text-gray-300 bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors"
+                    title="Download photo"
+                >
+                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                </button>
+                <button
+                    onClick={onClose}
+                    className="text-white hover:text-gray-300 bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors"
+                >
+                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
 
             {/* Previous Button */}
             {photos.length > 1 && (

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -9,8 +9,8 @@ import { internal } from './_generated/api';
  */
 export const create = mutation({
     args: {
-        submissionId: v.id('submissions'),
-        creatorId: v.id('creators'),
+        submissionId: v.optional(v.id('submissions')),
+        creatorId: v.optional(v.id('creators')),
         source: v.union(v.literal('website'), v.literal('qr_code'), v.literal('direct')),
         name: v.string(),
         phone: v.string(),
@@ -30,34 +30,36 @@ export const create = mutation({
             createdAt: Date.now(),
         });
 
-        // Increment analytics
-        const today = new Date().toISOString().split('T')[0];
-        const month = today.substring(0, 7);
+        // Analytics + notification only if linked to a creator
+        if (args.creatorId) {
+            const today = new Date().toISOString().split('T')[0];
+            const month = today.substring(0, 7);
 
-        await ctx.scheduler.runAfter(0, internal.analytics.incrementStat, {
-            creatorId: args.creatorId,
-            period: today,
-            periodType: 'daily',
-            field: 'leadsGenerated',
-            delta: 1,
-        });
-        await ctx.scheduler.runAfter(0, internal.analytics.incrementStat, {
-            creatorId: args.creatorId,
-            period: month,
-            periodType: 'monthly',
-            field: 'leadsGenerated',
-            delta: 1,
-        });
+            await ctx.scheduler.runAfter(0, internal.analytics.incrementStat, {
+                creatorId: args.creatorId,
+                period: today,
+                periodType: 'daily',
+                field: 'leadsGenerated',
+                delta: 1,
+            });
+            await ctx.scheduler.runAfter(0, internal.analytics.incrementStat, {
+                creatorId: args.creatorId,
+                period: month,
+                periodType: 'monthly',
+                field: 'leadsGenerated',
+                delta: 1,
+            });
 
-        // Send notification to creator
-        const submission = await ctx.db.get(args.submissionId);
-        await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
-            creatorId: args.creatorId,
-            type: 'new_lead',
-            title: 'New Lead!',
-            body: `${args.name} inquired about ${submission?.businessName ?? 'your business'}`,
-            data: { submissionId: args.submissionId, leadId },
-        });
+            // Send notification to creator
+            const submission = args.submissionId ? await ctx.db.get(args.submissionId) : null;
+            await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+                creatorId: args.creatorId,
+                type: 'new_lead',
+                title: 'New Lead!',
+                body: `${args.name} inquired about ${submission?.businessName ?? 'your business'}`,
+                data: { submissionId: args.submissionId, leadId },
+            });
+        }
 
         return leadId;
     },
@@ -81,6 +83,39 @@ export const updateStatus = mutation({
         await ctx.db.patch(args.id, { status: args.status });
     },
 });
+
+/**
+ * Update a lead's details (name, phone, email, message, status)
+ */
+export const update = mutation({
+    args: {
+        id: v.id('leads'),
+        name: v.optional(v.string()),
+        phone: v.optional(v.string()),
+        email: v.optional(v.string()),
+        message: v.optional(v.string()),
+        status: v.optional(v.union(
+            v.literal('new'),
+            v.literal('contacted'),
+            v.literal('qualified'),
+            v.literal('converted'),
+            v.literal('lost')
+        )),
+    },
+    handler: async (ctx, args) => {
+        const { id, ...updates } = args
+        // Remove undefined fields so we don't overwrite with undefined
+        const patch: Record<string, any> = {}
+        if (updates.name !== undefined) patch.name = updates.name
+        if (updates.phone !== undefined) patch.phone = updates.phone
+        if (updates.email !== undefined) patch.email = updates.email
+        if (updates.message !== undefined) patch.message = updates.message
+        if (updates.status !== undefined) patch.status = updates.status
+        if (Object.keys(patch).length > 0) {
+            await ctx.db.patch(id, patch)
+        }
+    },
+})
 
 /**
  * Delete a lead and its notes
@@ -117,6 +152,28 @@ export const getBySubmission = query({
             .collect();
     },
 });
+
+/**
+ * Get all leads in the system (admin)
+ */
+export const getAll = query({
+    args: {},
+    handler: async (ctx) => {
+        const leads = await ctx.db.query('leads').order('desc').take(500)
+        const enriched = await Promise.all(
+            leads.map(async (lead) => {
+                const submission = lead.submissionId ? await ctx.db.get(lead.submissionId) : null
+                const creator = lead.creatorId ? await ctx.db.get(lead.creatorId) : null
+                return {
+                    ...lead,
+                    businessName: submission?.businessName || 'Unlinked',
+                    creatorName: creator ? `${creator.firstName || ''} ${creator.lastName || ''}`.trim() : 'N/A',
+                }
+            })
+        )
+        return enriched
+    },
+})
 
 /**
  * Get all leads across all of a creator's businesses

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -347,8 +347,8 @@ export default defineSchema({
 
     // ==================== LEADS ====================
     leads: defineTable({
-        submissionId: v.id('submissions'),
-        creatorId: v.id('creators'),
+        submissionId: v.optional(v.id('submissions')), // Optional — standalone leads don't need a submission
+        creatorId: v.optional(v.id('creators')),        // Optional — auto-filled from submission if linked
         businessOwnerId: v.optional(v.string()),
         source: v.union(
             v.literal('website'),

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -66,7 +66,8 @@ interface PaymentLinkEmailData {
     amount: number
     paymentLink: string
     referenceCode: string
-    platformEmail?: string // Platform's Wise account email
+    platformEmail?: string
+    customDomain?: string // If set, shows breakdown (website ₱1,000 + domain ₱500)
 }
 
 export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
@@ -96,6 +97,7 @@ export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
             paymentLink,
             referenceCode,
             platformEmail,
+            customDomain: data.customDomain,
         })
 
         const info = await transporter.sendMail({

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -13,8 +13,9 @@ export function getPaymentConfirmationEmailHtml(params: {
     websiteUrl: string
     amount: number
     wiseEmail?: string
+    customDomain?: string // If set, shows "domain being configured" notice
 }): string {
-    const { businessName, businessOwnerName, websiteUrl, amount, wiseEmail: customWiseEmail } = params
+    const { businessName, businessOwnerName, websiteUrl, amount, wiseEmail: customWiseEmail, customDomain } = params
     
     const wiseEmail = customWiseEmail || paymentConfig.wiseEmail || 'frmwrkd.media@gmail.com'
 
@@ -92,6 +93,24 @@ export function getPaymentConfirmationEmailHtml(params: {
                         </td>
                     </tr>
 
+                    ${customDomain ? `
+                    <!-- Custom Domain Notice -->
+                    <tr>
+                        <td style="padding:28px 40px 0;">
+                            <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#0c1f17;border:1px solid #065f46;border-radius:12px;overflow:hidden;">
+                                <tr>
+                                    <td style="padding:24px;">
+                                        <p style="margin:0 0 8px;font-size:14px;color:#10b981;font-weight:700;">🌐 Custom Domain: ${customDomain}</p>
+                                        <p style="margin:0;font-size:13px;color:#6ee7b7;line-height:1.6;">
+                                            Your custom domain is being configured and will be live within 5 minutes. You'll receive a separate email with your domain details and renewal information once it's ready.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    ` : ''}
+
                     <!-- Website CTA -->
                     <tr>
                         <td style="padding:28px 40px 0;">
@@ -162,8 +181,9 @@ export function getPaymentLinkEmailHtml(params: {
     paymentLink: string
     referenceCode: string
     platformEmail?: string
+    customDomain?: string // If set, email shows a breakdown: website ₱1,000 + domain ₱500
 }): string {
-    const { businessName, businessOwnerName, amount, paymentLink, referenceCode, platformEmail } = params
+    const { businessName, businessOwnerName, amount, paymentLink, referenceCode, platformEmail, customDomain } = params
 
     const displayEmail = platformEmail || paymentConfig.wiseEmail || 'frmwrkd.media@gmail.com'
 
@@ -219,8 +239,39 @@ export function getPaymentLinkEmailHtml(params: {
                                 <tr>
                                     <td>
                                         <p style="margin:0 0 16px;font-size:12px;color:#6b7280;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">Payment Amount</p>
-                                        <p style="margin:0 0 20px;font-size:32px;color:#10b981;font-weight:800;">₱${amount.toLocaleString('en-PH')}</p>
-                                        
+                                        <p style="margin:0 0 8px;font-size:32px;color:#10b981;font-weight:800;">₱${amount.toLocaleString('en-PH')}</p>
+                                        ${customDomain ? `
+                                        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 20px;background:#0a0a0a;border-radius:8px;overflow:hidden;">
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #262626;">
+                                                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                                                        <tr>
+                                                            <td style="font-size:13px;color:#9ca3af;">Website Package</td>
+                                                            <td align="right" style="font-size:13px;color:#e5e7eb;font-weight:600;">₱1,000</td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:12px 16px;border-bottom:1px solid #262626;">
+                                                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                                                        <tr>
+                                                            <td style="font-size:13px;color:#9ca3af;">Custom Domain: <strong style="color:#10b981;">${customDomain}</strong></td>
+                                                            <td align="right" style="font-size:13px;color:#e5e7eb;font-weight:600;">₱500</td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding:10px 16px;background:#111;">
+                                                    <p style="margin:0;font-size:11px;color:#6b7280;line-height:1.5;">
+                                                        Year 1 of your custom domain is <strong style="color:#10b981;">included free</strong>. After year 1, renewal is ~₱1,120/year and is your responsibility. We do NOT auto-renew.
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        ` : '<div style="margin-bottom:20px;"></div>'}
+
                                         <p style="margin:0 0 8px;font-size:12px;color:#6b7280;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">Reference Code</p>
                                         <p style="margin:0;font-size:16px;color:#ffffff;font-family:monospace;letter-spacing:1px;font-weight:700;">${referenceCode}</p>
                                     </td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/nodemailer": "^7.0.5",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^10.1.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "jest": "^30.3.0",
@@ -2581,6 +2582,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.0",
@@ -7597,6 +7605,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "cross-env NODE_OPTIONS=--no-node-snapshot next dev",
     "build": "cd astro-site-template && npm install --omit=dev && cd .. && next build",
     "start": "next start",
     "test": "jest",
@@ -42,6 +42,7 @@
     "@types/nodemailer": "^7.0.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "jest": "^30.3.0",


### PR DESCRIPTION
## Summary

- Full admin lead management module with CRUD, validation, and business linking
- Custom domain email templates with pricing breakdown and renewal disclaimers
- Privacy policy and terms updated to allow all ages
- Clerk proxy cleanup, Tailwind v4.2 upgrade, and various UI fixes

## Changes

### Lead Management (`app/admin/leads/`)
- New admin page at `/admin/leads` with full leads table (search, status filter pills, status counts)
- Add Lead modal with searchable business picker (auto-fills submissionId + creatorId)
- Business linking is optional — supports standalone leads not tied to any submission
- Edit Lead modal with pre-filled form
- Delete Lead modal with confirmation dialog and cascade warning
- Action dropdown (⋮) on each row with Edit/Delete options, auto-closes on outside click
- Inline validation on Add/Edit: name (min 2 chars), phone (7-15 digits), email (format check)
- Red border + inline error messages that clear on typing
- Added to admin sidebar navigation with FileText icon
- New Convex mutations: `leads.update`, `leads.getAll` (enriched with businessName + creatorName)
- Schema: `leads.submissionId` and `leads.creatorId` now optional

### Email Templates
- `getPaymentLinkEmailHtml`: new `customDomain` param — shows price breakdown table
  (Website ₱1,000 + Custom Domain ₱500) with renewal disclaimer when domain is included
- `getPaymentConfirmationEmailHtml`: new `customDomain` param — shows green notice box
  "Domain being configured, live in ~5 min" for custom domain submissions
- `sendPaymentLinkEmail` service: passes `customDomain` through to template
- `send-website-email` route: reads `submission.requestedDomain` and forwards to email

### Privacy Policy & Terms of Service
- Privacy policy: removed 18+ age restriction — now "Open Platform for All Ages"
  with language welcoming students and young entrepreneurs
- Terms of service: removed "must be at least 18" — now "Users of all ages are welcome"
- No consent/guardian language — simplified to just allow all users

### Clerk Proxy Cleanup
- Removed `redirects()` and `rewrites()` from `next.config.ts`
- Removed `proxyUrl` prop from `ClerkProvider`
- Removed `frontendApiProxy` / proxy options from `middleware.ts`
- Middleware restored to clean `clerkMiddleware()` with route matchers only

### Tailwind v4.2 Upgrade
- Upgraded `tailwindcss` 4.1.18 → 4.2.2 and `@tailwindcss/postcss` 4.1.18 → 4.2.2
- Fixes `EINVAL` worker thread error on Node.js 24 Windows
- Added `cross-env` for `npm run dev` with `--no-node-snapshot` flag (Node 24 workaround)

### UI Improvements
- Admin submission detail: copy-to-clipboard button for business info fields
- Admin submission detail: copy button for AI transcript text
- Photo lightbox: download button moved inside modal (top-right, next to close)
- Photo download: uses blob fetch + programmatic download (fixes cross-origin download)
- Navbar (Astro template): changed from fixed height `h-16` to padding `py-4 md:py-5`
- Footer Style A: removed Privacy/Terms links per request
- Gallery testimonial: hidden when both quote and author are empty (GalleryA/E/G)
- Featured section: renamed from "Gallery Section" to "Featured Products / Services"

### Custom Domain Test Pricing
- Temporarily set custom domain tier to ₱100 (normally ₱1,500) for end-to-end testing
- Affected files marked with "TEST PRICING" comments
- Full restore guide at `plans/REVERT-CUSTOM-DOMAIN-PRICING.md`