### PR TITLE
Fix: Domain Setup for Submission

### DIFF
--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -8,6 +8,7 @@ import {
     registerDomain as registrarRegister,
     disableAutoRenewal as registrarDisableAutoRenewal,
     findSubscriptionForDomain as registrarFindSubscription,
+    getCatalogItemId as registrarGetCatalogItemId,
     updateNameservers,
     getPaymentMethodStatus as registrarGetPaymentMethodStatus,
     type RegistrantContact,
@@ -360,7 +361,7 @@ export const setupForSubmission = internalAction({
         try {
             console.log(`[DOMAINS] Starting setup for ${domain} (submission ${args.submissionId})`)
 
-            // Step 1: Re-verify availability + get the catalog item_id (required for purchase)
+            // Step 1: Re-verify availability
             await ctx.runMutation(internal.domains.setDomainStatus, {
                 submissionId: args.submissionId,
                 status: 'registering',
@@ -369,13 +370,24 @@ export const setupForSubmission = internalAction({
             if (!availCheck.available) {
                 throw new Error(`Domain ${domain} is no longer available`)
             }
-            if (!availCheck.itemId) {
-                throw new Error(`No Hostinger catalog item_id returned for ${domain} — cannot purchase`)
-            }
 
-            // Step 2: Build registrant contact from business owner info + register with item_id
+            // Step 1b: Get catalog item_id (required for purchase)
+            // Try from availability response first, then catalog endpoint, then use domain name as fallback
+            let itemId: string | undefined = availCheck.itemId
+            if (!itemId) {
+                const tld = domain.split('.').slice(1).join('.')
+                console.log(`[DOMAINS] No item_id from availability check, looking up catalog for .${tld}`)
+                itemId = (await registrarGetCatalogItemId(tld)) ?? undefined
+            }
+            if (!itemId) {
+                console.log(`[DOMAINS] No item_id from catalog either, using domain name as item_id fallback`)
+                itemId = domain
+            }
+            console.log(`[DOMAINS] Using item_id: ${itemId} for ${domain}`)
+
+            // Step 2: Build registrant contact from business owner info + register
             const contact = buildContactFromSubmission(submission)
-            const reg = await registrarRegister(domain, availCheck.itemId, contact)
+            const reg = await registrarRegister(domain, itemId!, contact)
             await ctx.runMutation(internal.domains.setRegistrarMetadata, {
                 submissionId: args.submissionId,
                 orderId: reg.orderId,

--- a/convex/lib/hostinger.ts
+++ b/convex/lib/hostinger.ts
@@ -252,6 +252,38 @@ export async function suggestAlternatives(
     }
 }
 
+// ==================== CATALOG LOOKUP ====================
+
+/**
+ * Get the catalog item_id for a domain TLD.
+ * The item_id is required by the purchase endpoint.
+ * Spec: GET /api/billing/v1/catalog (filter by category=domain, name matches TLD)
+ */
+export async function getCatalogItemId(tld: string): Promise<string | null> {
+    try {
+        const data = await hostingerRequest(`/billing/v1/catalog?category=domain`, { method: 'GET' })
+        const items = Array.isArray(data) ? data : (data?.data || data?.items || [])
+
+        // Find the item matching this TLD
+        const match = items.find((item: any) => {
+            const name = (item.name || item.title || item.slug || '').toLowerCase()
+            return name.includes(`.${tld}`) || name === tld || name === `.${tld}`
+        })
+
+        if (match) {
+            return String(match.id || match.item_id || '')
+        }
+
+        // If catalog search fails, try using the TLD directly as the item_id
+        // (some registrar APIs accept the TLD name as the item identifier)
+        console.warn(`[HOSTINGER] No catalog item found for .${tld}, will try domain name as item_id`)
+        return null
+    } catch (error) {
+        console.warn(`[HOSTINGER] Catalog lookup failed for .${tld}:`, error)
+        return null
+    }
+}
+
 // ==================== REGISTRATION ====================
 // Spec: POST /api/domains/v1/portfolio
 // Body: { domain, item_id, payment_method_id?, domain_contacts?, additional_details?, coupons? }
@@ -279,9 +311,8 @@ export async function registerDomain(
         throw new Error(`Cannot register .${tld} — TLD is blocked from standard tier`)
     }
 
-    if (!itemId) {
-        throw new Error('itemId is required to register a domain (get it from checkAvailability)')
-    }
+    // item_id is required by Hostinger — if not provided, try the domain name itself
+    const effectiveItemId = itemId || normalized
 
     const paymentMethodId = getPaymentMethodId()
 
@@ -303,7 +334,7 @@ export async function registerDomain(
         method: 'POST',
         body: JSON.stringify({
             domain: normalized,
-            item_id: itemId,
+            item_id: effectiveItemId,
             payment_method_id: paymentMethodId,
             domain_contacts: {
                 owner: contactObject,


### PR DESCRIPTION
# Latest Changes 

**Enhancements to domain registration robustness:**

* Added a new `getCatalogItemId` function in `convex/lib/hostinger.ts` to fetch the catalog `item_id` for a given TLD, with fallback logic if the item is not found.
* Updated the `setupForSubmission` flow in `convex/domains.ts` to use the new `getCatalogItemId` utility, trying the availability check first, then the catalog lookup, and finally falling back to the domain name as `item_id` if all else fails.
* Modified the `registerDomain` function to use the provided `itemId` or fall back to the normalized domain name, ensuring the registration can proceed even if the `itemId` is missing. [[1]](diffhunk://#diff-e5aec1a6dc8b54c548ec1e3731c9b0dbd2d204a77d616917b2db45615bd72899L282-R315) [[2]](diffhunk://#diff-e5aec1a6dc8b54c548ec1e3731c9b0dbd2d204a77d616917b2db45615bd72899L306-R337)

**Code integration and refactoring:**

* Exported the new `getCatalogItemId` function from `convex/domains.ts` for use in the registration flow.

**Minor improvements:**

* Clarified comments and step labels in the registration setup flow.