### PR TITLE
Add: Missing Hostinger Fee Calculation on Total Earnings

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -81,6 +81,8 @@ export default function AdminDashboard() {
 
     // Analytics data
     const allAnalytics = useQuery(api.analytics.getAllAnalytics, {})
+    // Hostinger custom-domain fees the platform paid (deducted from gross earnings)
+    const totalHostingerCosts = useQuery(api.domains.getTotalHostingerDomainCostsPHP, {})
 
     const handleBackfill = async () => {
         setBackfilling(true)
@@ -197,8 +199,8 @@ export default function AdminDashboard() {
             .map(([period, earnings]) => ({ period, earnings }))
     }, [allAnalytics])
 
-    // Total earnings across all time (for stat widget)
-    const totalEarnings = useMemo(() => {
+    // Gross earnings across all time (sum of creator payouts before fees)
+    const grossEarnings = useMemo(() => {
         if (!allAnalytics) return 0
         // Use monthly to avoid double-counting (monthly aggregates daily)
         const monthly = allAnalytics.filter((r: any) => r.periodType === "monthly")
@@ -209,6 +211,10 @@ export default function AdminDashboard() {
         const daily = allAnalytics.filter((r: any) => r.periodType === "daily")
         return daily.reduce((sum: number, r: any) => sum + (r.earningsTotal || 0), 0)
     }, [allAnalytics])
+
+    // Net earnings = gross minus Hostinger custom-domain fees the platform paid
+    const hostingerCosts = totalHostingerCosts ?? 0
+    const totalEarnings = Math.max(0, grossEarnings - hostingerCosts)
 
     const earningsChartData = {
         labels: earningsTimeSeries.map((r) => {
@@ -379,11 +385,16 @@ export default function AdminDashboard() {
                     <div className="p-2.5 rounded-xl bg-green-50/50 w-fit mb-4 group-hover:scale-110 transition-transform duration-300">
                         <TrendingUp className="text-green-600" size={20} />
                     </div>
-                    <p className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-1">Total Earnings</p>
+                    <p className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-1">Total Earnings (Net)</p>
                     <div className="flex items-baseline gap-2">
                         <p className="text-3xl font-black text-gray-900 tracking-tight">₱{totalEarnings.toLocaleString()}</p>
                         <span className="text-[10px] font-bold text-gray-400">All time</span>
                     </div>
+                    {hostingerCosts > 0 && (
+                        <p className="text-[10px] font-medium text-gray-400 mt-2">
+                            Gross ₱{grossEarnings.toLocaleString()} − Hostinger ₱{hostingerCosts.toLocaleString()}
+                        </p>
+                    )}
                 </div>
 
                 {/* Widget 2: Submissions (total + pending review combined) */}

--- a/convex/domains.ts
+++ b/convex/domains.ts
@@ -265,11 +265,52 @@ export const setRegistrarMetadata = internalMutation({
         submissionId: v.id('submissions'),
         orderId: v.string(),
         expiresAt: v.number(),
+        costPHP: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const patch: any = {
+            registrarOrderId: args.orderId,
+            domainExpiresAt: args.expiresAt,
+        }
+        if (args.costPHP !== undefined && args.costPHP > 0) {
+            patch.domainCostPHP = args.costPHP
+        }
+        await ctx.db.patch(args.submissionId, patch)
+    },
+})
+
+/**
+ * Sum of all Hostinger custom-domain registration fees the platform has paid.
+ * Subtracted from gross earnings on the admin dashboard to show net revenue.
+ */
+export const getTotalHostingerDomainCostsPHP = query({
+    args: {},
+    handler: async (ctx) => {
+        const submissions = await ctx.db
+            .query('submissions')
+            .withIndex('by_domainStatus')
+            .collect()
+        let total = 0
+        for (const s of submissions) {
+            const cost = (s as any).domainCostPHP
+            if (typeof cost === 'number' && cost > 0) total += cost
+        }
+        return total
+    },
+})
+
+/**
+ * One-off backfill: set a submission's `domainCostPHP` field manually for
+ * registrations that happened before cost capture was wired into the pipeline.
+ */
+export const backfillDomainCostPHP = internalMutation({
+    args: {
+        submissionId: v.id('submissions'),
+        costPHP: v.number(),
     },
     handler: async (ctx, args) => {
         await ctx.db.patch(args.submissionId, {
-            registrarOrderId: args.orderId,
-            domainExpiresAt: args.expiresAt,
+            domainCostPHP: args.costPHP,
         } as any)
     },
 })
@@ -396,7 +437,9 @@ export const setupForSubmission = internalAction({
                 submissionId: args.submissionId,
                 orderId: reg.orderId,
                 expiresAt: reg.expiresAt,
+                costPHP: reg.totalPHP,
             })
+            console.log(`[DOMAINS] Hostinger charged $${reg.totalUSD.toFixed(2)} (₱${reg.totalPHP.toFixed(2)}) for ${domain}`)
 
             // Schedule the 30-day-before-expiry renewal reminder email.
             // Convex schedulers persist long-future jobs reliably.

--- a/convex/lib/hostinger.ts
+++ b/convex/lib/hostinger.ts
@@ -110,6 +110,10 @@ export interface RegistrationResult {
     subscriptionId?: string
     /** Estimated expiry — Hostinger sets this; we approximate as 1 year from now */
     expiresAt: number
+    /** Total amount Hostinger charged for the registration, in USD (parsed from cents) */
+    totalUSD: number
+    /** Total amount in PHP (FX-converted from USD via fxRate at purchase time) */
+    totalPHP: number
 }
 
 export interface RegistrantContact {
@@ -388,12 +392,18 @@ export async function registerDomain(
     })
 
     // Response is an Order resource. Field names per Billing.V1.Order.OrderResource spec.
+    // Prices are in cents per Hostinger spec.
     const orderId = String(data?.id || data?.order_id || data?.data?.id || normalized)
     const expiresAt = Date.now() + 365 * 24 * 60 * 60 * 1000 // 1 year
+    const totalCents = Number(data?.total ?? data?.subtotal ?? 0)
+    const totalUSD = totalCents / 100
+    const totalPHP = totalUSD > 0 ? await usdToPhp(totalUSD) : 0
 
     return {
         orderId,
         expiresAt,
+        totalUSD,
+        totalPHP,
     }
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -126,6 +126,9 @@ export default defineSchema({
         // Registrar metadata
         registrarOrderId: v.optional(v.string()),
         domainExpiresAt: v.optional(v.number()),
+        // Actual cost the platform paid Hostinger for this registration (PHP).
+        // Used by the admin dashboard to deduct from gross earnings → net earnings.
+        domainCostPHP: v.optional(v.number()),
         // Cloudflare zone for this custom domain
         cloudflareZoneId: v.optional(v.string()),
     })


### PR DESCRIPTION
# Latest Changes ✨

**Admin Dashboard Earnings Calculation and Display:**

- The admin dashboard now queries the total Hostinger domain costs (`getTotalHostingerDomainCostsPHP`) and displays both gross earnings and net earnings (gross minus Hostinger fees) in the earnings widget, with updated labels and breakdown. [[1]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R84-R85) [[2]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43L200-R203) [[3]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R215-R218) [[4]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43L382-R397)

**Backend: Domain Cost Tracking and Aggregation:**

- The Convex schema for submissions now includes a `domainCostPHP` field to record the PHP cost of each custom-domain registration.
- When registering a domain, the platform now records the actual Hostinger fee paid (in both USD and PHP, with currency conversion at purchase time) in the submission document. [[1]](diffhunk://#diff-e5aec1a6dc8b54c548ec1e3731c9b0dbd2d204a77d616917b2db45615bd72899R113-R116) [[2]](diffhunk://#diff-e5aec1a6dc8b54c548ec1e3731c9b0dbd2d204a77d616917b2db45615bd72899R395-R406) [[3]](diffhunk://#diff-495f4ae4e6cf8f65ab5d5754637c4c1e926019fcb32eb21ab5e8c821744a01a7R440-R442)
- Added a Convex query, `getTotalHostingerDomainCostsPHP`, to sum all recorded Hostinger domain registration fees for use in analytics and reporting.
- Added a backfill mutation to manually set `domainCostPHP` for historical registrations made before automatic cost tracking was implemented.