### PR TITLE
Add: Pricing and Domain Display Widget on Detail Page

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -1823,6 +1823,88 @@ export default function SubmissionDetailPage() {
                                 </div>
                             </div>
                         )}
+
+                        {/* Pricing & Custom Domain */}
+                        <div className="bg-white rounded-xl p-6 border border-gray-200">
+                            <h2 className="text-lg font-bold text-gray-900 mb-4">Pricing & Domain</h2>
+                            <div className="space-y-3">
+                                {/* Package type */}
+                                <div>
+                                    <label className="text-xs text-gray-500 uppercase font-medium">Package</label>
+                                    <div className="flex items-center gap-2 mt-1">
+                                        {(submissionData as any)?.requestedDomain ? (
+                                            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-bold bg-emerald-100 text-emerald-700">
+                                                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9" /></svg>
+                                                Standard + Custom Domain
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold bg-gray-100 text-gray-700">
+                                                Standard
+                                            </span>
+                                        )}
+                                    </div>
+                                </div>
+
+                                {/* Amount */}
+                                <div>
+                                    <label className="text-xs text-gray-500 uppercase font-medium">Business Owner Fee</label>
+                                    {/* TEST PRICING: ₱100 for custom domain, normally ₱1,500 — see plans/REVERT-CUSTOM-DOMAIN-PRICING.md */}
+                                    <p className="text-2xl font-black text-gray-900 mt-1">
+                                        ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 100 : 1000)).toLocaleString()}
+                                    </p>
+                                    {(submissionData as any)?.requestedDomain && (
+                                        <p className="text-xs text-gray-500 mt-0.5">
+                                            Website ₱1,000 + Domain ₱500 included
+                                        </p>
+                                    )}
+                                </div>
+
+                                {/* Custom Domain (if requested) */}
+                                {(submissionData as any)?.requestedDomain && (
+                                    <div>
+                                        <label className="text-xs text-gray-500 uppercase font-medium">Custom Domain</label>
+                                        <div className="mt-1 flex items-center gap-2">
+                                            <p className="font-mono font-semibold text-emerald-700 text-sm">
+                                                {(submissionData as any).requestedDomain}
+                                            </p>
+                                            {(submissionData as any)?.domainStatus && (
+                                                <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                                                    (submissionData as any).domainStatus === 'live'
+                                                        ? 'bg-green-100 text-green-700'
+                                                        : (submissionData as any).domainStatus === 'failed'
+                                                            ? 'bg-red-100 text-red-700'
+                                                            : 'bg-amber-100 text-amber-700'
+                                                }`}>
+                                                    {(submissionData as any).domainStatus}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {(submissionData as any)?.domainStatus === 'live' && (
+                                            <a
+                                                href={`https://${(submissionData as any).requestedDomain}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-xs text-emerald-600 hover:text-emerald-700 font-medium mt-1 inline-flex items-center gap-1"
+                                            >
+                                                Visit live site
+                                                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                            </a>
+                                        )}
+                                        {(submissionData as any)?.domainFailureReason && (
+                                            <p className="text-xs text-red-500 mt-1">{(submissionData as any).domainFailureReason}</p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* No domain */}
+                                {!(submissionData as any)?.requestedDomain && (
+                                    <div>
+                                        <label className="text-xs text-gray-500 uppercase font-medium">Custom Domain</label>
+                                        <p className="text-sm text-gray-400 mt-1">Not requested (standard package)</p>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/plans/REVERT-CUSTOM-DOMAIN-PRICING.md
+++ b/plans/REVERT-CUSTOM-DOMAIN-PRICING.md
@@ -82,6 +82,18 @@ When testing is complete, all changes below must be reverted before production l
 
 ---
 
+### 4. `app/admin/submissions/[id]/page.tsx`
+
+**Pricing & Domain widget** — the fallback amount for custom domain:
+
+```diff
+  {/* TEST PRICING: ₱100 for custom domain, normally ₱1,500 — see plans/REVERT-CUSTOM-DOMAIN-PRICING.md */}
+- ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 100 : 1000)).toLocaleString()}
++ ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 1500 : 1000)).toLocaleString()}
+```
+
+---
+
 ## Quick revert (search & replace)
 
 If you'd rather grep your way through:
@@ -91,7 +103,8 @@ If you'd rather grep your way through:
 grep -rn "TEST PRICING\|TEST: ₱100\|? 100 :" \
   app/submit/review/page.tsx \
   convex/submissions.ts \
-  convex/schema.ts
+  convex/schema.ts \
+  app/admin/submissions/\[id\]/page.tsx
 
 # Then manually fix each match per the diffs above
 ```


### PR DESCRIPTION
#  Latest Changes ✨

**Admin UI Enhancements:**

* Added a "Pricing & Domain" section to the `SubmissionDetailPage` (`app/admin/submissions/[id]/page.tsx`) that displays package type (standard or standard + custom domain), business owner fee (with logic for test pricing), and custom domain details including status and failure reasons. ([app/admin/submissions/[id]/page.tsxR1826-R1907](diffhunk://#diff-a09a36732340f65cb5e62e44f2a492f1997092466713da18ebc4fca9b8913e57R1826-R1907))

**Documentation Updates for Test Pricing:**

* Updated `plans/REVERT-CUSTOM-DOMAIN-PRICING.md` to document the fallback amount logic for custom domains in the new widget, showing how to revert from test pricing (₱100) to normal pricing (₱1,500) before production.
* Added `app/admin/submissions/[id]/page.tsx` to the list of files in the grep command for reverting test pricing, ensuring all relevant files are covered.