### PR TITLE
Add: Save & Publish Edits flow + revert custom domain test pricing

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -444,6 +444,72 @@ export default function SubmissionDetailPage() {
         }
     }
 
+    // Handler to save edits + regenerate + republish in one action
+    const [saveAndPublishStep, setSaveAndPublishStep] = useState<'idle' | 'saving' | 'generating' | 'publishing'>('idle')
+    const handleSaveAndPublishEdits = async () => {
+        if (saveAndPublishStep !== 'idle' || !submission || !submissionData) return
+
+        try {
+            // Step 1: Save edits if currently in edit mode
+            if (isEditing) {
+                setSaveAndPublishStep('saving')
+                await updateSubmissionMutation({
+                    id: submissionData._id,
+                    businessName: editedData.business_name,
+                    businessType: editedData.business_type,
+                    ownerName: editedData.owner_name,
+                    ownerPhone: editedData.owner_phone,
+                    ownerEmail: editedData.owner_email || undefined,
+                    address: editedData.address,
+                    city: editedData.city,
+                    transcript: editedData.transcript || undefined,
+                    photos: editedData.photos,
+                })
+                setIsEditing(false)
+            }
+
+            // Step 2: Regenerate website so htmlContent reflects the latest submission data
+            setSaveAndPublishStep('generating')
+            const genRes = await fetch('/api/generate-website', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    submissionId,
+                    customizations: websiteCustomizations,
+                }),
+            })
+            if (!genRes.ok) {
+                const errData = await genRes.json().catch(() => ({}))
+                throw new Error(`Regeneration failed: ${errData.error || genRes.statusText}`)
+            }
+
+            // Step 3: Republish to Cloudflare Worker (overwrites existing deployment in place)
+            setSaveAndPublishStep('publishing')
+            const pubRes = await fetch('/api/publish-website', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ submissionId }),
+            })
+            if (!pubRes.ok) {
+                const errData = await pubRes.json().catch(() => ({}))
+                throw new Error(`Publishing failed: ${errData.error || pubRes.statusText}`)
+            }
+            const pubData = await pubRes.json()
+
+            setWebsitePublishedUrl(pubData.url)
+            setModalType('success')
+            setModalMessage(`Changes applied! Live at: ${pubData.url}`)
+            setShowModal(true)
+        } catch (error: any) {
+            console.error('Save & publish error:', error)
+            setModalType('error')
+            setModalMessage(error.message || 'Failed to apply changes to the live site')
+            setShowModal(true)
+        } finally {
+            setSaveAndPublishStep('idle')
+        }
+    }
+
     // Handler to send website URL to business owner
     const [sendingEmail, setSendingEmail] = useState(false)
     const handleSendWebsiteEmail = async () => {
@@ -1185,6 +1251,28 @@ export default function SubmissionDetailPage() {
                                             </svg>
                                             Visit Published Site
                                         </a>
+                                        {/* Save & Publish Edits — pushes latest submission data to the live Cloudflare Worker */}
+                                        <button
+                                            onClick={handleSaveAndPublishEdits}
+                                            disabled={saveAndPublishStep !== 'idle'}
+                                            className="inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            {saveAndPublishStep !== 'idle' ? (
+                                                <>
+                                                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                                                    {saveAndPublishStep === 'saving' && 'Saving...'}
+                                                    {saveAndPublishStep === 'generating' && 'Regenerating...'}
+                                                    {saveAndPublishStep === 'publishing' && 'Publishing...'}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                                    </svg>
+                                                    Save & Publish Edits
+                                                </>
+                                            )}
+                                        </button>
                                         {/* Unpublish button */}
                                         <button
                                             onClick={handleUnpublishWebsite}
@@ -1877,9 +1965,8 @@ export default function SubmissionDetailPage() {
                                 {/* Amount */}
                                 <div>
                                     <label className="text-xs text-gray-500 uppercase font-medium">Business Owner Fee</label>
-                                    {/* TEST PRICING: ₱100 for custom domain, normally ₱1,500 — see plans/REVERT-CUSTOM-DOMAIN-PRICING.md */}
                                     <p className="text-2xl font-black text-gray-900 mt-1">
-                                        ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 100 : 1000)).toLocaleString()}
+                                        ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 1500 : 1000)).toLocaleString()}
                                     </p>
                                     {(submissionData as any)?.requestedDomain && (
                                         <p className="text-xs text-gray-500 mt-0.5">

--- a/app/submit/review/page.tsx
+++ b/app/submit/review/page.tsx
@@ -40,8 +40,7 @@ export default function ReviewSubmissionPage() {
     // Auto-derived: if user typed something, tier is "with_custom_domain"
     const wantsCustomDomain = domainInput.trim().length > 0
     const tier: 'standard' | 'with_custom_domain' = wantsCustomDomain ? 'with_custom_domain' : 'standard'
-    // TEST PRICING: custom domain is temporarily ₱100 instead of ₱1,500 (revert via plans/REVERT-CUSTOM-DOMAIN-PRICING.md)
-    const totalAmount = wantsCustomDomain ? 100 : 1000
+    const totalAmount = wantsCustomDomain ? 1500 : 1000
 
     // Get creator from Convex
     const creator = useQuery(
@@ -342,7 +341,7 @@ export default function ReviewSubmissionPage() {
                         </div>
                     </div>
 
-                    {/* Custom Domain (optional) — typing here auto-flags submission as ₱100 (TEST PRICING — normally ₱1,500) */}
+                    {/* Custom Domain (optional) — typing here auto-flags submission as ₱1,500 */}
                     <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
                         <div className="p-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between">
                             <h3 className="font-semibold text-gray-900 flex items-center gap-2">
@@ -350,12 +349,12 @@ export default function ReviewSubmissionPage() {
                                 Custom Domain (Optional)
                             </h3>
                             <span className={`text-xs font-bold px-2 py-1 rounded-full ${wantsCustomDomain ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-500'}`}>
-                                {wantsCustomDomain ? 'TEST: ₱100' : 'Not included'}
+                                {wantsCustomDomain ? '+₱500' : 'Not included'}
                             </span>
                         </div>
                         <div className="p-4 space-y-3">
                             <p className="text-xs text-gray-500">
-                                Leave this blank for the standard package (₱1,000, free subdomain). Type a domain to add a custom domain — your fee automatically becomes ₱100 (TEST PRICING) and includes year 1 of the domain.
+                                Leave this blank for the standard package (₱1,000, free subdomain). Type a domain to add a custom domain — your fee automatically becomes ₱1,500 and includes year 1 of the domain.
                             </p>
 
                             <div>
@@ -386,7 +385,7 @@ export default function ReviewSubmissionPage() {
                                 <div className="text-xs">
                                     {domainCheck.available && domainCheck.withinBudget && (
                                         <p className="text-green-700 font-semibold">
-                                            ✓ Available · ₱{domainCheck.pricePHP} (within budget — included in your ₱100 test fee)
+                                            ✓ Available · ₱{domainCheck.pricePHP} (within budget — included in your ₱1,500 fee)
                                         </p>
                                     )}
                                     {domainCheck.available && !domainCheck.withinBudget && (

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -108,7 +108,7 @@ export default defineSchema({
         // Pricing tier chosen at submission time
         submissionType: v.optional(v.union(
             v.literal('standard'),              // ₱1,000 — free subdomain
-            v.literal('with_custom_domain')     // TEST: ₱100 (normally ₱1,500) — includes custom domain
+            v.literal('with_custom_domain')     // ₱1,500 — includes custom domain (year 1 + setup)
         )),
         // The domain the creator picked on the review page
         requestedDomain: v.optional(v.string()),

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -323,9 +323,7 @@ export const setDomainTier = mutation({
 
         const updates: any = {
             submissionType: args.submissionType,
-            // TEST PRICING: custom domain temporarily ₱100 instead of ₱1,500
-            // See plans/REVERT-CUSTOM-DOMAIN-PRICING.md to restore
-            amount: isWithDomain ? 100 : 1000,
+            amount: isWithDomain ? 1500 : 1000,
             domainStatus: isWithDomain ? 'pending_payment' : 'not_requested',
         };
         if (isWithDomain) {
@@ -381,9 +379,11 @@ export const submit = mutation({
         }
 
         // 1. Update submission status
+        // Preserve tier-based amount set by setDomainTier (₱1,500 for with_custom_domain, ₱1,000 for standard).
+        const hasCustomDomain = (submission as any).submissionType === 'with_custom_domain';
         await ctx.db.patch(args.id, {
             status: 'submitted',
-            amount: 1000,
+            amount: hasCustomDomain ? 1500 : 1000,
             airtableSyncStatus: 'pending_push',
         });
 

--- a/lib/payments/wise-api.ts
+++ b/lib/payments/wise-api.ts
@@ -102,16 +102,21 @@ export async function sendWiseTransfer(params: WisePayoutRequest): Promise<WiseT
 
         const transfer = await transferResponse.json();
 
-        // Step 4: Fund the transfer
-        const fundResponse = await fetch(`https://api.wise.com/v1/transfers/${transfer.id}/payments`, {
+        // Step 4: Fund the transfer from the Creator Payout jar when configured,
+        // otherwise fall back to the main PHP balance. Using a dedicated jar keeps
+        // creator withdrawals isolated from operating funds.
+        const creatorPayoutBalanceId = process.env.WISE_CREATOR_PAYOUT_BALANCE_ID;
+        const fundBody: Record<string, unknown> = { type: 'BALANCE' };
+        if (creatorPayoutBalanceId) {
+            fundBody.sourceBalanceId = creatorPayoutBalanceId;
+        }
+        const fundResponse = await fetch(`https://api.wise.com/v3/profiles/${accountId}/transfers/${transfer.id}/payments`, {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${apiToken}`,
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-                type: 'BALANCE',
-            }),
+            body: JSON.stringify(fundBody),
         });
 
         if (!fundResponse.ok) {

--- a/plans/PROMPTS-CUSTOM-DOMAIN-PIPELINE-WISE.MD
+++ b/plans/PROMPTS-CUSTOM-DOMAIN-PIPELINE-WISE.MD
@@ -1,0 +1,319 @@
+# User Prompts — Custom Domain Pipeline + Wise Withdrawal Session
+
+> Chronological record of every prompt the user sent during the build of the custom domain purchase pipeline (and prior wise withdrawal context). Pasted verbatim so another AI agent can read them as-is and understand what was asked.
+
+---
+
+## Prompt 1 — Continue four-issue task
+
+please continue this agent task Four separate issues. Let me fix them one by one:
+
+Issue 1: targetType: "payment" rejected — the deployed schema still has the old v.union(). Need to redeploy schema.
+
+Issue 2: creators ID passed as submissionId — the leads.create mutation is being called somewhere with a creator ID in the submission field. This is likely from the auto-payment flow or a lead created from the website contact form. Let me check.
+
+Issue 3: "No withdrawal found" — harmless, the old /wise-webhook seeing deposit events.
+
+Issue 4: "No Hostinger catalog item_id" — the availability check returned no item_id. This means either the Hostinger API response format is different than expected, or the domain isn't available.
+
+Grep "leads\.create|api\.leads\.create" (in c:\Users\Steven\Work\negosyo-digital\convex)
+1 line of output
+Grep "leads\.create"
+2 lines of output
+Issue 2 is from the admin leads page — when you add a lead without a linked submission, submissionId might get a creator ID. But the real fix is making the schema accept string for validation. Let me focus on the critical fixes:
+
+Fix 1: Ensure schema is deployed — the auditLogs.targetType needs to be v.string() in production.
+
+Grep "targetType.*v\."" (in c:\Users\Steven\Work\negosyo-digital\convex\schema.ts)
+1 line of output
+Grep "targetType" (in c:\Users\Steven\Work\negosyo-digital\convex\schema.ts)
+2 lines of output
+Schema is correct locally (v.string()). The issue is the deployed Convex still has the old union. You need to run npx convex deploy again.
+
+Fix 2: The item_id issue with Hostinger — the availability check is working but not returning an item_id. This is because the Hostinger API response shape might not include item_id in the availability check. Let me update the domain setup to handle this — make item_id optional and try to purchase without it if needed:
+
+Read c:\Users\Steven\Work\negosyo-digital\convex\domains.ts (lines 360-379)
+The problem is clear — the availability check doesn't return item_id. Hostinger's availability endpoint likely doesn't include catalog items. The item_id comes from a separate catalog endpoint. Let me update the flow to fetch the catalog item separately:
+
+Read c:\Users\Steven\Work\negosyo-digital\convex\lib\hostinger.ts (lines 109-138)
+Now add a getCatalogItemId function and update the flow:
+
+Edit c:\Users\Steven\Work\negosyo-digital\convex\lib\hostinger.ts
+Added 32 lines
+Now update registerDomain to handle missing item_id — try the domain name itself as fallback:
+
+Edit c:\Users\Steven\Work\negosyo-digital\convex\lib\hostinger.ts
+Removed 1 line
+Edit c:\Users\Steven\Work\negosyo-digital\convex\lib\hostinger.ts
+Modified
+Now update domains.ts to get item_id from the catalog if availability check doesn't return it:
+
+Edit c:\Users\Steven\Work\negosyo-digital\convex\domains.ts
+Added 1 line
+Now update the setup pipeline to try catalog lookup when item_id is missing:
+
+Edit c:\Users\Steven\Work\negosyo-digital\convex\domains.ts
+Added 11 lines
+Bash
+IN
+cd "c:/Users/Steven/Work/negosyo-digital" && npm run build 2>&1 | tail -5
+
+OUT
+ [90m     |[39m                 [31m[1m^[22m[39m
+ [90m 381 |[39m             }
+ [90m 382 |[39m             [36mif[39m ([33m![39mitemId) {
+ [90m 383 |[39m                 console[33m.[39mlog([32m`[DOMAINS] No item_id from catalog either, using domain name as item_id fallback`[39m)[0m
+Next.js build worker exited with code: 1 and signal: null
+Bash
+IN
+cd "c:/Users/Steven/Work/negosyo-digital" && npm run build 2>&1 | grep "Type error" | head -3
+
+OUT
+Type error: Type 'string | null' is not assignable to type 'string | undefined'.
+Bash
+IN
+cd "c:/Users/Steven/Work/negosyo-digital" && npm run build 2>&1 | grep -B2 "Type error" | head -3
+
+OUT
+./convex/domains.ts:380:17
+Type error: Type 'string | null' is not assignable to type  also tell me how can like i trigger the custom domain pipeline to go since i know paid and the automation is working. how can i trigger in convex the custom domain to work wihout paying anymmore
+
+---
+
+## Prompt 2 — Confirm full pipeline + Hostinger/Cloudflare docs check
+
+so if i run option 1  it will run the full pipeline (availability → register → disable auto-renew → DNS → cloudflare → email). right? have you access hostinger api docs if all of our implementation as well as cloduflare pages docs to setup custom domain are all good in our currrent automated implementation?
+
+---
+
+## Prompt 3 — On the Run Function dashboard, what's next
+
+[screenshot of Convex dashboard showing setupForSubmission internal action]
+i', here now what' next
+
+---
+
+## Prompt 4 — Province/postalcode missing error
+
+[screenshot of failed setup logs]
+[DOMAINS] Setup failed for benjoetiresupply.com: [Error: Cannot register domain: business owner info incomplete. Missing: province, postalCode]  what the heck we dont need this provicnce and postalcode please don;t include them on registering custom domain. aslo it says no tem id
+
+---
+
+## Prompt 5 — Item_id 422 error
+
+[screenshot]
+tired deployed new changges and run function still this is the error
+
+Function execution timed out (maximum duration: 600s)
+[DOMAINS] Setup failed for benjoetiresupply.com: [Error: Hostinger API error (422): Incorrect "item_id" value]
+
+---
+
+## Prompt 6 — Hostinger MCP docs research
+
+[DOMAINS] Setup failed for benjoetiresupply.com: [Error: Hostinger API error (402): Card payment could not be completed, use other payment method or try again] please access hostinger api mcp docs and other references to resolve this
+
+---
+
+## Prompt 7 — Payment failed 422 + ask about correct request shape
+
+[DOMAINS] Setup failed for benjoetiresupply.com: [Error: Hostinger API error (422): [Billing:422] Payment failed: Something went wrong with your request. Please try again later.]    upon trying to trigger the setupSubmission function on convex. How are you getting the payment_method_id — are you calling GET /api/billing/v1/payment-methods first to get the real ID, or hardcoding it?
+What does your full request body to POST /api/domains/v1/portfolio look like?
+Do you have a WHOIS contact profile created?  please research on hotinger api docs if it's correct and we are doing hte right thing and implement andd fix the errors
+
+---
+
+## Prompt 8 — Approve the four-change plan + verification
+
+yes please and after making changes tell me what specifically to do also verify everything on hostinger api docs after build
+
+---
+
+## Prompt 9 — WHOIS ownership question
+
+waiit the WHOIS must be the business owner or me?
+
+---
+
+## Prompt 10 — Implications of WHOIS ownership
+
+so i create a WHOIS Profile then suddenly all domain purchase would be under me?
+
+---
+
+## Prompt 11 — One WHOIS account per hostinger
+
+so for the WHOIS Profile one account per hostinger?
+
+---
+
+## Prompt 12 — Pass actual API key + fetch real WHOIS profile
+
+The missing whois_profile_id in your request body is very likely the actual cause of your 422 error — not the payment method. try running an api command to get the  WHOIS profile in hPanel of my account in hostinger HOSTINGER_API_KEY=8hTCuL8WLyQkLYPjEWhb6fN1aLXtvQE4FNY0Q0U9ec029dcd
+HOSTINGER_PAYMENT_METHOD_ID=42192252
+ then get the whoisproifle id and add it to your domain purchase call also don't hardcode it and make it into an env var and tell me what i need to setup in convex. make sure to double check hostinger api mcp docs for this implementation so we can resolve the [DOMAINS] Setup failed for benjoetiresupply.com: [Error: Hostinger API error (422): [Billing:422] Payment failed: Something went wrong with your request. Please try again later.]
+
+---
+
+## Prompt 13 — Full convex log after latest changes
+
+Full log on convex upon latest change
+
+[DOMAINS] Setup failed for benjoetiresupply.com: [Error: Hostinger API error (422): [Billing:422] Payment failed: Something went wrong with your request. Please try again later.]
+
+[HOSTINGER] POST /domains/v1/portfolio body: {"domain":"benjoetiresupply.com","item_id":"hostingercom-domain-com-usd-1y","payment_method_id":"***","domain_contacts":{"owner_id":13905931,"admin_id":13905931,"billing_id":13905931,"tech_id":13905931}}
+
+[DOMAINS] Using item_id: hostingercom-domain-com-usd-1y for benjoetiresupply.com
+
+[HOSTINGER] Selected price id hostingercom-domain-com-usd-1y (period: 1) for .com
+
+[HOSTINGER] First catalog item: {"id":"hostingercom-domain-com","name":".COM Domain","category":"DOMAIN","metadata":null,"prices":[{"id":"hostingercom-domain-com-usd-1y","name":".COM Domain (billed every year)","currency":"USD","price":1999,"first_period_price":999,"period":1,"period_unit":"year"},{"id":"hostingercom-domain-com-usd-3y","name":".COM Domain (billed every 3 years)","currency":"USD","price":5997,"first_period_price":3999,"period":3,"period_unit":"year"},{"id":"hostingercom-domain-com-usd-2y","name":".COM Domain (billed every 2 years)","currency":"USD","price":3998,"first_period_price":2298,"period":2,"period_unit":"year"}]}
+
+[HOSTINGER] Catalog response for .com: 14 items
+
+[DOMAINS] No item_id from availability check, looking up catalog for .com
+
+[DOMAINS] Starting setup for benjoetiresupply.com (submission jd7ez40egfxmtvtpch2w0hdwm984q9av)
+
+---
+
+## Prompt 14 — Why resumeAfterRegistration not setupSubmission
+
+why i need to run domains:resumeAfterRegistration instead of setupSubmission?
+
+---
+
+## Prompt 15 — Resume timeout + workers.dev URL stuck
+
+[screenshot of NXDOMAIN error and convex resumeAfterRegistration timeout]
+after running resumeRegistration
+
+Function execution timed out (maximum duration: 600s)
+
+[DOMAINS] Resuming post-registration setup for benjoetiresupply.com
+[DOMAINS] Created Cloudflare zone ff13c47b22bcc77da407f803777af7d4 for benjoetiresupply.com
+[DOMAINS] Updated nameservers for benjoetiresupply.com
+[DOMAINS] Attached benjoetiresupply.com to Pages project ben-joe-tire-supply
+
+and if i visit benjoetiresupply.com. also if i click visit published site on the submission detail page it is still https://ben-joe-tire-supply.frmwrkd-media.workers.dev/ instead of http://benjoetiresupply.com/ what's wrong with this error Function execution timed out (maximum duration: 600s) function works a charm lately please access convex docs and hostinger docs to resolve this issue
+
+---
+
+## Prompt 16 — Be specific about which functions to run after deploy
+
+could you please be specific agaiin what functions i need ed to run after deploy?
+
+---
+
+## Prompt 17 — Confirm setCustomDomainOnWebsite mutation args
+
+[screenshot of Convex dashboard with setCustomDomainOnWebsite mutation args]
+is this right?
+
+---
+
+## Prompt 18 — SSL still not set after 20 attempts + 404 email
+
+[screenshot of NXDOMAIN + Cloudflare DNS records page]
+20 times have passed ssl not set [DOMAINS] ✓ benjoetiresupply.com marked live (sslReady: false, attempts: 20)  also [DOMAINS] Failed to send domain-live email: 404 [HUGE HTML 404 BODY OMITTED]   when i visit benjoetiresupply.com. also if i click visit published site on the submission detail page it is still https://ben-joe-tire-supply.frmwrkd-media.workers.dev/ instead of http://benjoetiresupply.com/ what's wrong with this error  Function execution timed out (maximum duration: 600s) function works a charm lately please access convex docs and hostinger docs to resolve this issue
+
+---
+
+## Prompt 19 — DNS cached locally but works globally
+
+[screenshot showing site-can't-be-reached + Cloudflare DNS records present]
+tried doing step 1 - 4 this is the result  still can't access the site tried running pollDomasSSL it says '[DOMAINS] SSL not ready for benjoetiresupply.com (attempt 1/20), rescheduling'. website log if viist (index):1 Unsafe attempt to load URL https://benjoetiresupply.com/ from frame with URL chrome-error://chromewebdata/. Domains, protocols and ports must match.  second image attached shows dns records of the domain in cloudflare
+
+---
+
+## Prompt 20 — Wrong project — assigning to old Pages site instead of Worker
+
+[screenshot showing wrong "TIRES THAT TAKE YOUR FURTHER" content vs the correct generated site]
+okay it works! but hte problem is it's using the old. instead on what we have geenrated. it's assigning the custom domain on the old site instead of this generated website under workers and pages in cloudflarre ben-joe-tire-supply.frmwrkd-media.workers.dev. also no email was sent to business owners upon sending the custom domain website is assign to the generated website and completed. in the view email sent page add a send website is live with custom domain or not when click will sned the email template to the user
+
+---
+
+## Prompt 21 — Confirm migration target + naming
+
+yes it is in https://ben-joe-tire-supply.pages.dev/ we need to put the benjoetiresupply.com on the https://ben-joe-tire-supply.frmwrkd-media.workers.dev/ page that was generated also ensure that no generated wbsite would be deleted just the domain name would be move. fixBenjoeToUseWorker please fix this naming if we are going ot use it as function.
+
+---
+
+## Prompt 22 — Complete the pipeline flow user-friendly
+
+okay great it works please complete the flow it a more specific manner way a user can understand it quiuckly based on our current implementation Overview Pipeline flow
+
+Creator Enters Custom Domain want by business owner on review page ->
+
+---
+
+## Prompt 23 — Repeat: complete pipeline flow
+
+okay complete the pipeline flow based on our setupp Overview Pipeline flow
+
+Creator Enters Custom Domain want by business owner on review page ->
+
+---
+
+## Prompt 24 — View email sent page button + automated email + don't break stuff
+
+in the view email sent page when the website is deployed and custom domain is assign to that page. no email was sent to the business owner. add a button on the email sent page send completeed website. when click will email business owner about the complete website generated with new domain assign to it same goes if hte submission is normal. also ensure that the automated pipeline is triggering this email template
+
+---
+
+## Prompt 25 — Commit message + description
+
+create me a commit message for this changes and a description of the changes we did
+
+---
+
+## Prompt 26 — "Send to Client Email" preview wrong + new SSL provisioning email + renewal reminder template
+
+[screenshot of actual sent payment-link email + screenshot of wrong preview showing approval template]
+the sent to email client is not showing up the right email that was sent to business early. also create an email template that will send if the custom domain ssl is still being prepared it will send if the polling starts also ensure nothing breaks on your changes. also create an email template for We'll send you a reminder email 30 days before the expiry date so you don't lose the domain. that is also scheduled
+
+---
+
+## Prompt 27 — Total earnings should deduct hostinger fee
+
+[screenshot of admin dashboard showing ₱1,600 Total Earnings]
+my total earnins in production said i earn 1600 like how, please deduct the hostinger custom domain fee on the earnings
+
+---
+
+## Prompt 28 — Renewal email wording (handle for them)
+
+[screenshot of "Your Website is Live!" email with renewal disclaimer]
+please state on the email template that if they want to renew they can reach us for it
+
+---
+
+## Prompt 29 — Build plan markdown for mobile-side AI
+
+based on this branch create a md and put it inside the plans folder documenting every plan about how the schemas changes we did overall what are the functions we added this is to instruct the other ai agent on the mobile platform side what to add on the missing schema field when npx convex deploy PS C:\dev\ndm> npx convex deploy
+You're currently developing against your dev deployment
+
+  diligent-ibex-454 (set in CONVEX_DEPLOYMENT)
+
+Your prod deployment energetic-panther-693 serves traffic at:
+
+  EXPO_PUBLIC_CONVEX_URL=https://energetic-panther-693.convex.cloud
+
+Make sure that your published client is configured with this URL (for instructions see https://docs.convex.dev/hosting)
+
+✔ Do you want to push your code to your prod deployment energetic-panther-693 now? Yes
+A minor update is available for Convex (1.34.1 → 1.35.1)
+Changelog: https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md#changelog
+Convex AI files are not installed. Run npx convex ai-files install to get started or npx convex ai-files disable to hide this message.
+✔ No large indexes are deleted by this push
+Uploading functions to Convex...
+Generating TypeScript bindings...
+Running TypeScript...
+Pushing code to your Convex deployment...
+✖ Schema validation failed.
+Document with ID "jd7ez40egfxmtvtpch2w0hdwm984q9av" in table "submissions" does not match the schema: Object contains extra field `domainCostPHP` that is not in the validator.
+
+
+
+

--- a/plans/REVERT-CUSTOM-DOMAIN-PRICING.md
+++ b/plans/REVERT-CUSTOM-DOMAIN-PRICING.md
@@ -1,145 +1,234 @@
-# Revert Custom Domain Pricing: ₱100 → ₱1,500
+# Revert Custom Domain Test Pricing → Production
 
-**Status:** Test pricing currently active
-**Created:** April 2026
-**Purpose:** Temporary low pricing for end-to-end testing of the custom domain purchase pipeline
-
-## Why this exists
-
-The custom domain feature charges business owners ₱1,500 normally (₱500 of which covers a year of domain registration via Hostinger). For end-to-end testing of the full pipeline (Wise payment → webhook → Hostinger purchase → Cloudflare zone → SSL → live site), the ₱1,500 was temporarily lowered to **₱100** so test transactions don't burn real money.
-
-When testing is complete, all changes below must be reverted before production launch.
+**Status:** ✅ REVERTED on April 12, 2026 — pricing is back to ₱1,500 production value
+**Original test applied:** April 10, 2026 (₱100 for easier Wise payment flow testing)
+**Kept for reference** — search this file for each change site if you need to re-apply test pricing in the future.
 
 ---
 
-## Files to revert (4 changes total)
+## ⚠ Also ensure Wise Creator Payout jar is configured
 
-### 1. `app/submit/review/page.tsx`
-
-**Line ~43** — `totalAmount` calculation:
-
-```diff
-- // TEST PRICING: custom domain is temporarily ₱100 instead of ₱1,500 (revert via plans/REVERT-CUSTOM-DOMAIN-PRICING.md)
-- const totalAmount = wantsCustomDomain ? 100 : 1000
-+ const totalAmount = wantsCustomDomain ? 1500 : 1000
-```
-
-**Line ~345** — Section comment:
-
-```diff
-- {/* Custom Domain (optional) — typing here auto-flags submission as ₱100 (TEST PRICING — normally ₱1,500) */}
-+ {/* Custom Domain (optional) — typing here auto-flags submission as ₱1,500 */}
-```
-
-**Line ~353** — Header badge:
-
-```diff
-- {wantsCustomDomain ? 'TEST: ₱100' : 'Not included'}
-+ {wantsCustomDomain ? '+₱500' : 'Not included'}
-```
-
-**Line ~357** — Description text:
-
-```diff
-- Leave this blank for the standard package (₱1,000, free subdomain). Type a domain to add a custom domain — your fee automatically becomes ₱100 (TEST PRICING) and includes year 1 of the domain.
-+ Leave this blank for the standard package (₱1,000, free subdomain). Type a domain to add a custom domain — your fee automatically becomes ₱1,500 and includes year 1 of the domain.
-```
-
-**Line ~390** — Availability success message:
-
-```diff
-- ✓ Available · ₱{domainCheck.pricePHP} (within budget — included in your ₱100 test fee)
-+ ✓ Available · ₱{domainCheck.pricePHP} (within budget — included in your ₱1,500 fee)
-```
-
----
-
-### 2. `convex/submissions.ts`
-
-**Line ~324-328** — `submit` mutation amount:
-
-```diff
-  const updates: any = {
-      submissionType: args.submissionType,
--     // TEST PRICING: custom domain temporarily ₱100 instead of ₱1,500
--     // See plans/REVERT-CUSTOM-DOMAIN-PRICING.md to restore
--     amount: isWithDomain ? 100 : 1000,
-+     amount: isWithDomain ? 1500 : 1000,
-      domainStatus: isWithDomain ? 'pending_payment' : 'not_requested',
-  };
-```
-
----
-
-### 3. `convex/schema.ts`
-
-**Line ~126** — Comment on the `submissionType` literal:
-
-```diff
-- v.literal('with_custom_domain')     // TEST: ₱100 (normally ₱1,500) — includes custom domain
-+ v.literal('with_custom_domain')     // ₱1,500 — includes custom domain
-```
-
----
-
-### 4. `app/admin/submissions/[id]/page.tsx`
-
-**Pricing & Domain widget** — the fallback amount for custom domain:
-
-```diff
-  {/* TEST PRICING: ₱100 for custom domain, normally ₱1,500 — see plans/REVERT-CUSTOM-DOMAIN-PRICING.md */}
-- ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 100 : 1000)).toLocaleString()}
-+ ₱{((submissionData as any)?.amount || ((submissionData as any)?.requestedDomain ? 1500 : 1000)).toLocaleString()}
-```
-
----
-
-## Quick revert (search & replace)
-
-If you'd rather grep your way through:
+Before going live, confirm that the **Creator Payout jar** is set up so creator withdrawals pull from it instead of the main PHP balance:
 
 ```bash
-# Search for all test-pricing markers
-grep -rn "TEST PRICING\|TEST: ₱100\|? 100 :" \
-  app/submit/review/page.tsx \
-  convex/submissions.ts \
-  convex/schema.ts \
-  app/admin/submissions/\[id\]/page.tsx
+# Required on production Convex
+npx convex env set WISE_CREATOR_PAYOUT_BALANCE_ID "<creator_payout_jar_id>" --prod
+```
 
-# Then manually fix each match per the diffs above
+Find the jar ID via:
+```bash
+curl -H "Authorization: Bearer $WISE_API_TOKEN" \
+  "https://api.wise.com/v4/profiles/$WISE_PROFILE_ID/balances?types=SAVINGS"
+```
+
+Without this env var, creator withdrawals fall back to the main PHP balance, which mixes operating funds with creator payouts. See [WISE_PAYMENT_FLOW.md § Creator Payout Jar](../payments/WISE_PAYMENT_FLOW.md) for details.
+
+**Related code changes (already applied):**
+- `services/wise.ts` — `createQuote` accepts optional `sourceBalanceId`; `WiseConfig.creatorPayoutBalanceId` added
+- `convex/wise.ts` — `getWiseConfig()` reads `WISE_CREATOR_PAYOUT_BALANCE_ID` env var and passes it through `createQuote`
+- `docs/payments/WISE_PAYMENT_FLOW.md` — documents the Creator Payout jar flow
+
+These are permanent — do NOT revert. They apply regardless of the ₱100/₱1,500 pricing.
+
+---
+
+## What changed for testing
+
+When a creator types into the **Custom Domain (Optional)** field on the review page, the submission is auto-flagged with `submissionType: "with_custom_domain"` and the price is currently set to **₱100** instead of the production value of **₱1,500**.
+
+**Standard tier (no custom domain) is unchanged at ₱1,000.** Only the with-custom-domain tier was lowered.
+
+This is intentionally lower than the standard tier so that testing the bundled payment flow with Wise can be done with a minimal amount.
+
+---
+
+## Files changed
+
+### 1. `convex/submissions.ts`
+
+#### Change A — `submit` mutation (~line 218)
+```ts
+// CURRENT (TEST):
+const submissionAmount = hasCustomDomain ? 100 : 1000;
+
+// REVERT TO:
+const submissionAmount = hasCustomDomain ? 1500 : 1000;
+```
+
+Also update the comment above the line:
+```ts
+// CURRENT (TEST):
+// TEMP TEST PRICING: ₱100 for custom domain tier (was ₱1,500).
+// See docs/plans/CUSTOM_DOMAIN_REVERT_PRICING.md to restore.
+
+// REVERT TO:
+// Pricing: ₱1,500 if a custom domain is requested, ₱1,000 otherwise.
+// The extra ₱500 covers domain registration + setup automation.
+```
+
+#### Change B — `setDomainTier` mutation (~line 315)
+```ts
+// CURRENT (TEST):
+// TEMP TEST PRICING: ₱100 for custom domain tier (was ₱1,500)
+amount: args.submissionType === "with_custom_domain" ? 100 : 1000,
+
+// REVERT TO:
+amount: args.submissionType === "with_custom_domain" ? 1500 : 1000,
+```
+
+#### Change C — `setDomainTier` JSDoc (~line 270)
+```ts
+// CURRENT (TEST):
+ *   - "with_custom_domain"   → ₱100 (TEST PRICING — was ₱1,500), requires requestedDomain
+ * ...
+ * See docs/plans/CUSTOM_DOMAIN_REVERT_PRICING.md to restore production pricing.
+
+// REVERT TO:
+ *   - "with_custom_domain"   → ₱1,500, requires requestedDomain
+```
+(Remove the line that links back to this revert doc.)
+
+---
+
+### 2. `convex/domains.ts` (~line 20)
+
+```ts
+// CURRENT (TEST):
+const STANDARD_FEE_PHP = 1000;
+// TEMP TEST PRICING: 100 (was 1500). See docs/plans/CUSTOM_DOMAIN_REVERT_PRICING.md
+const WITH_DOMAIN_FEE_PHP = 100;
+const DEFAULT_DOMAIN_BUDGET_PHP = 500;
+
+// REVERT TO:
+const STANDARD_FEE_PHP = 1000;
+const WITH_DOMAIN_FEE_PHP = 1500;
+const DEFAULT_DOMAIN_BUDGET_PHP = 500;
+```
+
+(Remove the comment line.)
+
+---
+
+### 3. `app/(app)/submit/review.tsx`
+
+#### Change A — `totalAmount` derivation (~line 89)
+```ts
+// CURRENT (TEST):
+// TEMP TEST PRICING: ₱100 for custom domain tier (was ₱1,500).
+// See docs/plans/CUSTOM_DOMAIN_REVERT_PRICING.md to restore.
+const totalAmount = wantsCustomDomain ? 100 : 1000;
+
+// REVERT TO:
+const totalAmount = wantsCustomDomain ? 1500 : 1000;
+```
+
+#### Change B — Body text in the custom domain card (~line 766)
+```tsx
+// CURRENT (TEST):
+<Text className="text-xs text-zinc-600 leading-5 mb-3">
+  Type a domain to add a custom domain — your fee automatically becomes
+  ₱100 (TEST PRICING) and includes year 1 of the domain.
+</Text>
+
+// REVERT TO:
+<Text className="text-xs text-zinc-600 leading-5 mb-3">
+  Type a domain to add a custom domain — your fee automatically becomes
+  ₱1,500 and includes year 1 of the domain.
+</Text>
+```
+
+#### Change C — Header badge (~line 754)
+```tsx
+// CURRENT (TEST):
+{wantsCustomDomain && (
+  <View className="ml-2 px-2 py-0.5 bg-amber-100 rounded-full">
+    <Text className="text-amber-700 text-[10px] font-bold">TEST ₱100</Text>
+  </View>
+)}
+
+// REVERT TO:
+{wantsCustomDomain && (
+  <View className="ml-2 px-2 py-0.5 bg-emerald-100 rounded-full">
+    <Text className="text-emerald-700 text-[10px] font-bold">+₱500</Text>
+  </View>
+)}
+```
+
+#### Change D — Total fee breakdown card (~line 922)
+```tsx
+// CURRENT (TEST):
+{/* TEST MODE notice — replaces the production breakdown card.
+    See docs/plans/CUSTOM_DOMAIN_REVERT_PRICING.md to restore. */}
+{wantsCustomDomain && (
+  <View className="border-t border-amber-200 pt-3 mt-1">
+    <View className="flex-row items-center">
+      <Ionicons name="flask-outline" size={14} color="#d97706" />
+      <Text className="text-amber-700 text-xs font-bold ml-1">
+        TEST PRICING — ₱100 flat (production: ₱1,500)
+      </Text>
+    </View>
+  </View>
+)}
+
+// REVERT TO:
+{/* Breakdown when custom domain is selected */}
+{wantsCustomDomain && (
+  <View className="border-t border-emerald-200 pt-3 mt-1">
+    <View className="flex-row justify-between mb-1">
+      <Text className="text-emerald-700 text-xs">Website creation</Text>
+      <Text className="text-emerald-700 text-xs font-medium">₱1,000</Text>
+    </View>
+    <View className="flex-row justify-between">
+      <Text className="text-emerald-700 text-xs">
+        Custom domain (year 1 + setup)
+      </Text>
+      <Text className="text-emerald-700 text-xs font-medium">₱500</Text>
+    </View>
+  </View>
+)}
 ```
 
 ---
 
-## After reverting
+## Things that DID NOT change (and should stay as-is)
 
-1. **Delete this file** — `plans/REVERT-CUSTOM-DOMAIN-PRICING.md`
-2. **Run** `npm run build` to confirm no broken references
-3. **Run** `npm test` to confirm Jest tests still pass (50 tests)
-4. **Deploy** to Convex: `npx convex deploy` (schema comment change is cosmetic but the deploy refreshes generated types)
-5. **Smoke test**: visit the review page on a draft submission, type a domain, confirm the total summary shows ₱1,500 again
+These reference ₱500 / ₱1,500 for domain budget logic, NOT the bundled fee. **Do not touch them when reverting:**
 
----
-
-## What stays the same (do NOT change)
-
-These are unrelated and should remain at their current values:
-
-- **Standard tier price**: ₱1,000 (only the with_custom_domain tier was lowered)
-- **Domain budget**: ₱500 max for Hostinger registration (this is the budget the platform allocates for the actual domain cost — independent of the tier price)
-- **Renewal disclaimer text**: still mentions "~₱1,120/year for year 2+" — this is the actual Hostinger renewal cost the business owner will eventually pay, not a tier price
-- **Wise payment flow**: still uses `submission.amount` so once you revert to 1500, the payment email and webhook matching will use the correct amount automatically
+- `DEFAULT_DOMAIN_BUDGET_PHP = 500` in `convex/domains.ts` — this is the per-domain registration budget cap (Hostinger price ceiling), not the test fee
+- All `₱500 budget` references in `review.tsx` (e.g. line 239, 815, 979) — these refer to the domain price cap shown in availability errors, not the bundled fee
 
 ---
 
-## Files that mention 1500 but should NOT change
+## How to revert (3-step checklist)
 
-These contain ₱1,500 references in documentation/architecture text — they describe the production pricing model and don't need to be edited for testing:
+1. **Apply the file edits above** — search the codebase for `CUSTOM_DOMAIN_REVERT_PRICING` to find every spot that has a TEST comment pointing here
+2. **Push to Convex production:**
+   ```powershell
+   cd C:\dev\ndm
+   npx convex deploy
+   ```
+3. **Rebuild the mobile APK** with the production env:
+   ```powershell
+   Set-Location 'C:\dev\ndm\android'
+   $env:NODE_OPTIONS='--max-old-space-size=8192'
+   .\gradlew.bat assembleRelease --no-daemon -PreactNativeArchitectures=arm64-v8a
+   ```
 
-- `docs/changes/CUSTOM-DOMAIN-PURCHASE-PLAN.md`
-- `docs/changes/HOSTINGER-CUSTOM-DOMAIN.md`
-- `docs/wise/WISE-PAYMENT-RE-ENGINEERING.md`
-- `docs/wise/WISE-PAYMENT-FLOW-MOBILE.md`
-- `docs/wise/WISE-PAYMENT-ARCHITECTURE.md`
+After reverting, do a final sanity check:
+- Open the review page in the rebuilt APK
+- Type a domain → fee should jump to ₱1,500 (not ₱100)
+- Total fee card should show the ₱1,000 + ₱500 breakdown
+- Header badge should be the green `+₱500` chip (not amber `TEST ₱100`)
+- Submit a test submission → check `submissions[id].amount === 1500` in the Convex dashboard
 
-(Doc text still says ₱1,500 because that's the real production price. The code is the only thing currently overriding it for testing.)
+---
+
+## Search keys to find all change sites quickly
+
+```
+grep -r "CUSTOM_DOMAIN_REVERT_PRICING" .
+grep -rn "TEST PRICING" convex app
+grep -n "TEMP TEST PRICING" convex
+```
+
+Each occurrence is paired with a `// REVERT` reminder in the code itself.

--- a/plans/SCHEMA-UPDATE-WEB-TO-MOBILE.md
+++ b/plans/SCHEMA-UPDATE-WEB-TO-MOBILE.md
@@ -1,0 +1,254 @@
+# Schema Updates for Mobile Platform
+
+This document details the recent schema updates and function additions made on the web platform (Admin/Creator Dashboard). 
+
+**Attention Mobile AI Agent**: When running `npx convex deploy` on the mobile repository, you may encounter schema validation errors like:
+> `Object contains extra field domainCostPHP that is not in the validator.`
+
+This happens because the production Convex database now expects or contains new fields added from the web branch. You must update your local `convex/schema.ts` to include these missing fields (most importantly as `v.optional(...)`) so that your deploy succeeds without rejecting the existing production data.
+
+## 1. `creators` Table Changes
+Several fields were added to track creator status, payouts, and referrals:
+- `email`: `v.string()` — Made required.
+- `firstName`, `lastName`, `balance`, `referralCode`: Changed to `v.optional(...)`.
+- `role`, `status`: Changed from `v.union(...)` to `v.optional(v.string())` for cross-deploy safety.
+- **New Fields Added**:
+  - `profileImage`: `v.optional(v.string())`
+  - `wiseEmail`: `v.optional(v.string())`
+  - `certifiedAt`: `v.optional(v.number())`
+  - `isDeleted`: `v.optional(v.boolean())`
+  - `deletedAt`: `v.optional(v.number())`
+  - `referredByName`: `v.optional(v.string())`
+  - `payoutMethod`: `v.optional(v.string())`
+  - `payoutDetails`: `v.optional(v.string())`
+  - `totalWithdrawn`, `submissionCount`, `lastActiveAt`, `referredByCode`: `v.optional(...)`
+- **Indexes**: 
+  - Renamed index `by_clerkId` to `by_clerk_id` to match the mobile schema.
+
+## 2. `submissions` Table Changes
+The `submissions` table received extensive changes, largely to support custom domain workflow, Airtable syncing, and transcription metadata.
+- `photos`, `videoStorageId`, `audioStorageId`: Changed to `v.optional(...)` strings instead of unions.
+- `amount`, `creatorPayout`: Changed to `v.optional(v.number())`.
+- `status`: Changed from a strict union to `v.string()` for cross-deploy safety.
+- **New General Fields**:
+  - `transcriptionError`: `v.optional(v.string())`
+  - `transcriptionUpdatedAt`: `v.optional(v.number())`
+  - `province`, `barangay`, `postalCode`: `v.optional(v.string())`
+  - `coordinates`: `v.optional(v.object({ lat: v.number(), lng: v.number() }))`
+  - `businessDescription`: `v.optional(v.string())`
+  - `hasProducts`: `v.optional(v.boolean())`
+  - `aiGeneratedContent`: `v.optional(v.any())`
+- **Admin & Review Tracking Fields**:
+  - `reviewedBy`: `v.optional(v.string())`
+  - `reviewedAt`: `v.optional(v.number())`
+  - `rejectionReason`: `v.optional(v.string())`
+  - `platformFee`: `v.optional(v.number())`
+  - `sentEmailAt`: `v.optional(v.number())`
+  - `unpublishedAt`: `v.optional(v.number())`
+- **Airtable Sync Fields**:
+  - `airtableRecordId`: `v.optional(v.string())`
+  - `airtableSyncStatus`: `v.optional(v.string())`
+- **CUSTOM DOMAIN FIELDS (Crucial for Deploy Error)**:
+  - `submissionType`: `v.optional(v.union(v.literal('standard'), v.literal('with_custom_domain')))`
+  - `requestedDomain`: `v.optional(v.string())`
+  - `domainStatus`: `v.optional(v.union(v.literal('not_requested'), v.literal('pending_payment'), v.literal('registering'), v.literal('configuring_dns'), v.literal('provisioning_ssl'), v.literal('live'), v.literal('failed')))`
+  - `domainFailureReason`: `v.optional(v.string())`
+  - `registrarOrderId`: `v.optional(v.string())`
+  - `domainExpiresAt`: `v.optional(v.number())`
+  - `domainCostPHP`: `v.optional(v.number())` *(This caused the deploy error!)*
+  - `cloudflareZoneId`: `v.optional(v.string())`
+- **Indexes**:
+  - Added indexes: `by_payoutRequested`, `by_airtable_sync`, `by_creator_status`, `by_city`, `by_domainStatus`. Rename `by_creatorId` to `by_creator_id`.
+
+## 3. `generatedWebsites` Table Changes
+- Status became `v.optional(v.union(v.literal('draft'), v.literal('published')))`.
+- Added Cloudflare fields: `cfPagesProjectName`, `subdomain`, `customDomain` (all optional strings).
+- Merged content fields from mobile branch direct into `generatedWebsites`.
+
+## 4. `websiteContent` Table Changes
+- Added customization schema styles like `galleryStyle`, `contactStyle` and legacy fields (`heroSubHeadline`, `airtableSyncedAt`).
+
+## 5. newly defined tables
+- `auditLogs`
+- `earnings`
+- `withdrawals`
+- `payoutMethods`
+- `leads` and `leadNotes`
+- `notifications`
+- `pushTokens`
+- `referrals`
+- `analytics` and `websiteAnalytics`
+- `settings`
+- `paymentTokens`
+- `rateLimits`
+
+## New Functions (Overview)
+- **`submissions.ts`**:
+  - `updateStatus`: Now accepts `unpublished`.
+  - `setDomainTier`: New mutation for users/admins to choose standard vs. custom domain tier, assigning costs.
+  - `submit`: Refactored to fire Airtable syncing and analytical updates automatically upon submission.
+  - `getByIdInternal`: Internal helper to skip auth/public blocks.
+- **`analytics.ts`**:
+  - `getAllAnalytics`: Ensure this public function is not deleted, as the admin dashboard relies on it.
+- **`admin.ts`**:
+  - `checkBackfillNeeded`: Ensure this public function is preserved for admin features.
+- **`domains.ts`**:
+  - `getTotalHostingerDomainCostsPHP`: Ensure this public function is preserved.
+  - Multiple function updates to support the new submission review process (`approveSubmission`), tracking domain pricing (`domainCostPHP`), and integration with Cloudflare/hostinger via the new `domainStatus` lifecycle.
+
+### Important Environment Variables
+The web platform relies on certain environment variables to function correctly. When deploying or updating backend logic (like in `submissions.ts`), ensure the `ADMIN_CLERK_IDS` environment variable is checked or gracefully handled to prevent crashes like `Uncaught Error: No admin users configured. Set ADMIN_CLERK_IDS environment variable.`.
+
+### Action Items for Mobile Agent
+Copy the exact `domainCostPHP: v.optional(v.number()),` and related custom domain fields into the `submissions` validator in the mobile `convex/schema.ts` file to allow `npx convex deploy` to pass. Treat all newly introduced structure fields from the web as `v.optional(...)` if mobile doesn't populate them directly.
+
+**CRITICAL**: Do not remove the following files or their exported public functions when syncing backend code from mobile to production, as they will break the Admin Web Platform. Here is the exact code for the functions that must be included or restored:
+
+1. **`convex/analytics.ts`**
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const getAllAnalytics = query({
+    args: {
+        periodType: v.optional(v.union(v.literal('daily'), v.literal('monthly'))),
+    },
+    handler: async (ctx, args) => {
+        if (args.periodType) {
+            return await ctx.db
+                .query('analytics')
+                .withIndex('by_period', (q) => q.eq('periodType', args.periodType!))
+                .collect();
+        }
+        return await ctx.db.query('analytics').collect();
+    },
+});
+```
+
+2. **`convex/admin.ts`**
+```typescript
+import { query } from "./_generated/server";
+
+export const checkBackfillNeeded = query({
+    args: {},
+    handler: async (ctx) => {
+        try {
+            const targetStatuses = ['deployed', 'pending_payment', 'paid', 'completed'] as const;
+
+            for (const status of targetStatuses) {
+                let submission = await ctx.db
+                    .query('submissions')
+                    .withIndex('by_status', (q) => q.eq('status', status))
+                    .first();
+
+                if (submission) {
+                    const website = await ctx.db
+                        .query('generatedWebsites')
+                        .withIndex('by_submissionId', (q) => q.eq('submissionId', submission._id))
+                        .first();
+
+                    if (!submission.websiteUrl && website?.publishedUrl) {
+                        return true;
+                    }
+
+                    if (website && !website.publishedUrl && submission.websiteUrl) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        } catch (error) {
+            console.error('Error in checkBackfillNeeded:', error);
+            return false;
+        }
+    },
+});
+```
+
+3. **`convex/domains.ts`**
+```typescript
+import { query } from "./_generated/server";
+
+export const getTotalHostingerDomainCostsPHP = query({
+    args: {},
+    handler: async (ctx) => {
+        const submissions = await ctx.db
+            .query('submissions')
+            .withIndex('by_domainStatus')
+            .collect();
+            
+        let total = 0;
+        for (const s of submissions) {
+            const cost = (s as any).domainCostPHP;
+            if (typeof cost === 'number' && cost > 0) total += cost;
+        }
+        return total;
+    },
+});
+```
+
+4. **`ADMIN_CLERK_IDS` Environment Variable Handle**
+When porting user/admin checking logic (like inside `convex/submissions.ts`), avoid unconditionally throwing an error if the environment variable is missing on a new project or branch. Either ensure you have `ADMIN_CLERK_IDS` set in the convex dashboard environment variables, or wrap the error check safely, like:
+
+5. **`convex/r2.ts`**
+(If the R2 storage integrations for apk generation are missing from the mobile repository, you must restore these public endpoints for AWS SDK compatibility):
+```typescript
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+// NOTE: Make sure getR2Client, getBucketName, and getPublicUrlPrefix are defined in your module
+
+export const deleteFile = action({
+    args: { key: v.string() },
+    handler: async (ctx, args) => {
+        const client = getR2Client(); // defined in your internal r2 utils
+        const bucketName = getBucketName();
+
+        const command = new DeleteObjectCommand({
+            Bucket: bucketName,
+            Key: args.key,
+        });
+
+        await client.send(command);
+        return { success: true };
+    },
+});
+
+export const generateApkUploadUrl = action({
+    args: {
+        fileName: v.string(),
+        fileType: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const client = getR2Client();
+        const bucketName = getBucketName();
+        const publicUrlPrefix = getPublicUrlPrefix();
+
+        const timestamp = Date.now();
+        const randomStr = Math.random().toString(36).substring(2, 10);
+        const extension = args.fileName.split('.').pop() || 'apk';
+        const key = `releases/${timestamp}-${randomStr}.${extension}`;
+
+        const command = new PutObjectCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentType: args.fileType || 'application/vnd.android.package-archive',
+        });
+
+        const uploadUrl = await getSignedUrl(client, command, { expiresIn: 3600 });
+        const publicUrl = `${publicUrlPrefix}/${key}`;
+
+        return { uploadUrl, publicUrl, key };
+    },
+});
+```
+
+---
+
+### Wise & Hostinger Integrations (Schema Verification Check)
+To make your deployment succeed and handle web features safely, double-check that your `convex/schema.ts` on mobile includes both the **Hostinger custom domain properties** and **Wise payout properties**.
+
+1. **Hostinger (in `submissions`)**: Double check the above list under `submissions` is exactly replicated. In particular: `domainStatus`, `domainFailureReason`, `registrarOrderId`, `domainCostPHP`, `domainExpiresAt`, `cloudflareZoneId`, `requestedDomain`, `submissionType`.
+2. **Wise (in `creators`, `withdrawals`, `earnings`, and `paymentTokens`)**: Ensure `wiseEmail` exists in `creators`. The `withdrawals` and `earnings` schema must include tracking attributes: `wiseRecipientId`, `wiseTransferId`, `wiseTransactionId`, `wiseStatus`, `wiseDetailedState`, and `lastStatusCheckAt`. All these must be mapped safely as `v.optional(...)` fields on the mobile side.


### PR DESCRIPTION
## Summary

- **New admin action — Save & Publish Edits.** Adds a single-click flow for pushing post-completion field edits (phone, address, business name, etc.) to the live Cloudflare Worker. Chains `api.submissions.update` → `/api/generate-website` → `/api/publish-website`. Replaces the previous manual Save → Generate → Republish sequence.
- **Custom domain pricing reverted to ₱1,500.** Removes the temporary ₱100 test pricing that was in place while validating the Wise → Hostinger → Cloudflare pipeline end-to-end. Touches `setDomainTier`, `submit`, the review page `totalAmount`/copy/badge, and the schema comment.
- **Wise funding hardened.** Transfer funding now uses the v3 profile-scoped endpoint and pulls from the Creator Payout jar (`WISE_CREATOR_PAYOUT_BALANCE_ID`) when set, falling back to the main PHP balance otherwise.

## Changes

### Feature: Save & Publish Edits
- [app/admin/submissions/[id]/page.tsx](app/admin/submissions/[id]/page.tsx) — new `handleSaveAndPublishEdits` handler with a 3-stage state (`saving | generating | publishing`) and a button positioned between Visit Published Site and Unpublish. Only renders when `websitePublishedUrl` is set.

### Revert: ₱100 → ₱1,500 pricing
- [convex/submissions.ts](convex/submissions.ts) — `setDomainTier` amount back to `1500`; `submit` now respects the tier-based amount (`hasCustomDomain ? 1500 : 1000`) instead of hardcoding `1000`, which would have overwritten any tier upsell at submission time
- [convex/schema.ts](convex/schema.ts) — stale tier comment updated
- [app/submit/review/page.tsx](app/submit/review/page.tsx) — `totalAmount`, body copy, badge, and within-budget message all back to production values
- [plans/REVERT-CUSTOM-DOMAIN-PRICING.md](plans/REVERT-CUSTOM-DOMAIN-PRICING.md) — rewritten as a reference artifact now that revert is complete

### Wise funding fix
- [lib/payments/wise-api.ts](lib/payments/wise-api.ts) — `POST /v1/transfers/:id/payments` → `POST /v3/profiles/:profileId/transfers/:id/payments`, optional `sourceBalanceId` from `WISE_CREATOR_PAYOUT_BALANCE_ID` env var

## Deploy steps

1. Push Convex: `npx convex deploy` (required for the `update` mutation to accept `transcript` and the new pricing to take effect)
2. Set on production Convex: `npx convex env set WISE_CREATOR_PAYOUT_BALANCE_ID "<jar_id>" --prod` — without this, creator withdrawals fall back to the main PHP balance
3. Deploy Next.js

