### PR TITLE
Add: New Email Templates and Internal Service Action

### DIFF
--- a/app/admin/submissions/[id]/emails/page.tsx
+++ b/app/admin/submissions/[id]/emails/page.tsx
@@ -15,6 +15,8 @@ interface EmailPreview {
     html: string
     /** API endpoint to POST { submissionId } to in order to (re)send this email */
     sendEndpoint: string
+    /** Optional `type` body field forwarded to the send endpoint */
+    sendType?: string
 }
 
 export default function EmailsSentPage() {
@@ -53,6 +55,7 @@ export default function EmailsSentPage() {
                 label: string
                 description: string
                 sendEndpoint: string
+                sendType?: string
             }[] = []
 
             if (['pending_payment', 'paid', 'completed'].includes(submissionData.status)) {
@@ -91,6 +94,26 @@ export default function EmailsSentPage() {
                 })
             }
 
+            // Custom-domain-only emails: setup in progress + 30-day renewal reminder
+            if (hasCustomDomain && ['paid', 'completed'].includes(submissionData.status)) {
+                emailsToFetch.push({
+                    type: 'domain_setup_progress',
+                    label: 'Domain Setup In Progress Email',
+                    description:
+                        'Auto-sent when SSL provisioning starts. Tells the business owner the domain is registered and DNS is pointed, SSL cert is being issued by Cloudflare (2–10 min).',
+                    sendEndpoint: '/api/send-completed-website-email',
+                    sendType: 'domain_setup_progress',
+                })
+                emailsToFetch.push({
+                    type: 'domain_renewal_reminder',
+                    label: 'Domain Renewal Reminder Email',
+                    description:
+                        'Auto-scheduled to send 30 days before the domain expires. Reminds the business owner that year 2 onwards is their responsibility.',
+                    sendEndpoint: '/api/send-completed-website-email',
+                    sendType: 'domain_renewal_reminder',
+                })
+            }
+
             if (emailsToFetch.length === 0) {
                 setEmails([])
                 setLoading(false)
@@ -99,13 +122,13 @@ export default function EmailsSentPage() {
 
             try {
                 const results = await Promise.all(
-                    emailsToFetch.map(async ({ type, label, description, sendEndpoint }) => {
+                    emailsToFetch.map(async ({ type, label, description, sendEndpoint, sendType }) => {
                         const response = await fetch(
                             `/api/preview-email?submissionId=${submissionData._id}&type=${type}`
                         )
                         if (!response.ok) throw new Error(`Failed to load ${label}`)
                         const html = await response.text()
-                        return { type, label, description, html, sendEndpoint }
+                        return { type, label, description, html, sendEndpoint, sendType }
                     })
                 )
                 setEmails(results)
@@ -127,7 +150,10 @@ export default function EmailsSentPage() {
             const response = await fetch(email.sendEndpoint, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ submissionId: submissionData._id }),
+                body: JSON.stringify({
+                    submissionId: submissionData._id,
+                    ...(email.sendType ? { type: email.sendType } : {}),
+                }),
             })
             const json = await response.json().catch(() => ({}))
             if (!response.ok) {

--- a/app/api/preview-email/route.ts
+++ b/app/api/preview-email/route.ts
@@ -50,20 +50,62 @@ export async function GET(request: NextRequest) {
 
         // Dynamically import the template functions to avoid bundling nodemailer on client
         const {
-            getApprovalEmailHtml,
+            getPaymentLinkEmailHtml,
             getPaymentConfirmationEmailHtml,
             getDomainLiveEmailHtml,
+            getDomainSetupInProgressEmailHtml,
+            getDomainRenewalReminderEmailHtml,
         } = await import('@/lib/email/templates')
 
         let html: string
 
         if (type === 'approval') {
-            html = getApprovalEmailHtml({
+            // Render the SAME template that send-website-email actually sends (payment-link
+            // email). Fetch the existing payment token if any so the preview mirrors the
+            // real email; otherwise show placeholder values.
+            const submissionAny = submission as any
+            const customDomain = submissionAny.requestedDomain as string | undefined
+
+            let referenceCode = submission.paymentReference || 'ND-XXXX-XXXX'
+            let paymentLink = '#'
+            try {
+                const token = await fetchQuery(api.paymentTokens.getBySubmissionId, {
+                    submissionId: submissionId as Id<'submissions'>,
+                })
+                if (token) {
+                    referenceCode = token.referenceCode
+                    const { getPaymentConfig } = await import('@/lib/payment/config')
+                    paymentLink = getPaymentConfig().getPaymentLink(token.token)
+                }
+            } catch {
+                // Preview-only — placeholder is fine if token lookup fails
+            }
+
+            html = getPaymentLinkEmailHtml({
                 businessName: submission.businessName,
                 businessOwnerName: submission.ownerName,
-                websiteUrl: publishedUrl || '#',
                 amount: submission.amount ?? 0,
-                submissionId: submission._id,
+                paymentLink,
+                referenceCode,
+                platformEmail: process.env.WISE_EMAIL,
+                customDomain,
+            })
+        } else if (type === 'domain_setup_progress') {
+            const submissionAny = submission as any
+            const customDomain = (submissionAny.requestedDomain as string | undefined) || 'your-domain.com'
+            html = getDomainSetupInProgressEmailHtml({
+                businessName: submission.businessName,
+                businessOwnerName: submission.ownerName,
+                customDomain,
+            })
+        } else if (type === 'domain_renewal_reminder') {
+            const submissionAny = submission as any
+            const customDomain = (submissionAny.requestedDomain as string | undefined) || 'your-domain.com'
+            html = getDomainRenewalReminderEmailHtml({
+                businessName: submission.businessName,
+                businessOwnerName: submission.ownerName,
+                customDomain,
+                expiresAt: submissionAny.domainExpiresAt || Date.now() + 365 * 24 * 60 * 60 * 1000,
             })
         } else if (type === 'completed_website') {
             // Branches on requestedDomain — same logic as send-completed-website-email

--- a/app/api/send-completed-website-email/route.ts
+++ b/app/api/send-completed-website-email/route.ts
@@ -6,6 +6,8 @@ import { Id } from '@/convex/_generated/dataModel'
 import {
     sendDomainLiveEmail,
     sendPaymentConfirmationEmail,
+    sendDomainSetupInProgressEmail,
+    sendDomainRenewalReminderEmail,
 } from '@/lib/email/service'
 
 /**
@@ -44,7 +46,7 @@ export async function POST(request: NextRequest) {
         }
 
         const body = await request.json()
-        const { submissionId } = body
+        const { submissionId, type } = body as { submissionId?: string; type?: string }
         if (!submissionId) {
             return NextResponse.json({ error: 'submissionId required' }, { status: 400 })
         }
@@ -62,6 +64,36 @@ export async function POST(request: NextRequest) {
         const submissionAny = submission as any
         const customDomain = submissionAny.requestedDomain as string | undefined
 
+        // Explicit type → setup-in-progress email
+        if (type === 'domain_setup_progress') {
+            if (!customDomain) {
+                return NextResponse.json({ error: 'No custom domain on submission' }, { status: 400 })
+            }
+            await sendDomainSetupInProgressEmail({
+                businessName: submission.businessName,
+                businessOwnerName: submission.ownerName,
+                businessOwnerEmail: submission.ownerEmail,
+                customDomain,
+            })
+            return NextResponse.json({ success: true, type: 'domain_setup_progress', sentTo: submission.ownerEmail })
+        }
+
+        // Explicit type → 30-day renewal reminder
+        if (type === 'domain_renewal_reminder') {
+            if (!customDomain) {
+                return NextResponse.json({ error: 'No custom domain on submission' }, { status: 400 })
+            }
+            await sendDomainRenewalReminderEmail({
+                businessName: submission.businessName,
+                businessOwnerName: submission.ownerName,
+                businessOwnerEmail: submission.ownerEmail,
+                customDomain,
+                expiresAt: submissionAny.domainExpiresAt || Date.now() + 365 * 24 * 60 * 60 * 1000,
+            })
+            return NextResponse.json({ success: true, type: 'domain_renewal_reminder', sentTo: submission.ownerEmail })
+        }
+
+        // Default behavior: completed website email (branches on requestedDomain)
         if (customDomain) {
             await sendDomainLiveEmail({
                 businessName: submission.businessName,

--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -397,6 +397,18 @@ export const setupForSubmission = internalAction({
                 orderId: reg.orderId,
                 expiresAt: reg.expiresAt,
             })
+
+            // Schedule the 30-day-before-expiry renewal reminder email.
+            // Convex schedulers persist long-future jobs reliably.
+            const reminderAt = reg.expiresAt - 30 * 24 * 60 * 60 * 1000
+            if (reminderAt > Date.now()) {
+                await ctx.scheduler.runAt(
+                    reminderAt,
+                    internal.domains.sendDomainRenewalReminderEmailAction,
+                    { submissionId: args.submissionId }
+                )
+                console.log(`[DOMAINS] Scheduled renewal reminder for ${domain} at ${new Date(reminderAt).toISOString()}`)
+            }
             console.log(`[DOMAINS] Registered ${domain} with Hostinger, orderId: ${reg.orderId}`)
 
             // Step 2b: CRITICAL — find the subscription created by the purchase, then disable auto-renewal
@@ -489,6 +501,12 @@ export const setupForSubmission = internalAction({
                 attempt: 0,
                 orderId: reg.orderId,
                 zoneId: zone.zoneId,
+            })
+
+            // Step 8b: Send the "your domain is being set up, SSL is provisioning"
+            // email to the business owner so they know what to expect.
+            await ctx.scheduler.runAfter(0, internal.domains.sendDomainSetupInProgressEmailAction, {
+                submissionId: args.submissionId,
             })
 
             console.log(`[DOMAINS] ✓ Setup handoff complete for ${domain} — SSL poll scheduled`)
@@ -615,6 +633,11 @@ export const resumeAfterRegistration = internalAction({
             attempt: 0,
             orderId: args.orderId,
             zoneId: zone.zoneId,
+        })
+
+        // Send the setup-in-progress email so the owner knows what's happening.
+        await ctx.scheduler.runAfter(0, internal.domains.sendDomainSetupInProgressEmailAction, {
+            submissionId: args.submissionId,
         })
 
         console.log(`[DOMAINS] ✓ Resume handoff complete for ${domain} — SSL poll scheduled`)
@@ -846,41 +869,66 @@ export const diagnoseHostingerSetup = internalAction({
 // ==================== EMAIL: DOMAIN LIVE NOTIFICATION ====================
 
 /**
- * Internal action that calls the Next.js endpoint to send the "your website is
- * complete" email to the business owner. The endpoint branches on whether the
- * submission has a custom domain, so this single call works for both flows.
- *
- * Requires NEXT_PUBLIC_APP_URL (or SITE_URL) to be set in Convex env vars to the
- * production Next.js host. The internal shared secret authorizes the call.
+ * Internal helper: POST to the unified send endpoint with an optional type.
+ * Used by all three domain-related email actions below.
+ */
+async function postSendEmail(submissionId: string, type?: string): Promise<void> {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.SITE_URL
+    const internalSecret = process.env.INTERNAL_API_SECRET || ''
+    if (!baseUrl) {
+        console.error(`[DOMAINS] NEXT_PUBLIC_APP_URL / SITE_URL not set — cannot send ${type || 'completed'} email`)
+        return
+    }
+    try {
+        const response = await fetch(`${baseUrl}/api/send-completed-website-email`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Internal-Secret': internalSecret,
+            },
+            body: JSON.stringify({ submissionId, ...(type ? { type } : {}) }),
+        })
+        if (!response.ok) {
+            const text = await response.text()
+            console.error(`[DOMAINS] Failed to send ${type || 'completed'} email: ${response.status} ${text.slice(0, 200)}`)
+        } else {
+            console.log(`[DOMAINS] Sent ${type || 'completed'} email for submission ${submissionId}`)
+        }
+    } catch (error) {
+        console.error(`[DOMAINS] Error sending ${type || 'completed'} email:`, error)
+    }
+}
+
+/**
+ * Sends the "your website is complete" email to the business owner. The endpoint
+ * branches on whether the submission has a custom domain, so this single call
+ * works for both flows.
  */
 export const sendDomainLiveEmailAction = internalAction({
     args: { submissionId: v.id('submissions') },
     handler: async (_ctx, args) => {
-        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.SITE_URL
-        const internalSecret = process.env.INTERNAL_API_SECRET || ''
+        await postSendEmail(args.submissionId)
+    },
+})
 
-        if (!baseUrl) {
-            console.error('[DOMAINS] NEXT_PUBLIC_APP_URL / SITE_URL not set — cannot send completed-website email')
-            return
-        }
+/**
+ * Sends the "we're setting up your domain, SSL is provisioning" email.
+ * Triggered when the SSL polling phase begins.
+ */
+export const sendDomainSetupInProgressEmailAction = internalAction({
+    args: { submissionId: v.id('submissions') },
+    handler: async (_ctx, args) => {
+        await postSendEmail(args.submissionId, 'domain_setup_progress')
+    },
+})
 
-        try {
-            const response = await fetch(`${baseUrl}/api/send-completed-website-email`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Internal-Secret': internalSecret,
-                },
-                body: JSON.stringify({ submissionId: args.submissionId }),
-            })
-            if (!response.ok) {
-                const text = await response.text()
-                console.error(`[DOMAINS] Failed to send completed-website email: ${response.status} ${text.slice(0, 200)}`)
-            } else {
-                console.log(`[DOMAINS] Sent completed-website email for submission ${args.submissionId}`)
-            }
-        } catch (error) {
-            console.error('[DOMAINS] Error sending completed-website email:', error)
-        }
+/**
+ * Sends the 30-day-before-expiry domain renewal reminder. Scheduled via runAt
+ * immediately after a successful registration (see setupForSubmission step 4b).
+ */
+export const sendDomainRenewalReminderEmailAction = internalAction({
+    args: { submissionId: v.id('submissions') },
+    handler: async (_ctx, args) => {
+        await postSendEmail(args.submissionId, 'domain_renewal_reminder')
     },
 })

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -4,6 +4,8 @@ import {
     getPaymentConfirmationEmailHtml,
     getPaymentLinkEmailHtml,
     getDomainLiveEmailHtml,
+    getDomainSetupInProgressEmailHtml,
+    getDomainRenewalReminderEmailHtml,
     getWithdrawalStatusEmailHtml,
 } from './templates'
 
@@ -189,6 +191,69 @@ export async function sendDomainLiveEmail(data: DomainLiveEmailData) {
         return { success: true, messageId: info.messageId }
     } catch (error: any) {
         console.error('Error in sendDomainLiveEmail:', error)
+        throw error
+    }
+}
+
+interface DomainSetupInProgressEmailData {
+    businessName: string
+    businessOwnerName: string
+    businessOwnerEmail: string
+    customDomain: string
+}
+
+export async function sendDomainSetupInProgressEmail(data: DomainSetupInProgressEmailData) {
+    const { businessName, businessOwnerEmail, customDomain } = data
+    try {
+        const transporter = nodemailer.createTransport({
+            service: 'gmail',
+            auth: {
+                user: process.env.GMAIL_USER,
+                pass: process.env.GMAIL_APP_PASSWORD,
+            },
+        })
+        const emailHtml = getDomainSetupInProgressEmailHtml(data)
+        const info = await transporter.sendMail({
+            from: `"Negosyo Digital" <${process.env.GMAIL_USER}>`,
+            to: businessOwnerEmail,
+            subject: `⏳ Setting up ${customDomain} — ${businessName}`,
+            html: emailHtml,
+        })
+        return { success: true, messageId: info.messageId }
+    } catch (error: any) {
+        console.error('Error in sendDomainSetupInProgressEmail:', error)
+        throw error
+    }
+}
+
+interface DomainRenewalReminderEmailData {
+    businessName: string
+    businessOwnerName: string
+    businessOwnerEmail: string
+    customDomain: string
+    expiresAt: number
+}
+
+export async function sendDomainRenewalReminderEmail(data: DomainRenewalReminderEmailData) {
+    const { businessName, businessOwnerEmail, customDomain } = data
+    try {
+        const transporter = nodemailer.createTransport({
+            service: 'gmail',
+            auth: {
+                user: process.env.GMAIL_USER,
+                pass: process.env.GMAIL_APP_PASSWORD,
+            },
+        })
+        const emailHtml = getDomainRenewalReminderEmailHtml(data)
+        const info = await transporter.sendMail({
+            from: `"Negosyo Digital" <${process.env.GMAIL_USER}>`,
+            to: businessOwnerEmail,
+            subject: `⏰ Renew ${customDomain} — ${businessName}`,
+            html: emailHtml,
+        })
+        return { success: true, messageId: info.messageId }
+    } catch (error: any) {
+        console.error('Error in sendDomainRenewalReminderEmail:', error)
         throw error
     }
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -827,3 +827,84 @@ export function getWithdrawalStatusEmailHtml(params: {
 </html>
     `
 }
+
+// ==================== DOMAIN SETUP IN PROGRESS EMAIL ====================
+// Sent when SSL provisioning starts — domain registered, DNS pointed, SSL pending.
+
+export function getDomainSetupInProgressEmailHtml(params: {
+    businessName: string
+    businessOwnerName: string
+    customDomain: string
+}): string {
+    const { businessName, businessOwnerName, customDomain } = params
+    return [
+        '<!DOCTYPE html>',
+        '<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">',
+        `<title>Setting up ${customDomain}</title></head>`,
+        '<body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial,sans-serif;">',
+        '<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f3f4f6;"><tr><td align="center" style="padding:40px 16px;">',
+        '<table width="600" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 20px rgba(0,0,0,0.08);">',
+        '<tr><td style="padding:48px 40px;background:linear-gradient(135deg,#3b82f6 0%,#1d4ed8 100%);text-align:center;color:#ffffff;">',
+        '<div style="display:inline-block;padding:6px 14px;background:rgba(255,255,255,0.2);border-radius:999px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;margin-bottom:16px;">Negosyo Digital</div>',
+        '<h1 style="margin:0;font-size:28px;font-weight:700;line-height:1.2;">Setting up your domain</h1>',
+        `<p style="margin:12px 0 0;font-size:15px;opacity:0.9;">${customDomain}</p>`,
+        '</td></tr>',
+        '<tr><td style="padding:40px;color:#1f2937;">',
+        `<p style="margin:0 0 16px;font-size:16px;">Hi <strong>${businessOwnerName}</strong>,</p>`,
+        `<p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:#374151;">Great news — we have successfully registered <strong>${customDomain}</strong> for your <strong>${businessName}</strong> website and pointed it to our servers.</p>`,
+        '<p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#374151;">We are now provisioning a free SSL certificate so your visitors can browse securely over HTTPS. This usually takes <strong>2 to 10 minutes</strong>. You do not need to do anything — we will send another email as soon as your site is fully live.</p>',
+        '<table width="100%" cellspacing="0" cellpadding="0" border="0" style="margin:24px 0;background:#eff6ff;border-left:4px solid #3b82f6;border-radius:8px;"><tr><td style="padding:16px 20px;">',
+        '<p style="margin:0;font-size:13px;color:#1e40af;line-height:1.5;"><strong>What is happening behind the scenes:</strong><br>Domain registered<br>DNS configured<br>SSL certificate being issued by Cloudflare<br>Final activation</p>',
+        '</td></tr></table>',
+        '<p style="margin:24px 0 0;font-size:14px;color:#6b7280;line-height:1.6;">If your site does not load yet, your browser may be cached. Try opening it in an incognito window in a few minutes.</p>',
+        '</td></tr>',
+        '<tr><td style="padding:24px 40px;background:#f9fafb;text-align:center;border-top:1px solid #e5e7eb;"><p style="margin:0;font-size:12px;color:#9ca3af;">Negosyo Digital — Build Your Digital Business</p></td></tr>',
+        '</table></td></tr></table></body></html>',
+    ].join('')
+}
+
+// ==================== DOMAIN RENEWAL REMINDER EMAIL ====================
+// Sent ~30 days before the registered domain's expiry date.
+
+export function getDomainRenewalReminderEmailHtml(params: {
+    businessName: string
+    businessOwnerName: string
+    customDomain: string
+    expiresAt: number
+}): string {
+    const { businessName, businessOwnerName, customDomain, expiresAt } = params
+    const expiryDate = new Date(expiresAt).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    })
+    const daysRemaining = Math.max(
+        0,
+        Math.floor((expiresAt - Date.now()) / (1000 * 60 * 60 * 24))
+    )
+    return [
+        '<!DOCTYPE html>',
+        '<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">',
+        `<title>Renew ${customDomain} before it expires</title></head>`,
+        '<body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial,sans-serif;">',
+        '<table width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f3f4f6;"><tr><td align="center" style="padding:40px 16px;">',
+        '<table width="600" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 20px rgba(0,0,0,0.08);">',
+        '<tr><td style="padding:48px 40px;background:linear-gradient(135deg,#f59e0b 0%,#d97706 100%);text-align:center;color:#ffffff;">',
+        '<div style="display:inline-block;padding:6px 14px;background:rgba(255,255,255,0.2);border-radius:999px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;margin-bottom:16px;">Reminder · Negosyo Digital</div>',
+        `<h1 style="margin:0;font-size:28px;font-weight:700;line-height:1.2;">Renew ${customDomain}</h1>`,
+        `<p style="margin:12px 0 0;font-size:15px;opacity:0.95;">${daysRemaining > 0 ? `${daysRemaining} days remaining` : 'Expires soon'}</p>`,
+        '</td></tr>',
+        '<tr><td style="padding:40px;color:#1f2937;">',
+        `<p style="margin:0 0 16px;font-size:16px;">Hi <strong>${businessOwnerName}</strong>,</p>`,
+        `<p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:#374151;">This is your friendly reminder that your custom domain <strong>${customDomain}</strong> for <strong>${businessName}</strong> will expire on <strong>${expiryDate}</strong>.</p>`,
+        '<p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#374151;">Negosyo Digital paid for your first year of registration. <strong>Year 2 onwards is your responsibility</strong> — if the domain is not renewed before the expiry date, you will lose it and your website will stop being reachable on this address.</p>',
+        '<table width="100%" cellspacing="0" cellpadding="0" border="0" style="margin:24px 0;background:#fffbeb;border-left:4px solid #f59e0b;border-radius:8px;"><tr><td style="padding:20px;">',
+        '<p style="margin:0 0 10px;font-size:14px;font-weight:600;color:#92400e;">How to renew:</p>',
+        `<ol style="margin:0;padding-left:20px;font-size:13px;color:#78350f;line-height:1.7;"><li>Visit your domain registrar (or transfer to one of your choice)</li><li>Search for <strong>${customDomain}</strong> and follow their renewal process</li><li>Pay the standard yearly registration fee (around 500 to 1200 PHP depending on registrar)</li></ol>`,
+        '</td></tr></table>',
+        '<p style="margin:24px 0 0;font-size:14px;color:#6b7280;line-height:1.6;">If you have any questions or need help transferring the domain to your own account, just reply to this email and we will guide you through it.</p>',
+        '</td></tr>',
+        '<tr><td style="padding:24px 40px;background:#f9fafb;text-align:center;border-top:1px solid #e5e7eb;"><p style="margin:0;font-size:12px;color:#9ca3af;">Negosyo Digital — Build Your Digital Business</p></td></tr>',
+        '</table></td></tr></table></body></html>',
+    ].join('')
+}


### PR DESCRIPTION
# Latest Changes ✨

**New custom domain email flows:**

* Added support for "domain setup in progress" and "domain renewal reminder" emails, including templates, preview endpoints, and email sending logic. These are now available for submissions with a custom domain in the admin email UI. ([app/admin/submissions/[id]/emails/page.tsxR97-R116](diffhunk://#diff-8e1f13ffb81e1b275d3254e21e669f946324ac8dce6a506883d93d89d6bb4b7bR97-R116), [app/admin/submissions/[id]/emails/page.tsxL130-R156](diffhunk://#diff-8e1f13ffb81e1b275d3254e21e669f946324ac8dce6a506883d93d89d6bb4b7bL130-R156), [[1]](diffhunk://#diff-f17687f3c3ee2e24d801b1070c4cd19e0388a355d500d75105f69bc4221d6d64L53-R108) [[2]](diffhunk://#diff-011ada1fba369ae947816c61021e84849232a1ef88b083158afdb4db56ce2194R198-R260)

**Email scheduling and automation:**

* The renewal reminder email is automatically scheduled to be sent 30 days before domain expiry using Convex schedulers during domain registration. The setup-in-progress email is sent immediately when SSL provisioning starts. [[1]](diffhunk://#diff-495f4ae4e6cf8f65ab5d5754637c4c1e926019fcb32eb21ab5e8c821744a01a7R400-R411) [[2]](diffhunk://#diff-495f4ae4e6cf8f65ab5d5754637c4c1e926019fcb32eb21ab5e8c821744a01a7R506-R511) [[3]](diffhunk://#diff-495f4ae4e6cf8f65ab5d5754637c4c1e926019fcb32eb21ab5e8c821744a01a7R638-R642)

**Backend API and internal action improvements:**

* Refactored the `/api/send-completed-website-email` endpoint to accept an optional `type` parameter, routing requests to the appropriate email sender (live, setup-in-progress, or renewal reminder). Added internal actions for each email type using a shared helper. [[1]](diffhunk://#diff-e536efb8036a2d6c38a7d9393a5986fbf757828a556da41116fdaf0a6cefa54dL47-R49) [[2]](diffhunk://#diff-e536efb8036a2d6c38a7d9393a5986fbf757828a556da41116fdaf0a6cefa54dR67-R96) [[3]](diffhunk://#diff-495f4ae4e6cf8f65ab5d5754637c4c1e926019fcb32eb21ab5e8c821744a01a7L849-R932)

**UI and type updates:**

* Updated the admin email preview and send UI to support the new email types by forwarding the `sendType` parameter and displaying the new emails when relevant. ([app/admin/submissions/[id]/emails/page.tsxR18-R19](diffhunk://#diff-8e1f13ffb81e1b275d3254e21e669f946324ac8dce6a506883d93d89d6bb4b7bR18-R19), [app/admin/submissions/[id]/emails/page.tsxR58](diffhunk://#diff-8e1f13ffb81e1b275d3254e21e669f946324ac8dce6a506883d93d89d6bb4b7bR58), [app/admin/submissions/[id]/emails/page.tsxL102-R131](diffhunk://#diff-8e1f13ffb81e1b275d3254e21e669f946324ac8dce6a506883d93d89d6bb4b7bL102-R131))

**Template and service wiring:**

* Imported and wired up the new email templates and service functions for sending the setup-in-progress and renewal reminder emails. [[1]](diffhunk://#diff-f17687f3c3ee2e24d801b1070c4cd19e0388a355d500d75105f69bc4221d6d64L53-R108) [[2]](diffhunk://#diff-e536efb8036a2d6c38a7d9393a5986fbf757828a556da41116fdaf0a6cefa54dR9-R10) [[3]](diffhunk://#diff-011ada1fba369ae947816c61021e84849232a1ef88b083158afdb4db56ce2194R7-R8)
