### PR TITLE
Fix custom domain pipeline: Workers API + WHOIS + unified email

### DIFF
--- a/app/admin/submissions/[id]/emails/page.tsx
+++ b/app/admin/submissions/[id]/emails/page.tsx
@@ -13,6 +13,8 @@ interface EmailPreview {
     label: string
     description: string
     html: string
+    /** API endpoint to POST { submissionId } to in order to (re)send this email */
+    sendEndpoint: string
 }
 
 export default function EmailsSentPage() {
@@ -34,6 +36,10 @@ export default function EmailsSentPage() {
     const [emails, setEmails] = useState<EmailPreview[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [sendingType, setSendingType] = useState<string | null>(null)
+    const [sendResult, setSendResult] = useState<{ type: string; ok: boolean; message: string } | null>(null)
+
+    const hasCustomDomain = Boolean((submissionData as any)?.requestedDomain)
 
     useEffect(() => {
         if (!submissionData) return
@@ -42,13 +48,20 @@ export default function EmailsSentPage() {
             setLoading(true)
             setError(null)
 
-            const emailsToFetch: { type: string; label: string; description: string }[] = []
+            const emailsToFetch: {
+                type: string
+                label: string
+                description: string
+                sendEndpoint: string
+            }[] = []
 
             if (['pending_payment', 'paid', 'completed'].includes(submissionData.status)) {
                 emailsToFetch.push({
                     type: 'approval',
                     label: 'Send to Client Email',
-                    description: 'Sent when the website was deployed and shared with the client. Contains website preview link and payment instructions.',
+                    description:
+                        'Sent when the website was deployed and shared with the client. Contains website preview link and payment instructions.',
+                    sendEndpoint: '/api/send-website-email',
                 })
             }
 
@@ -56,7 +69,25 @@ export default function EmailsSentPage() {
                 emailsToFetch.push({
                     type: 'payment_confirmation',
                     label: 'Payment Confirmed Email',
-                    description: 'Sent after the admin confirmed payment was received. Contains payment confirmation and live website link.',
+                    description:
+                        'Sent after the admin confirmed payment was received. Contains payment confirmation and live website link.',
+                    sendEndpoint: '/api/send-completed-website-email',
+                })
+            }
+
+            // Completed-website email — available once the submission has been paid or
+            // marked completed. Branches automatically based on whether a custom domain
+            // is attached.
+            if (['paid', 'completed'].includes(submissionData.status)) {
+                emailsToFetch.push({
+                    type: 'completed_website',
+                    label: hasCustomDomain
+                        ? 'Website Live (Custom Domain) Email'
+                        : 'Website Live Email',
+                    description: hasCustomDomain
+                        ? 'Sent when the custom domain finishes provisioning. Includes the live URL and a year-1-paid renewal disclaimer for the business owner.'
+                        : 'Sent when the website is live on its workers.dev URL. Contains the published link and a thank-you message.',
+                    sendEndpoint: '/api/send-completed-website-email',
                 })
             }
 
@@ -68,11 +99,13 @@ export default function EmailsSentPage() {
 
             try {
                 const results = await Promise.all(
-                    emailsToFetch.map(async ({ type, label, description }) => {
-                        const response = await fetch(`/api/preview-email?submissionId=${submissionData._id}&type=${type}`)
+                    emailsToFetch.map(async ({ type, label, description, sendEndpoint }) => {
+                        const response = await fetch(
+                            `/api/preview-email?submissionId=${submissionData._id}&type=${type}`
+                        )
                         if (!response.ok) throw new Error(`Failed to load ${label}`)
                         const html = await response.text()
-                        return { type, label, description, html }
+                        return { type, label, description, html, sendEndpoint }
                     })
                 )
                 setEmails(results)
@@ -84,7 +117,33 @@ export default function EmailsSentPage() {
         }
 
         fetchEmails()
-    }, [submissionData])
+    }, [submissionData, hasCustomDomain])
+
+    async function handleSend(email: EmailPreview) {
+        if (!submissionData) return
+        setSendingType(email.type)
+        setSendResult(null)
+        try {
+            const response = await fetch(email.sendEndpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ submissionId: submissionData._id }),
+            })
+            const json = await response.json().catch(() => ({}))
+            if (!response.ok) {
+                throw new Error(json.error || `Failed (${response.status})`)
+            }
+            setSendResult({
+                type: email.type,
+                ok: true,
+                message: `Sent to ${submissionData.ownerEmail || 'business owner'}`,
+            })
+        } catch (err: any) {
+            setSendResult({ type: email.type, ok: false, message: err.message || 'Send failed' })
+        } finally {
+            setSendingType(null)
+        }
+    }
 
     const authLoading = !isLoaded || (user && currentCreator === undefined)
 
@@ -156,11 +215,11 @@ export default function EmailsSentPage() {
                                 <div className="px-6 py-4 border-b border-gray-100">
                                     <div className="flex items-start gap-3">
                                         <div className={`mt-0.5 w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
-                                            email.type === 'payment_confirmation'
+                                            email.type === 'payment_confirmation' || email.type === 'completed_website'
                                                 ? 'bg-emerald-100'
                                                 : 'bg-indigo-100'
                                         }`}>
-                                            {email.type === 'payment_confirmation' ? (
+                                            {email.type === 'payment_confirmation' || email.type === 'completed_website' ? (
                                                 <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                                                 </svg>
@@ -170,11 +229,11 @@ export default function EmailsSentPage() {
                                                 </svg>
                                             )}
                                         </div>
-                                        <div>
-                                            <div className="flex items-center gap-2">
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2 flex-wrap">
                                                 <h2 className="text-base font-semibold text-gray-900">{email.label}</h2>
                                                 <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                                                    email.type === 'payment_confirmation'
+                                                    email.type === 'payment_confirmation' || email.type === 'completed_website'
                                                         ? 'bg-emerald-50 text-emerald-700'
                                                         : 'bg-indigo-50 text-indigo-700'
                                                 }`}>
@@ -182,7 +241,33 @@ export default function EmailsSentPage() {
                                                 </span>
                                             </div>
                                             <p className="text-sm text-gray-500 mt-0.5">{email.description}</p>
+                                            {sendResult?.type === email.type && (
+                                                <p className={`text-xs mt-2 font-medium ${sendResult.ok ? 'text-emerald-700' : 'text-red-700'}`}>
+                                                    {sendResult.ok ? '✓ ' : '✗ '}{sendResult.message}
+                                                </p>
+                                            )}
                                         </div>
+                                        <button
+                                            type="button"
+                                            onClick={() => handleSend(email)}
+                                            disabled={sendingType === email.type || !submissionData?.ownerEmail}
+                                            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg bg-gray-900 text-white hover:bg-gray-800 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                                            title={!submissionData?.ownerEmail ? 'Business owner email is missing' : `Send to ${submissionData.ownerEmail}`}
+                                        >
+                                            {sendingType === email.type ? (
+                                                <>
+                                                    <span className="inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                                                    Sending…
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                                                    </svg>
+                                                    Send Email
+                                                </>
+                                            )}
+                                        </button>
                                     </div>
                                 </div>
 

--- a/app/api/preview-email/route.ts
+++ b/app/api/preview-email/route.ts
@@ -49,7 +49,11 @@ export async function GET(request: NextRequest) {
         }
 
         // Dynamically import the template functions to avoid bundling nodemailer on client
-        const { getApprovalEmailHtml, getPaymentConfirmationEmailHtml } = await import('@/lib/email/templates')
+        const {
+            getApprovalEmailHtml,
+            getPaymentConfirmationEmailHtml,
+            getDomainLiveEmailHtml,
+        } = await import('@/lib/email/templates')
 
         let html: string
 
@@ -61,6 +65,25 @@ export async function GET(request: NextRequest) {
                 amount: submission.amount ?? 0,
                 submissionId: submission._id,
             })
+        } else if (type === 'completed_website') {
+            // Branches on requestedDomain — same logic as send-completed-website-email
+            const submissionAny = submission as any
+            const customDomain = submissionAny.requestedDomain as string | undefined
+            if (customDomain) {
+                html = getDomainLiveEmailHtml({
+                    businessName: submission.businessName,
+                    businessOwnerName: submission.ownerName,
+                    customDomain,
+                    expiresAt: submissionAny.domainExpiresAt || Date.now() + 365 * 24 * 60 * 60 * 1000,
+                })
+            } else {
+                html = getPaymentConfirmationEmailHtml({
+                    businessName: submission.businessName,
+                    businessOwnerName: submission.ownerName,
+                    websiteUrl: publishedUrl || '#',
+                    amount: submission.amount ?? 0,
+                })
+            }
         } else {
             html = getPaymentConfirmationEmailHtml({
                 businessName: submission.businessName,

--- a/app/api/send-completed-website-email/route.ts
+++ b/app/api/send-completed-website-email/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { fetchQuery } from 'convex/nextjs'
+import { api } from '@/convex/_generated/api'
+import { Id } from '@/convex/_generated/dataModel'
+import {
+    sendDomainLiveEmail,
+    sendPaymentConfirmationEmail,
+} from '@/lib/email/service'
+
+/**
+ * Send the "your website is complete" email to the business owner.
+ *
+ * Branches on whether the submission has a custom domain:
+ *   - With requestedDomain → sends the domain-live email (with renewal disclaimer)
+ *   - Without              → sends the payment-confirmation email (workers.dev URL)
+ *
+ * Auth: either an authenticated admin (Clerk) OR the internal shared secret
+ * (X-Internal-Secret header). This lets both the admin UI button and the
+ * Convex pipeline use the same endpoint.
+ *
+ * POST /api/send-completed-website-email
+ * Body: { submissionId: string }
+ */
+export async function POST(request: NextRequest) {
+    try {
+        // Auth: admin Clerk session OR internal secret
+        let authorized = false
+        const providedSecret = request.headers.get('x-internal-secret')
+        const expectedSecret = process.env.INTERNAL_API_SECRET
+        if (expectedSecret && providedSecret === expectedSecret) {
+            authorized = true
+        } else {
+            const { userId } = await auth()
+            if (userId) {
+                const creator = await fetchQuery(api.creators.getByClerkId, { clerkId: userId })
+                if (creator?.role === 'admin') {
+                    authorized = true
+                }
+            }
+        }
+        if (!authorized) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const body = await request.json()
+        const { submissionId } = body
+        if (!submissionId) {
+            return NextResponse.json({ error: 'submissionId required' }, { status: 400 })
+        }
+
+        const submission = await fetchQuery(api.submissions.getById, {
+            id: submissionId as Id<'submissions'>,
+        })
+        if (!submission) {
+            return NextResponse.json({ error: 'Submission not found' }, { status: 404 })
+        }
+        if (!submission.ownerEmail) {
+            return NextResponse.json({ error: 'No owner email on submission' }, { status: 400 })
+        }
+
+        const submissionAny = submission as any
+        const customDomain = submissionAny.requestedDomain as string | undefined
+
+        if (customDomain) {
+            await sendDomainLiveEmail({
+                businessName: submission.businessName,
+                businessOwnerName: submission.ownerName,
+                businessOwnerEmail: submission.ownerEmail,
+                customDomain,
+                expiresAt: submissionAny.domainExpiresAt || Date.now() + 365 * 24 * 60 * 60 * 1000,
+            })
+            return NextResponse.json({ success: true, type: 'domain_live', sentTo: submission.ownerEmail })
+        }
+
+        // No custom domain — fall back to the payment-confirmation template with workers.dev URL
+        const website = await fetchQuery(api.generatedWebsites.getBySubmissionId, {
+            submissionId: submissionId as Id<'submissions'>,
+        })
+        const websiteUrl = website?.publishedUrl || ''
+        if (!websiteUrl) {
+            return NextResponse.json({ error: 'No published website URL found' }, { status: 400 })
+        }
+
+        await sendPaymentConfirmationEmail({
+            businessName: submission.businessName,
+            businessOwnerName: submission.ownerName,
+            businessOwnerEmail: submission.ownerEmail,
+            websiteUrl,
+            amount: submission.amount ?? 0,
+        })
+
+        return NextResponse.json({ success: true, type: 'payment_confirmation', sentTo: submission.ownerEmail })
+    } catch (error: any) {
+        console.error('send-completed-website-email error:', error)
+        return NextResponse.json(
+            { error: error.message || 'Failed to send completed website email' },
+            { status: 500 }
+        )
+    }
+}

--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -11,14 +11,19 @@ import {
     getCatalogItemId as registrarGetCatalogItemId,
     updateNameservers,
     getPaymentMethodStatus as registrarGetPaymentMethodStatus,
+    listPaymentMethods as registrarListPaymentMethods,
+    listWhoisProfiles as registrarListWhoisProfiles,
     type RegistrantContact,
 } from './lib/hostinger'
 import {
     createZone,
     getZoneStatus,
     isDomainOwnedByUs,
-    addCustomDomainToPages,
-    getCustomDomainStatus,
+    addCustomDomainToWorker,
+    getWorkerCustomDomainStatus,
+    removeCustomDomainFromPages,
+    listDnsRecords,
+    deleteDnsRecord,
 } from './lib/cloudflare'
 
 /**
@@ -371,8 +376,8 @@ export const setupForSubmission = internalAction({
                 throw new Error(`Domain ${domain} is no longer available`)
             }
 
-            // Step 1b: Get catalog item_id (required for purchase)
-            // Try from availability response first, then catalog endpoint, then use domain name as fallback
+            // Step 1b: Get catalog item_id (required for purchase).
+            // Hostinger rejects arbitrary values — must come from availability response or catalog endpoint.
             let itemId: string | undefined = availCheck.itemId
             if (!itemId) {
                 const tld = domain.split('.').slice(1).join('.')
@@ -380,14 +385,13 @@ export const setupForSubmission = internalAction({
                 itemId = (await registrarGetCatalogItemId(tld)) ?? undefined
             }
             if (!itemId) {
-                console.log(`[DOMAINS] No item_id from catalog either, using domain name as item_id fallback`)
-                itemId = domain
+                throw new Error(`Could not resolve Hostinger catalog item_id for ${domain}. Catalog lookup returned no match — check Hostinger logs.`)
             }
             console.log(`[DOMAINS] Using item_id: ${itemId} for ${domain}`)
 
-            // Step 2: Build registrant contact from business owner info + register
-            const contact = buildContactFromSubmission(submission)
-            const reg = await registrarRegister(domain, itemId!, contact)
+            // Step 2: Register. Hostinger will use the pre-created WHOIS profile
+            // for this TLD (verified inside registrarRegister).
+            const reg = await registrarRegister(domain, itemId!)
             await ctx.runMutation(internal.domains.setRegistrarMetadata, {
                 submissionId: args.submissionId,
                 orderId: reg.orderId,
@@ -459,68 +463,35 @@ export const setupForSubmission = internalAction({
                 console.warn(`[DOMAINS] Zone ${zone.zoneId} not active after 2min, continuing anyway`)
             }
 
-            // Step 6: Attach to Cloudflare Pages
-            await addCustomDomainToPages(website.cfPagesProjectName, domain)
-            console.log(`[DOMAINS] Attached ${domain} to Pages project ${website.cfPagesProjectName}`)
+            // Step 6: Attach to Cloudflare Worker (CF auto-creates DNS + SSL)
+            await addCustomDomainToWorker(website.cfPagesProjectName, domain, zone.zoneId)
+            console.log(`[DOMAINS] Attached ${domain} to Worker ${website.cfPagesProjectName}`)
 
-            // Step 7: Wait for SSL (poll up to 10 min)
-            await ctx.runMutation(internal.domains.setDomainStatus, {
-                submissionId: args.submissionId,
-                status: 'provisioning_ssl',
-            })
-            let sslReady = false
-            for (let i = 0; i < 60; i++) {
-                try {
-                    const status = await getCustomDomainStatus(website.cfPagesProjectName, domain)
-                    if (status.status === 'active') {
-                        sslReady = true
-                        break
-                    }
-                } catch {
-                    // Continue polling
-                }
-                await new Promise((r) => setTimeout(r, 10000))
-            }
-
-            // Step 8: Update website record + mark live
+            // Step 7: Update website record + status NOW. We set customDomain
+            // immediately so the UI switches over even while SSL is provisioning —
+            // browsers will auto-redirect to HTTPS once the cert is issued.
             await ctx.runMutation(internal.domains.setCustomDomainOnWebsite, {
                 submissionId: args.submissionId,
                 customDomain: domain,
             })
             await ctx.runMutation(internal.domains.setDomainStatus, {
                 submissionId: args.submissionId,
-                status: 'live',
+                status: 'provisioning_ssl',
             })
 
-            // Notify creator (push)
-            await ctx.runMutation(internal.notifications.createAndSend, {
-                creatorId: submission.creatorId,
-                type: 'website_live',
-                title: 'Your website is now live!',
-                body: `${domain} is up and running.${sslReady ? '' : ' (SSL still provisioning)'}`,
-                data: { submissionId: args.submissionId, url: `https://${domain}` },
-            })
-
-            // Send domain-live email to business owner with renewal disclaimer
-            await ctx.scheduler.runAfter(0, internal.domains.sendDomainLiveEmailAction, {
+            // Step 8: Schedule SSL polling in a follow-up action. Convex actions
+            // cap at 10 minutes; SSL issuance can sometimes exceed that, so we chain
+            // self-rescheduling invocations via pollDomainSsl.
+            await ctx.scheduler.runAfter(30_000, internal.domains.pollDomainSsl, {
                 submissionId: args.submissionId,
+                projectName: website.cfPagesProjectName,
+                domain,
+                attempt: 0,
+                orderId: reg.orderId,
+                zoneId: zone.zoneId,
             })
 
-            // Audit log
-            await ctx.runMutation(internal.auditLogs.log, {
-                adminId: 'system:domain-setup',
-                action: 'website_deployed',
-                targetType: 'submission',
-                targetId: args.submissionId,
-                metadata: {
-                    action: 'custom_domain_live',
-                    domain,
-                    orderId: reg.orderId,
-                    zoneId: zone.zoneId,
-                },
-            })
-
-            console.log(`[DOMAINS] ✓ Setup complete for ${domain}`)
+            console.log(`[DOMAINS] ✓ Setup handoff complete for ${domain} — SSL poll scheduled`)
         } catch (error: any) {
             console.error(`[DOMAINS] Setup failed for ${domain}:`, error)
             await ctx.runMutation(internal.domains.setDomainFailed, {
@@ -555,20 +526,346 @@ export const getHostingerPaymentMethodStatus = action({
     },
 })
 
+/**
+ * Admin-only diagnostic. Verifies that the Hostinger account is actually ready to
+ * register domains: payment method ID points at a real saved method, and a WHOIS
+ * profile exists for the requested TLD. Run this whenever a domain purchase fails.
+ */
+/**
+ * Recovery action: resume the domain setup pipeline for a submission whose domain
+ * is ALREADY registered at Hostinger, skipping the registration step. Use this when
+ * a manual curl/direct registration succeeded but Convex never wrote the metadata.
+ *
+ * Args: submissionId, orderId (Hostinger), subscriptionId (Hostinger).
+ * Runs: setRegistrarMetadata → (assumes auto-renewal already disabled) → Cloudflare
+ * zone → nameservers → wait for active → Pages attach → SSL → mark live → notify.
+ */
+export const resumeAfterRegistration = internalAction({
+    args: {
+        submissionId: v.id('submissions'),
+        orderId: v.string(),
+        subscriptionId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const submission = await ctx.runQuery(internal.submissions.getByIdInternal, {
+            id: args.submissionId,
+        })
+        if (!submission) throw new Error(`Submission ${args.submissionId} not found`)
+        const domain = (submission as any).requestedDomain
+        if (!domain) throw new Error('Submission has no requestedDomain')
+
+        const website = await ctx.runQuery(internal.generatedWebsites.getBySubmissionInternal, {
+            submissionId: args.submissionId,
+        })
+        if (!website?.cfPagesProjectName) throw new Error('No Cloudflare Pages project for submission')
+
+        console.log(`[DOMAINS] Resuming post-registration setup for ${domain}`)
+
+        const expiresAt = Date.now() + 365 * 24 * 60 * 60 * 1000
+        await ctx.runMutation(internal.domains.setRegistrarMetadata, {
+            submissionId: args.submissionId,
+            orderId: args.orderId,
+            expiresAt,
+        })
+
+        await ctx.runMutation(internal.domains.setDomainStatus, {
+            submissionId: args.submissionId,
+            status: 'configuring_dns',
+        })
+        const zone = await createZone(domain)
+        await ctx.runMutation(internal.domains.setCloudflareZone, {
+            submissionId: args.submissionId,
+            zoneId: zone.zoneId,
+        })
+        console.log(`[DOMAINS] Created Cloudflare zone ${zone.zoneId} for ${domain}`)
+
+        try {
+            await updateNameservers(domain, zone.nameservers)
+            console.log(`[DOMAINS] Updated nameservers for ${domain}`)
+        } catch (nsError) {
+            console.warn(`[DOMAINS] Failed to update nameservers:`, nsError)
+        }
+
+        let zoneActive = false
+        for (let i = 0; i < 24; i++) {
+            const status = await getZoneStatus(zone.zoneId)
+            if (status === 'active') { zoneActive = true; break }
+            await new Promise((r) => setTimeout(r, 5000))
+        }
+        if (!zoneActive) console.warn(`[DOMAINS] Zone ${zone.zoneId} not active after 2min, continuing`)
+
+        await addCustomDomainToWorker(website.cfPagesProjectName, domain, zone.zoneId)
+        console.log(`[DOMAINS] Attached ${domain} to Worker ${website.cfPagesProjectName}`)
+
+        // Set customDomain immediately so the submission UI reflects the new URL,
+        // then hand off SSL polling to a self-rescheduling follow-up action.
+        await ctx.runMutation(internal.domains.setCustomDomainOnWebsite, {
+            submissionId: args.submissionId,
+            customDomain: domain,
+        })
+        await ctx.runMutation(internal.domains.setDomainStatus, {
+            submissionId: args.submissionId,
+            status: 'provisioning_ssl',
+        })
+
+        await ctx.scheduler.runAfter(30_000, internal.domains.pollDomainSsl, {
+            submissionId: args.submissionId,
+            projectName: website.cfPagesProjectName,
+            domain,
+            attempt: 0,
+            orderId: args.orderId,
+            zoneId: zone.zoneId,
+        })
+
+        console.log(`[DOMAINS] ✓ Resume handoff complete for ${domain} — SSL poll scheduled`)
+        return { ok: true, zoneId: zone.zoneId }
+    },
+})
+
+/**
+ * Self-rescheduling SSL status poll. Runs short invocations well under the 10-minute
+ * Convex action limit, then either marks the domain live or reschedules itself.
+ *
+ * One invocation = up to 5 checks × 10s = 50s of work max.
+ * Total window = MAX_ATTEMPTS × invocation delay ≈ 20 × 30s = 10 min of real time,
+ * plus a grace period on the final attempt — after which we mark live anyway
+ * (the customer can hit HTTP while HTTPS finishes in the background).
+ */
+export const pollDomainSsl = internalAction({
+    args: {
+        submissionId: v.id('submissions'),
+        projectName: v.string(),
+        domain: v.string(),
+        attempt: v.number(),
+        orderId: v.string(),
+        zoneId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const MAX_ATTEMPTS = 20
+        const POLLS_PER_INVOCATION = 5
+        const POLL_INTERVAL_MS = 10_000
+        const RESCHEDULE_DELAY_MS = 30_000
+
+        let sslReady = false
+        for (let i = 0; i < POLLS_PER_INVOCATION; i++) {
+            try {
+                const status = await getWorkerCustomDomainStatus(args.domain)
+                if (status.status === 'active') {
+                    sslReady = true
+                    break
+                }
+            } catch {
+                // Transient Cloudflare error — keep polling
+            }
+            if (i < POLLS_PER_INVOCATION - 1) {
+                await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+            }
+        }
+
+        if (!sslReady && args.attempt + 1 < MAX_ATTEMPTS) {
+            console.log(
+                `[DOMAINS] SSL not ready for ${args.domain} (attempt ${args.attempt + 1}/${MAX_ATTEMPTS}), rescheduling`
+            )
+            await ctx.scheduler.runAfter(RESCHEDULE_DELAY_MS, internal.domains.pollDomainSsl, {
+                ...args,
+                attempt: args.attempt + 1,
+            })
+            return { sslReady: false, rescheduled: true }
+        }
+
+        // Either SSL is ready, or we exhausted retries — mark live either way.
+        // If SSL still pending at this point, the site will auto-upgrade to HTTPS
+        // once Cloudflare finishes issuing the cert in the background.
+        const submission = await ctx.runQuery(internal.submissions.getByIdInternal, {
+            id: args.submissionId,
+        })
+        if (!submission) {
+            console.error(`[DOMAINS] Submission ${args.submissionId} vanished during SSL poll`)
+            return { sslReady, rescheduled: false }
+        }
+
+        await ctx.runMutation(internal.domains.setDomainStatus, {
+            submissionId: args.submissionId,
+            status: 'live',
+        })
+
+        await ctx.runMutation(internal.notifications.createAndSend, {
+            creatorId: submission.creatorId,
+            type: 'website_live',
+            title: 'Your website is now live!',
+            body: `${args.domain} is up and running.${sslReady ? '' : ' (SSL still provisioning — HTTPS will activate shortly)'}`,
+            data: { submissionId: args.submissionId, url: `https://${args.domain}` },
+        })
+
+        await ctx.scheduler.runAfter(0, internal.domains.sendDomainLiveEmailAction, {
+            submissionId: args.submissionId,
+        })
+
+        await ctx.runMutation(internal.auditLogs.log, {
+            adminId: 'system:domain-setup',
+            action: 'website_deployed',
+            targetType: 'submission',
+            targetId: args.submissionId,
+            metadata: {
+                action: 'custom_domain_live',
+                domain: args.domain,
+                orderId: args.orderId,
+                zoneId: args.zoneId,
+                sslReady,
+                totalAttempts: args.attempt + 1,
+            },
+        })
+
+        console.log(
+            `[DOMAINS] ✓ ${args.domain} marked live (sslReady: ${sslReady}, attempts: ${args.attempt + 1})`
+        )
+        return { sslReady, rescheduled: false }
+    },
+})
+
+/**
+ * Migrate a custom domain from a legacy Pages project attachment onto the
+ * current Worker deployment. Does NOT touch any generated website content —
+ * only reassigns the hostname.
+ *
+ * Steps:
+ *   1. Detach the hostname from the old Pages project (if still attached)
+ *   2. Delete the apex + www CNAME records that pointed at {project}.pages.dev
+ *   3. Attach the hostname to the Worker (CF auto-creates correct DNS + SSL)
+ *
+ * Idempotent: each step swallows "not found" errors so re-running is safe.
+ */
+export const migrateDomainToWorker = internalAction({
+    args: {
+        domain: v.string(),
+        zoneId: v.string(),
+        workerName: v.string(),
+        oldPagesProjectName: v.optional(v.string()),
+    },
+    handler: async (_ctx, args) => {
+        const { domain, zoneId, workerName, oldPagesProjectName } = args
+        const report: any = { domain, steps: {} }
+
+        // Step 1: detach from old Pages project (if any)
+        if (oldPagesProjectName) {
+            try {
+                await removeCustomDomainFromPages(oldPagesProjectName, domain)
+                report.steps.detachedFromPages = true
+                console.log(`[DOMAINS] Detached ${domain} from Pages project ${oldPagesProjectName}`)
+            } catch (e: any) {
+                report.steps.detachedFromPages = `skipped: ${e.message || e}`
+                console.log(`[DOMAINS] Pages detach skipped (likely already detached): ${e.message}`)
+            }
+        }
+
+        // Step 2: delete the apex + www CNAMEs we previously created
+        try {
+            const records = await listDnsRecords(zoneId)
+            const toDelete = records.filter(
+                (r: any) =>
+                    r.type === 'CNAME' &&
+                    (r.name === domain || r.name === `www.${domain}`)
+            )
+            for (const r of toDelete) {
+                await deleteDnsRecord(zoneId, r.id)
+                console.log(`[DOMAINS] Deleted stale CNAME ${r.name} (id ${r.id})`)
+            }
+            report.steps.deletedCnames = toDelete.length
+        } catch (e: any) {
+            report.steps.deletedCnames = `error: ${e.message || e}`
+        }
+
+        // Step 3: attach to the Worker (CF auto-handles DNS + SSL)
+        try {
+            const result = await addCustomDomainToWorker(workerName, domain, zoneId)
+            report.steps.attachedToWorker = { id: result.id, service: result.service }
+            console.log(`[DOMAINS] Attached ${domain} to Worker ${workerName} (id ${result.id})`)
+        } catch (e: any) {
+            report.steps.attachedToWorker = `error: ${e.message || e}`
+            throw new Error(`Worker attach failed: ${e.message || e}`)
+        }
+
+        console.log('[DOMAINS] migrateDomainToWorker report:', JSON.stringify(report, null, 2))
+        return report
+    },
+})
+
+export const diagnoseHostingerSetup = internalAction({
+    args: { tld: v.optional(v.string()) },
+    handler: async (_ctx, args) => {
+        const tld = (args.tld || 'com').replace(/^\./, '').toLowerCase()
+        const report: any = { tld, checks: {} }
+
+        try {
+            const methods = await registrarListPaymentMethods()
+            const envId = process.env.HOSTINGER_PAYMENT_METHOD_ID || ''
+            const match = methods.find(
+                (m: any) => String(m.id ?? m.payment_method_id ?? '') === envId
+            )
+            report.checks.paymentMethods = {
+                count: methods.length,
+                envId: envId || '(not set)',
+                envIdMatchesSavedMethod: !!match,
+                savedMethods: methods.map((m: any) => ({
+                    id: m.id ?? m.payment_method_id,
+                    brand: m.brand ?? m.card_brand ?? m.type ?? 'UNKNOWN',
+                    last4: m.last_four ?? m.last4 ?? m.card_last_four ?? '????',
+                    isDefault: m.is_default ?? m.default ?? false,
+                })),
+            }
+        } catch (e: any) {
+            report.checks.paymentMethods = { error: e.message || String(e) }
+        }
+
+        try {
+            const profiles = await registrarListWhoisProfiles(tld)
+            report.checks.whoisProfiles = {
+                tld,
+                count: profiles.length,
+                profiles: profiles.map((p: any) => ({
+                    id: p.id ?? p.whois_id,
+                    tld: p.tld,
+                    entityType: p.entity_type,
+                    country: p.country,
+                })),
+                ready: profiles.length > 0,
+            }
+        } catch (e: any) {
+            report.checks.whoisProfiles = { tld, error: e.message || String(e) }
+        }
+
+        report.ready =
+            report.checks.paymentMethods?.envIdMatchesSavedMethod === true &&
+            report.checks.whoisProfiles?.ready === true
+
+        console.log('[DOMAINS] diagnoseHostingerSetup report:', JSON.stringify(report, null, 2))
+        return report
+    },
+})
+
 // ==================== EMAIL: DOMAIN LIVE NOTIFICATION ====================
 
 /**
- * Internal action that calls the Next.js endpoint to send the domain-live email
- * (with renewal disclaimer) to the business owner.
+ * Internal action that calls the Next.js endpoint to send the "your website is
+ * complete" email to the business owner. The endpoint branches on whether the
+ * submission has a custom domain, so this single call works for both flows.
+ *
+ * Requires NEXT_PUBLIC_APP_URL (or SITE_URL) to be set in Convex env vars to the
+ * production Next.js host. The internal shared secret authorizes the call.
  */
 export const sendDomainLiveEmailAction = internalAction({
     args: { submissionId: v.id('submissions') },
-    handler: async (ctx, args) => {
-        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.SITE_URL || 'https://negosyo-digital.vercel.app'
+    handler: async (_ctx, args) => {
+        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.SITE_URL
         const internalSecret = process.env.INTERNAL_API_SECRET || ''
 
+        if (!baseUrl) {
+            console.error('[DOMAINS] NEXT_PUBLIC_APP_URL / SITE_URL not set — cannot send completed-website email')
+            return
+        }
+
         try {
-            const response = await fetch(`${baseUrl}/api/internal/send-domain-live-email`, {
+            const response = await fetch(`${baseUrl}/api/send-completed-website-email`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -578,10 +875,12 @@ export const sendDomainLiveEmailAction = internalAction({
             })
             if (!response.ok) {
                 const text = await response.text()
-                console.error(`[DOMAINS] Failed to send domain-live email: ${response.status} ${text}`)
+                console.error(`[DOMAINS] Failed to send completed-website email: ${response.status} ${text.slice(0, 200)}`)
+            } else {
+                console.log(`[DOMAINS] Sent completed-website email for submission ${args.submissionId}`)
             }
         } catch (error) {
-            console.error('[DOMAINS] Error sending domain-live email:', error)
+            console.error('[DOMAINS] Error sending completed-website email:', error)
         }
     },
 })

--- a/convex/lib/cloudflare.ts
+++ b/convex/lib/cloudflare.ts
@@ -82,49 +82,81 @@ export async function isDomainOwnedByUs(domain: string): Promise<{ owned: boolea
     return { owned: false }
 }
 
-// ==================== PAGES CUSTOM DOMAINS ====================
+// ==================== WORKERS CUSTOM DOMAINS ====================
 
 /**
- * Attach a custom domain to a Cloudflare Pages project.
- * Cloudflare auto-creates the DNS records pointing to the Pages project.
+ * Attach a custom domain (hostname) to a Cloudflare Worker.
+ *
+ * Spec: PUT /accounts/{account_id}/workers/domains
+ * Body: { hostname, service, zone_id, environment }
+ *
+ * Cloudflare auto-creates DNS records and issues SSL certificates on attach —
+ * no manual CNAME creation is required (unlike Pages). The zone must already
+ * exist in the same Cloudflare account.
+ *
+ * Idempotent: re-attaching the same hostname to the same service is a no-op.
  */
-export async function addCustomDomainToPages(
-    projectName: string,
-    domain: string
-): Promise<{ id: string; status: string }> {
+export async function addCustomDomainToWorker(
+    workerName: string,
+    hostname: string,
+    zoneId: string,
+    environment: string = 'production'
+): Promise<{ id: string; hostname: string; service: string }> {
     const { accountId } = getCreds()
-    const result = await cfRequest(
-        `/accounts/${accountId}/pages/projects/${projectName}/domains`,
-        {
-            method: 'POST',
-            body: JSON.stringify({ name: domain }),
-        }
-    )
+    const result = await cfRequest(`/accounts/${accountId}/workers/domains`, {
+        method: 'PUT',
+        body: JSON.stringify({
+            hostname,
+            service: workerName,
+            zone_id: zoneId,
+            environment,
+        }),
+    })
     return {
-        id: result.id || domain,
-        status: result.status || 'pending',
+        id: result.id || hostname,
+        hostname: result.hostname || hostname,
+        service: result.service || workerName,
     }
 }
 
 /**
- * Get the status of a custom domain on a Pages project (includes SSL cert status).
+ * Get the status of a custom domain attached to a Worker (SSL cert provisioning
+ * state is implicit — once the record exists and zone is active, CF issues SSL).
+ *
+ * Spec: GET /accounts/{account_id}/workers/domains?hostname=...
  */
-export async function getCustomDomainStatus(
-    projectName: string,
-    domain: string
-): Promise<{ status: string; certificateStatus: string }> {
+export async function getWorkerCustomDomainStatus(
+    hostname: string
+): Promise<{ status: string; id?: string }> {
     const { accountId } = getCreds()
     const result = await cfRequest(
-        `/accounts/${accountId}/pages/projects/${projectName}/domains/${domain}`
+        `/accounts/${accountId}/workers/domains?hostname=${encodeURIComponent(hostname)}`
     )
+    const items = Array.isArray(result) ? result : []
+    const match = items.find((d: any) => d?.hostname === hostname) || items[0]
+    if (!match) return { status: 'pending' }
     return {
-        status: result.status || 'pending',
-        certificateStatus: result.certificate_authority || result.verification_data?.status || 'pending',
+        status: match.cert_id ? 'active' : 'pending',
+        id: match.id,
     }
 }
 
 /**
- * Remove a custom domain from a Pages project (cleanup on failure/cancellation).
+ * Remove a custom domain attachment from a Worker. Used for cleanup/migration.
+ */
+export async function removeCustomDomainFromWorker(domainId: string): Promise<void> {
+    const { accountId } = getCreds()
+    await cfRequest(`/accounts/${accountId}/workers/domains/${domainId}`, {
+        method: 'DELETE',
+    })
+}
+
+// ==================== PAGES CUSTOM DOMAINS (cleanup only) ====================
+
+/**
+ * Remove a custom domain from a Pages project. Kept for cleanup/migration when
+ * a hostname was previously attached to a legacy Pages project and needs to be
+ * moved to a Worker. New purchases should use addCustomDomainToWorker.
  */
 export async function removeCustomDomainFromPages(
     projectName: string,
@@ -135,4 +167,15 @@ export async function removeCustomDomainFromPages(
         `/accounts/${accountId}/pages/projects/${projectName}/domains/${domain}`,
         { method: 'DELETE' }
     )
+}
+
+// ==================== DNS RECORD UTILITIES ====================
+
+export async function listDnsRecords(zoneId: string): Promise<any[]> {
+    const result = await cfRequest(`/zones/${zoneId}/dns_records?per_page=100`)
+    return Array.isArray(result) ? result : []
+}
+
+export async function deleteDnsRecord(zoneId: string, recordId: string): Promise<void> {
+    await cfRequest(`/zones/${zoneId}/dns_records/${recordId}`, { method: 'DELETE' })
 }

--- a/convex/lib/hostinger.ts
+++ b/convex/lib/hostinger.ts
@@ -50,6 +50,16 @@ function getPaymentMethodId(): number {
     return parsed
 }
 
+function getWhoisProfileId(): number {
+    const id = process.env.HOSTINGER_WHOIS_PROFILE_ID
+    if (!id) {
+        throw new Error('HOSTINGER_WHOIS_PROFILE_ID env var must be set (WHOIS profile ID from GET /api/domains/v1/whois)')
+    }
+    const parsed = parseInt(id, 10)
+    if (isNaN(parsed)) throw new Error('HOSTINGER_WHOIS_PROFILE_ID must be a numeric ID')
+    return parsed
+}
+
 async function hostingerRequest(path: string, options: RequestInit = {}): Promise<any> {
     const token = getHostingerToken()
     const response = await fetch(`${BASE_URL}${path}`, {
@@ -256,27 +266,63 @@ export async function suggestAlternatives(
 
 /**
  * Get the catalog item_id for a domain TLD.
- * The item_id is required by the purchase endpoint.
- * Spec: GET /api/billing/v1/catalog (filter by category=domain, name matches TLD)
+ * Spec (per Hostinger API MCP server docs):
+ *   GET /api/billing/v1/catalog?category=DOMAIN&name=.COM*
+ *   Category is uppercase, name uses leading-dot wildcard (e.g. ".COM*").
+ *
+ * Each catalog item has a `prices` array with one entry per billing period
+ * (1y, 2y, 3y, etc.). The PURCHASE endpoint expects the PRICE id, not the
+ * catalog item id. We pick the shortest-period price (year 1 only — platform
+ * does not pay for renewals).
  */
 export async function getCatalogItemId(tld: string): Promise<string | null> {
     try {
-        const data = await hostingerRequest(`/billing/v1/catalog?category=domain`, { method: 'GET' })
+        const tldUpper = tld.toUpperCase()
+        const url = `/billing/v1/catalog?category=DOMAIN&name=.${encodeURIComponent(tldUpper)}*`
+        const data = await hostingerRequest(url, { method: 'GET' })
         const items = Array.isArray(data) ? data : (data?.data || data?.items || [])
 
-        // Find the item matching this TLD
-        const match = items.find((item: any) => {
-            const name = (item.name || item.title || item.slug || '').toLowerCase()
-            return name.includes(`.${tld}`) || name === tld || name === `.${tld}`
-        })
-
-        if (match) {
-            return String(match.id || match.item_id || '')
+        console.log(`[HOSTINGER] Catalog response for .${tld}: ${items.length} items`)
+        if (items.length > 0) {
+            // Log first item shape so we can see structure if matching fails
+            console.log(`[HOSTINGER] First catalog item:`, JSON.stringify(items[0]).slice(0, 800))
         }
 
-        // If catalog search fails, try using the TLD directly as the item_id
-        // (some registrar APIs accept the TLD name as the item identifier)
-        console.warn(`[HOSTINGER] No catalog item found for .${tld}, will try domain name as item_id`)
+        // Find the item whose name exactly matches ".{tld}" (case-insensitive)
+        const match = items.find((item: any) => {
+            const name = String(item.name || item.title || item.slug || '').toLowerCase()
+            return name === `.${tld}` || name === tld
+        }) || items[0] // fall back to first result if no exact match (wildcard already filtered)
+
+        if (!match) {
+            console.warn(`[HOSTINGER] No catalog item found for .${tld}`)
+            return null
+        }
+
+        // Pick the cheapest / shortest-period price from the prices array.
+        // Hostinger price objects typically have: { id, period, period_unit, price, currency, ... }
+        const prices = Array.isArray(match.prices) ? match.prices : []
+        if (prices.length > 0) {
+            const sorted = [...prices].sort((a: any, b: any) => {
+                const pa = Number(a.period ?? a.duration ?? 999)
+                const pb = Number(b.period ?? b.duration ?? 999)
+                return pa - pb
+            })
+            const chosen = sorted[0]
+            const priceId = String(chosen.id || chosen.item_id || chosen.price_id || '')
+            if (priceId) {
+                console.log(`[HOSTINGER] Selected price id ${priceId} (period: ${chosen.period}) for .${tld}`)
+                return priceId
+            }
+        }
+
+        // No prices array — fall back to the catalog item's own id
+        const itemId = String(match.id || match.item_id || '')
+        if (itemId) {
+            console.log(`[HOSTINGER] No prices array, using catalog item id ${itemId} for .${tld}`)
+            return itemId
+        }
+
         return null
     } catch (error) {
         console.warn(`[HOSTINGER] Catalog lookup failed for .${tld}:`, error)
@@ -293,7 +339,10 @@ export async function getCatalogItemId(tld: string): Promise<string | null> {
  * Register a domain for 1 year using a saved Hostinger payment method.
  * Requires the `itemId` from a prior availability check (returned in AvailabilityResult.itemId).
  *
- * The contact info is used as registrant + admin + tech contact (per ICANN requirements).
+ * Per Hostinger docs: "If no WHOIS information is provided, default contact information
+ * for that TLD will be used. Before making request, ensure WHOIS information for desired
+ * TLD exists in your account." We therefore do NOT send inline `domain_contacts` and rely
+ * on a pre-created WHOIS profile. Verify one exists by calling `listWhoisProfiles(tld)`.
  *
  * IMPORTANT: After successful registration, the caller MUST immediately call:
  *   1. findSubscriptionForDomain(domain) → get subscriptionId
@@ -301,8 +350,7 @@ export async function getCatalogItemId(tld: string): Promise<string | null> {
  */
 export async function registerDomain(
     domain: string,
-    itemId: string,
-    contact: RegistrantContact
+    itemId: string
 ): Promise<RegistrationResult> {
     const normalized = domain.trim().toLowerCase()
     const tld = normalized.split('.').slice(1).join('.')
@@ -310,39 +358,33 @@ export async function registerDomain(
     if (BLOCKED_TLDS.includes(tld)) {
         throw new Error(`Cannot register .${tld} — TLD is blocked from standard tier`)
     }
-
-    // item_id is required by Hostinger — if not provided, try the domain name itself
-    const effectiveItemId = itemId || normalized
+    if (!itemId) {
+        throw new Error('item_id is required for domain registration')
+    }
 
     const paymentMethodId = getPaymentMethodId()
+    const whoisId = getWhoisProfileId()
 
-    // Hostinger expects a `domain_contacts` object. Field names follow common WHOIS conventions.
-    // The exact schema isn't fully documented in the OpenAPI public spec — we send standard fields.
-    const contactObject = {
-        first_name: contact.firstName,
-        last_name: contact.lastName,
-        email: contact.email,
-        phone: contact.phone,
-        address1: contact.address,
-        city: contact.city,
-        state: contact.state,
-        zip: contact.postalCode,
-        country: contact.country,
+    // Per Hostinger OpenAPI spec (Domains.V1.Portfolio.PurchaseRequest), domain_contacts
+    // takes WHOIS record IDs (integers), NOT inline contact details:
+    //   { owner_id, admin_id, billing_id, tech_id }
+    // We reuse the same profile id for all four roles.
+    const requestBody = {
+        domain: normalized,
+        item_id: itemId,
+        payment_method_id: paymentMethodId,
+        domain_contacts: {
+            owner_id: whoisId,
+            admin_id: whoisId,
+            billing_id: whoisId,
+            tech_id: whoisId,
+        },
     }
+    console.log(`[HOSTINGER] POST /domains/v1/portfolio body:`, JSON.stringify({ ...requestBody, payment_method_id: '***' }))
 
     const data = await hostingerRequest('/domains/v1/portfolio', {
         method: 'POST',
-        body: JSON.stringify({
-            domain: normalized,
-            item_id: effectiveItemId,
-            payment_method_id: paymentMethodId,
-            domain_contacts: {
-                owner: contactObject,
-                admin: contactObject,
-                billing: contactObject,
-                tech: contactObject,
-            },
-        }),
+        body: JSON.stringify(requestBody),
     })
 
     // Response is an Order resource. Field names per Billing.V1.Order.OrderResource spec.
@@ -436,6 +478,32 @@ export async function getDomainInfo(domain: string): Promise<{
         expirationDate: data?.expires_at ? new Date(data.expires_at).getTime() : 0,
         nameservers: data?.nameservers || [],
     }
+}
+
+// ==================== DIAGNOSTICS ====================
+
+/**
+ * List all saved payment methods on the Hostinger account.
+ * Used for diagnostics — verify HOSTINGER_PAYMENT_METHOD_ID matches a real method.
+ * Spec: GET /api/billing/v1/payment-methods
+ */
+export async function listPaymentMethods(): Promise<any[]> {
+    const data = await hostingerRequest('/billing/v1/payment-methods', { method: 'GET' })
+    return Array.isArray(data) ? data : (data?.data || data?.payment_methods || [])
+}
+
+/**
+ * List WHOIS contact profiles in the Hostinger account.
+ * Spec: GET /api/domains/v1/whois (optional ?tld= filter, no leading dot)
+ *
+ * Hostinger's purchase endpoint uses these profiles as the default registrant
+ * contact when `domain_contacts` is not provided in the request body.
+ * At least one profile for the target TLD must exist before purchase.
+ */
+export async function listWhoisProfiles(tld?: string): Promise<any[]> {
+    const qs = tld ? `?tld=${encodeURIComponent(tld.replace(/^\./, '').toLowerCase())}` : ''
+    const data = await hostingerRequest(`/domains/v1/whois${qs}`, { method: 'GET' })
+    return Array.isArray(data) ? data : (data?.data || data?.whois || [])
 }
 
 // ==================== PAYMENT METHOD STATUS ====================


### PR DESCRIPTION
## Summary
Resolved a stack of bugs preventing the custom domain pipeline from
completing end-to-end, plus added admin tooling to manually re-send the
"website live" email to business owners.

## Hostinger registration
- Send `domain_contacts` as WHOIS record IDs (`{owner_id, admin_id,
  billing_id, tech_id}`) per the OpenAPI spec, instead of inline contact
  objects which Hostinger silently rejects.
- New `HOSTINGER_WHOIS_PROFILE_ID` env var for the registrant profile.
- Catalog lookup uses correct query format (`category=DOMAIN&name=.TLD*`)
  and selects the 1-year price ID from the `prices` array.
- Removed the bogus "use domain name as item_id" fallback that was
  masking real errors.
- Made `province`/`postalCode` optional on submissions with sensible
  fallbacks (Metro Manila / 1000) for ICANN compliance.
- New `diagnoseHostingerSetup` internal action verifies payment method
  and WHOIS profile are configured correctly before purchase.

## Cloudflare deployment target
- Generated sites are deployed as Cloudflare Workers, not Pages — the
  pipeline was attaching custom domains to a phantom legacy Pages project
  with the same name, causing the wrong content to serve on the domain.
- Replaced `addCustomDomainToPages` with `addCustomDomainToWorker`
  (`PUT /accounts/{id}/workers/domains`). Cloudflare auto-creates DNS
  records and issues SSL on attach, so manual CNAME creation is no
  longer needed.
- Added `getWorkerCustomDomainStatus`, `removeCustomDomainFromWorker`,
  `listDnsRecords`, `deleteDnsRecord` helpers.
- New `migrateDomainToWorker` recovery action: detaches a hostname from
  a legacy Pages project, deletes stale CNAMEs, and reattaches it to the
  Worker without touching any generated content.

## Convex action timeout
- Convex caps actions at 10 minutes; the inline SSL polling loop was
  blowing the budget and killing the pipeline before the website record
  could be updated, leaving submissions stuck on workers.dev.
- Extracted SSL polling into `pollDomainSsl`, a self-rescheduling action
  (5 polls × 10s per invocation, up to 20 attempts ≈ 10 min real time).
- Main pipeline now sets `customDomain` on the website record
  immediately after Pages attach, so the admin UI URL switches over
  even while SSL is still provisioning.
- New `resumeAfterRegistration` recovery action skips the registration
  step when a domain is already registered at Hostinger but Convex
  state is stale.

## Completed-website email
- New unified `POST /api/send-completed-website-email` endpoint that
  branches on `requestedDomain` to send either the domain-live template
  (with year-1-paid renewal disclaimer) or the standard payment
  confirmation template (workers.dev URL).
- Auth: admin Clerk session OR internal shared secret, so the same
  endpoint serves both the admin UI button and the automated pipeline.
- `sendDomainLiveEmailAction` now points at the new endpoint and fails
  loudly if `NEXT_PUBLIC_APP_URL` is unset (was previously falling back
  to a wrong host and silently 404-ing).

## Admin UI
- Emails Sent page now shows a third preview card for the website-live
  email (label adapts based on whether a custom domain is attached).
- Every email card has a "Send Email" button that re-sends the
  corresponding template to the business owner, with inline loading and
  success/error feedback.
- Preview endpoint supports `type=completed_website` so the iframe
  preview always matches what the send button will actually send.

## New env vars to set in Convex
- `HOSTINGER_WHOIS_PROFILE_ID` — registrant WHOIS profile ID
- `NEXT_PUBLIC_APP_URL` — production Next.js host (must be set for the
  pipeline's email step to work)

## Recovery actions added (admin-only, internal)
- `domains:diagnoseHostingerSetup` — pre-flight check for Hostinger env
- `domains:resumeAfterRegistration` — resume pipeline after manual or
  out-of-band Hostinger registration
- `domains:migrateDomainToWorker` — move hostname from legacy Pages
  attachment to the current Worker
- `domains:pollDomainSsl` — manually kick the SSL poller if it stalls
