### PR TITLE
Remove: Province and Postal ID ON hostinger

### DIFF
--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -33,8 +33,6 @@ function buildContactFromSubmission(submission: any): RegistrantContact {
     if (!submission.ownerPhone) missing.push('ownerPhone')
     if (!submission.address) missing.push('address')
     if (!submission.city) missing.push('city')
-    if (!submission.province) missing.push('province')
-    if (!submission.postalCode) missing.push('postalCode')
     if (missing.length > 0) {
         throw new Error(`Cannot register domain: business owner info incomplete. Missing: ${missing.join(', ')}`)
     }
@@ -60,8 +58,10 @@ function buildContactFromSubmission(submission: any): RegistrantContact {
         phone,
         address: submission.address,
         city: submission.city,
-        state: submission.province,
-        postalCode: submission.postalCode,
+        // ICANN/WHOIS requires state + postal code; fall back to sensible PH defaults
+        // when the submission didn't capture them.
+        state: submission.province || submission.city || 'Metro Manila',
+        postalCode: submission.postalCode || '1000',
         country: 'PH',
     }
 }


### PR DESCRIPTION
# Latest Changes 

**Improved handling of missing address fields:**

* The function no longer throws an error if `province` or `postalCode` are missing from the submission, allowing registrations to proceed even with partial address data.
* When `province` or `postalCode` are missing, the function now falls back to using the `city` or a default value (`'Metro Manila'` for state, `'1000'` for postal code) to ensure required fields are always set.