### PR TITLE
Devpatch3

### DIFF
--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -33,8 +33,6 @@ function buildContactFromSubmission(submission: any): RegistrantContact {
     if (!submission.ownerPhone) missing.push('ownerPhone')
     if (!submission.address) missing.push('address')
     if (!submission.city) missing.push('city')
-    if (!submission.province) missing.push('province')
-    if (!submission.postalCode) missing.push('postalCode')
     if (missing.length > 0) {
         throw new Error(`Cannot register domain: business owner info incomplete. Missing: ${missing.join(', ')}`)
     }
@@ -60,8 +58,10 @@ function buildContactFromSubmission(submission: any): RegistrantContact {
         phone,
         address: submission.address,
         city: submission.city,
-        state: submission.province,
-        postalCode: submission.postalCode,
+        // ICANN/WHOIS requires state + postal code; fall back to sensible PH defaults
+        // when the submission didn't capture them.
+        state: submission.province || submission.city || 'Metro Manila',
+        postalCode: submission.postalCode || '1000',
         country: 'PH',
     }
 }


### PR DESCRIPTION
# Latest Changes 

Validation and Defaults for Address Fields:

* Removed the requirement for `province` and `postalCode` fields to be present in the submission; these fields are no longer included in the missing fields check.
* Updated the construction of the contact object to provide default values for `state` and `postalCode` if they are missing: `state` falls back to `province`, then `city`, then `'Metro Manila'`, and `postalCode` falls back to `'1000'`. This ensures ICANN/WHOIS requirements are met even with incomplete submissions.