### PR TITLE
Patch: Mobile function parity, direct-Groq transcription, delete cascade

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -856,9 +856,26 @@ export default function SubmissionDetailPage() {
                 body: JSON.stringify({ submissionId: submissionData._id }),
             })
 
+            const data = await response.json().catch(() => ({} as any))
+
             if (!response.ok) {
-                const errorData = await response.json()
-                throw new Error(errorData.error || 'Failed to delete submission')
+                throw new Error(data?.error || 'Failed to delete submission')
+            }
+
+            // If some external asset (Airtable, Cloudflare, R2) failed to delete,
+            // show a warning before navigating away — otherwise orphan records are
+            // invisible to the admin.
+            const failed: Array<{ asset: string; error: string }> = data?.failedAssets || []
+            if (failed.length > 0) {
+                setShowDeleteModal(false)
+                setModalType('error')
+                setModalMessage(
+                    `Submission record deleted, but ${failed.length} external ${failed.length === 1 ? 'asset' : 'assets'} could not be cleaned up:\n\n` +
+                    failed.map((f) => `• ${f.asset}: ${f.error}`).join('\n') +
+                    `\n\nThese may need manual cleanup.`
+                )
+                setShowModal(true)
+                return
             }
 
             // Redirect to admin dashboard after successful deletion

--- a/app/api/delete-submission/route.ts
+++ b/app/api/delete-submission/route.ts
@@ -6,12 +6,27 @@ import { Id } from '@/convex/_generated/dataModel'
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3'
 
 /**
- * Extract R2 key from a public URL.
- * E.g., "https://pub-xxx.r2.dev/images/1234-abc.jpg" → "images/1234-abc.jpg"
+ * Extract R2 key from a stored value. Handles two shapes:
+ *   1. Full public URL ("https://pub-xxx.r2.dev/images/1234-abc.jpg") — strip the prefix.
+ *   2. Relative R2 path ("audio/1776945779223-fdhx1veh.m4a") — return as-is.
+ *
+ * The mobile APK writes relative paths into *StorageId fields; web writes full
+ * URLs into *Url fields. This handles both. Returns null only when the value
+ * clearly isn't an R2 asset (empty, Convex storage ID, or a foreign URL).
  */
-function extractR2Key(url: string, r2PublicUrl: string | undefined): string | null {
-    if (!r2PublicUrl || !url.startsWith(r2PublicUrl)) return null
-    return url.replace(r2PublicUrl + '/', '')
+function extractR2Key(value: string | undefined | null, r2PublicUrl: string | undefined): string | null {
+    if (!value) return null
+    // Relative R2 path under a known folder
+    if (/^(images|videos|audio|avatars)\//.test(value)) return value
+    // Full URL — must match our R2 public URL prefix
+    if (value.startsWith('http')) {
+        if (r2PublicUrl && value.startsWith(r2PublicUrl)) {
+            return value.replace(r2PublicUrl + '/', '')
+        }
+        // Foreign URL — not one of our R2 keys, skip
+        return null
+    }
+    return null
 }
 
 /**
@@ -218,54 +233,58 @@ export async function POST(request: NextRequest) {
                     requestHandler: { requestTimeout: 10_000 },
                 })
 
-                // Collect all R2 URLs to delete from ALL sources
-                const r2Urls: string[] = []
+                // Collect all R2 references (full URLs AND relative paths) to delete from ALL sources.
+                // Mobile stores R2 keys in *StorageId fields; web stores full URLs in *Url fields.
+                // We accept either shape — extractR2Key below normalizes them into bucket keys.
+                const r2Refs: string[] = []
 
-                // Source 1: Submission photos
+                // Source 1: Submission photos (strings — may be full URLs OR relative paths)
                 if (submission.photos && Array.isArray(submission.photos)) {
                     for (const photo of submission.photos) {
-                        if (typeof photo === 'string' && photo.startsWith('http')) {
-                            r2Urls.push(photo)
+                        if (typeof photo === 'string' && photo) {
+                            r2Refs.push(photo)
                         }
                     }
                 }
-                const submissionPhotoCount = r2Urls.length
+                const submissionPhotoCount = r2Refs.length
 
-                // Source 2: Submission video URL
-                if (submission.videoUrl && submission.videoUrl.startsWith('http')) {
-                    r2Urls.push(submission.videoUrl)
+                // Source 2 + 2b: Submission video (both URL and storageId — mobile uses storageId)
+                if (submission.videoUrl) r2Refs.push(submission.videoUrl)
+                if (submission.videoStorageId && typeof submission.videoStorageId === 'string') {
+                    r2Refs.push(submission.videoStorageId)
                 }
 
-                // Source 3: Submission audio URL
-                if (submission.audioUrl && submission.audioUrl.startsWith('http')) {
-                    r2Urls.push(submission.audioUrl)
+                // Source 3 + 3b: Submission audio (same — both URL and storageId fields)
+                if (submission.audioUrl) r2Refs.push(submission.audioUrl)
+                if (submission.audioStorageId && typeof submission.audioStorageId === 'string') {
+                    r2Refs.push(submission.audioStorageId)
                 }
 
                 // Source 4: Enhanced images from generatedWebsites (top-level)
                 const enhancedFromWebsite = collectEnhancedImageUrls(website?.enhancedImages)
-                r2Urls.push(...enhancedFromWebsite)
+                r2Refs.push(...enhancedFromWebsite)
 
                 // Source 5: Enhanced images from generatedWebsites.extractedContent
                 const enhancedFromExtracted = collectEnhancedImageUrls((website?.extractedContent as any)?.enhancedImages)
-                r2Urls.push(...enhancedFromExtracted)
+                r2Refs.push(...enhancedFromExtracted)
 
                 // Source 6: Enhanced images from websiteContent
                 const enhancedFromContent = collectEnhancedImageUrls(websiteContent?.enhancedImages)
-                r2Urls.push(...enhancedFromContent)
+                r2Refs.push(...enhancedFromContent)
 
                 // Source 7: Section images from generatedWebsites.images
                 const sectionFromWebsite = collectSectionImageUrls(website?.images)
-                r2Urls.push(...sectionFromWebsite)
+                r2Refs.push(...sectionFromWebsite)
 
                 // Source 8: Section images from websiteContent.images
                 const sectionFromContent = collectSectionImageUrls(websiteContent?.images)
-                r2Urls.push(...sectionFromContent)
+                r2Refs.push(...sectionFromContent)
 
                 // Source 9: Featured images from generatedWebsites
                 if (website?.featuredImages && Array.isArray(website.featuredImages)) {
                     for (const img of website.featuredImages) {
-                        if (typeof img === 'string' && img.startsWith('http')) {
-                            r2Urls.push(img)
+                        if (typeof img === 'string' && img) {
+                            r2Refs.push(img)
                         }
                     }
                 }
@@ -273,31 +292,31 @@ export async function POST(request: NextRequest) {
                 // Source 10: Featured images from websiteContent
                 if (websiteContent?.featuredImages && Array.isArray(websiteContent.featuredImages)) {
                     for (const img of websiteContent.featuredImages) {
-                        if (typeof img === 'string' && img.startsWith('http')) {
-                            r2Urls.push(img)
+                        if (typeof img === 'string' && img) {
+                            r2Refs.push(img)
                         }
                     }
                 }
 
-                // Deduplicate URLs
-                const uniqueR2Urls = [...new Set(r2Urls)]
+                // Normalize all refs → R2 object keys, dedupe, drop anything that
+                // isn't one of our R2 assets (foreign URLs, Convex storage IDs, etc).
+                const resolvedKeys = r2Refs
+                    .map(ref => extractR2Key(ref, r2PublicUrl))
+                    .filter((key): key is string => key !== null)
+                const uniqueKeys = [...new Set(resolvedKeys)]
 
-                console.log(`[delete-submission] R2 URLs collected: ${uniqueR2Urls.length} unique (${r2Urls.length} total before dedup)`)
+                console.log(`[delete-submission] R2 refs collected: ${r2Refs.length} raw → ${resolvedKeys.length} resolved → ${uniqueKeys.length} unique`)
                 console.log(`[delete-submission]   - submission.photos: ${submissionPhotoCount}`)
-                console.log(`[delete-submission]   - submission.videoUrl: ${submission.videoUrl ? 1 : 0}`)
-                console.log(`[delete-submission]   - submission.audioUrl: ${submission.audioUrl ? 1 : 0}`)
+                console.log(`[delete-submission]   - submission.videoUrl: ${submission.videoUrl ? 1 : 0}, videoStorageId: ${submission.videoStorageId ? 1 : 0}`)
+                console.log(`[delete-submission]   - submission.audioUrl: ${submission.audioUrl ? 1 : 0}, audioStorageId: ${submission.audioStorageId ? 1 : 0}`)
                 console.log(`[delete-submission]   - enhanced (website): ${enhancedFromWebsite.length}`)
                 console.log(`[delete-submission]   - enhanced (extractedContent): ${enhancedFromExtracted.length}`)
                 console.log(`[delete-submission]   - enhanced (websiteContent): ${enhancedFromContent.length}`)
                 console.log(`[delete-submission]   - section images (website): ${sectionFromWebsite.length}`)
                 console.log(`[delete-submission]   - section images (content): ${sectionFromContent.length}`)
 
-                // Extract keys and delete
                 const r2Results = await Promise.allSettled(
-                    uniqueR2Urls
-                        .map(url => extractR2Key(url, r2PublicUrl))
-                        .filter((key): key is string => key !== null)
-                        .map(key => deleteR2File(r2Client, r2BucketName, key))
+                    uniqueKeys.map(key => deleteR2File(r2Client, r2BucketName, key))
                 )
 
                 let r2Deleted = 0

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -14,18 +14,36 @@ export async function POST(request: NextRequest) {
     let submissionId: string | undefined
 
     try {
-        // Check Clerk authentication
-        const { userId } = await auth()
-        if (!userId) {
-            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-        }
+        // Allow server-to-server calls from Convex (scheduled transcribeMedia action)
+        // to bypass Clerk auth via a shared secret header. Server-side only —
+        // never surface this header to the browser.
+        const providedSecret = request.headers.get('X-Internal-Secret')
+        const expectedSecret = process.env.INTERNAL_API_SECRET
+        const isInternalCall = !!expectedSecret && providedSecret === expectedSecret
 
-        // Rate limit: expensive operation (5/min)
-        const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security')
-        const { allowed } = checkRateLimit(`transcribe:${userId}`, RATE_LIMITS.expensive.maxRequests, RATE_LIMITS.expensive.windowMs)
-        if (!allowed) {
-            return NextResponse.json({ error: 'Too many transcription requests. Please wait a moment.' }, { status: 429 })
+        let authedUserId: string | null = null
+        if (!isInternalCall) {
+            const { userId } = await auth()
+            if (!userId) {
+                return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+            }
+            authedUserId = userId
+
+            // Rate limit: expensive operation (5/min) — only applied to user-initiated calls.
+            // Internal calls come from our own scheduler so we don't rate-limit them.
+            const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security')
+            const { allowed } = checkRateLimit(
+                `transcribe:${userId}`,
+                RATE_LIMITS.expensive.maxRequests,
+                RATE_LIMITS.expensive.windowMs
+            )
+            if (!allowed) {
+                return NextResponse.json({ error: 'Too many transcription requests. Please wait a moment.' }, { status: 429 })
+            }
         }
+        // Suppress unused-var warning when called as internal (userId may be used
+        // later for per-user audit logs).
+        void authedUserId
 
         const body = await request.json()
         const { audioUrl, useConvexStorage, videoStorageId, audioStorageId, videoUrl } = body

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as leads from "../leads.js";
 import type * as lib_cloudflare from "../lib/cloudflare.js";
 import type * as lib_fxRate from "../lib/fxRate.js";
 import type * as lib_hostinger from "../lib/hostinger.js";
+import type * as lib_mediaChunker from "../lib/mediaChunker.js";
 import type * as lib_wise from "../lib/wise.js";
 import type * as migrations_migrateContent from "../migrations/migrateContent.js";
 import type * as notifications from "../notifications.js";
@@ -64,6 +65,7 @@ declare const fullApi: ApiFromModules<{
   "lib/cloudflare": typeof lib_cloudflare;
   "lib/fxRate": typeof lib_fxRate;
   "lib/hostinger": typeof lib_hostinger;
+  "lib/mediaChunker": typeof lib_mediaChunker;
   "lib/wise": typeof lib_wise;
   "migrations/migrateContent": typeof migrations_migrateContent;
   notifications: typeof notifications;

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -266,6 +266,71 @@ export const rejectSubmission = mutation({
 /**
  * Mark a submission as deployed — triggers audit + notification + analytics
  */
+/**
+ * Mark a submission as having a generated website.
+ *
+ * Referenced by the mobile app (Google Play binary) — keep exported. See
+ * docs/00-Overview-Mobile.md §admin.
+ */
+export const markWebsiteGenerated = mutation({
+    args: {
+        submissionId: v.id('submissions'),
+        adminId: v.string(),
+        websiteUrl: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const submission = await ctx.db.get(args.submissionId);
+        if (!submission) throw new Error('Submission not found');
+
+        const updates: Record<string, unknown> = { status: 'website_generated' };
+        if (args.websiteUrl) updates.websiteUrl = args.websiteUrl;
+        await ctx.db.patch(args.submissionId, updates);
+
+        await ctx.scheduler.runAfter(0, internal.auditLogs.log, {
+            adminId: args.adminId,
+            action: 'website_generated',
+            targetType: 'submission',
+            targetId: args.submissionId,
+            metadata: { businessName: submission.businessName, websiteUrl: args.websiteUrl },
+        });
+
+        return args.submissionId;
+    },
+});
+
+/**
+ * Alias for submissions.getAllWithCreator — mobile references it as
+ * `admin.getAllSubmissionsWithCreators`. Keep exported.
+ */
+export const getAllSubmissionsWithCreators = query({
+    args: {},
+    handler: async (ctx) => {
+        const submissions = await ctx.db
+            .query('submissions')
+            .order('desc')
+            .collect();
+
+        return Promise.all(
+            submissions.map(async (submission) => {
+                const creator = await ctx.db.get(submission.creatorId);
+                return {
+                    ...submission,
+                    creator: creator
+                        ? {
+                              _id: creator._id,
+                              firstName: creator.firstName,
+                              lastName: creator.lastName,
+                              email: creator.email,
+                              phone: creator.phone,
+                              profileImage: creator.profileImage,
+                          }
+                        : null,
+                };
+            })
+        );
+    },
+});
+
 export const markDeployed = mutation({
     args: {
         submissionId: v.id('submissions'),

--- a/convex/creators.ts
+++ b/convex/creators.ts
@@ -51,6 +51,31 @@ export const getByEmail = query({
 });
 
 /**
+ * Check whether an email matches a soft-deleted creator account.
+ *
+ * Mobile-referenced — do NOT remove, do NOT add an auth guard. Called
+ * unauthenticated from the mobile signup + forgot-password screens the moment
+ * the form mounts, so the caller is by definition not yet signed in. Any
+ * `requireAuth` / `requireAdmin` wrapper here produces `Server Error` on the
+ * client and totally blocks new-user signup on the Google Play APK.
+ *
+ * See docs/changes/MOBILE-REGISTER-ERROR.md for the incident that caused
+ * signup outage on 2026-04-23 when this query was missing from the web repo.
+ *
+ * Returns only a boolean — does not expose any account metadata.
+ */
+export const isDeletedByEmail = query({
+    args: { email: v.string() },
+    handler: async (ctx, args) => {
+        const creator = await ctx.db
+            .query('creators')
+            .withIndex('by_email', (q) => q.eq('email', args.email))
+            .first();
+        return creator?.isDeleted === true;
+    },
+});
+
+/**
  * Get creator by referral code
  */
 export const getByReferralCode = query({

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -13,12 +13,33 @@ export const generateUploadUrl = mutation({
 });
 
 /**
- * Get a URL for a stored file
+ * Get a URL for a stored file.
+ *
+ * Accepts any of: a full URL, an R2 relative path (images/..., videos/...,
+ * audio/...), a `convex:` prefixed ID, or a raw Convex storage ID. Mobile APK
+ * calls this with R2 object keys, which are not Convex storage IDs — a strict
+ * v.id('_storage') validator would reject those before the handler runs.
+ * Mobile-referenced — do not tighten the validator back.
  */
 export const getUrl = query({
-    args: { storageId: v.id('_storage') },
+    args: { storageId: v.string() },
     handler: async (ctx, args) => {
-        return await ctx.storage.getUrl(args.storageId);
+        const idString = args.storageId;
+        const r2PublicUrl = process.env.R2_PUBLIC_URL?.replace(/\/$/, '');
+        try {
+            if (idString.startsWith('http://') || idString.startsWith('https://')) {
+                return idString;
+            }
+            if (/^(images|videos|audio)\//.test(idString) && r2PublicUrl) {
+                return `${r2PublicUrl}/${idString}`;
+            }
+            const storageId = idString.startsWith('convex:')
+                ? idString.replace('convex:', '')
+                : idString;
+            return await ctx.storage.getUrl(storageId as Id<"_storage">);
+        } catch {
+            return null;
+        }
     },
 });
 
@@ -96,11 +117,23 @@ export const getMultipleUrls = query({
 });
 
 /**
- * Delete a file from storage
+ * Delete a file from Convex storage.
+ *
+ * Accepts a string for cross-caller compatibility. If the string looks like
+ * an R2 relative path or a full URL, Convex storage deletion is skipped
+ * (R2 files must be deleted through `r2.deleteFile`). Mobile-referenced —
+ * do not tighten the validator.
  */
 export const deleteFile = mutation({
-    args: { storageId: v.id('_storage') },
+    args: { storageId: v.string() },
     handler: async (ctx, args) => {
-        await ctx.storage.delete(args.storageId);
+        const s = args.storageId;
+        const looksLikeR2 = s.startsWith('http://') || s.startsWith('https://') || /^(images|videos|audio)\//.test(s);
+        if (looksLikeR2) {
+            console.warn(`[files.deleteFile] Called with R2 path "${s}" — skipping Convex storage delete. Use r2.deleteFile for R2 files.`);
+            return;
+        }
+        const id = s.startsWith('convex:') ? s.replace('convex:', '') : s;
+        await ctx.storage.delete(id as Id<"_storage">);
     },
 });

--- a/convex/lib/mediaChunker.ts
+++ b/convex/lib/mediaChunker.ts
@@ -1,0 +1,1173 @@
+/**
+ * Pure JS media file chunker for splitting large audio/video files
+ * into valid segments that fit within Groq Whisper's 25MB limit.
+ *
+ * Supports:
+ * - WebM (Opus/VP9): Split at EBML Cluster boundaries
+ * - MP3: Split at frame sync word boundaries
+ * - WAV: Split PCM data with header duplication
+ */
+
+const DEFAULT_MAX_CHUNK_SIZE = 22 * 1024 * 1024 // 22MB (3MB headroom under 25MB limit, accounting for multipart headers + form boundaries)
+
+// ==================== WEBM CHUNKING ====================
+
+/**
+ * WebM/Matroska EBML element IDs (big-endian)
+ * Cluster ID = 0x1F43B675 (4 bytes)
+ */
+const CLUSTER_ID = [0x1F, 0x43, 0xB6, 0x75]
+
+/**
+ * Read an EBML variable-length integer (VINT) from a buffer.
+ * Returns the value and the number of bytes consumed.
+ */
+function readEbmlVint(data: Uint8Array, offset: number): { value: number; length: number } | null {
+    if (offset >= data.length) return null
+
+    const firstByte = data[offset]
+    let length = 0
+    let mask = 0x80
+
+    // Count leading zeros to determine VINT length (1-8 bytes)
+    for (let i = 0; i < 8; i++) {
+        if (firstByte & mask) {
+            length = i + 1
+            break
+        }
+        mask >>= 1
+    }
+
+    if (length === 0 || offset + length > data.length) return null
+
+    // Read the value (first byte has the length bits masked off)
+    let value = firstByte & (mask - 1)
+    for (let i = 1; i < length; i++) {
+        value = (value << 8) | data[offset + i]
+    }
+
+    return { value, length }
+}
+
+/**
+ * Find all Cluster element boundaries in a WebM file.
+ * Returns byte offsets where each Cluster starts.
+ */
+function findClusterOffsets(data: Uint8Array): number[] {
+    const offsets: number[] = []
+
+    // Scan for Cluster ID pattern (0x1F 0x43 0xB6 0x75)
+    for (let i = 0; i < data.length - 4; i++) {
+        if (
+            data[i] === CLUSTER_ID[0] &&
+            data[i + 1] === CLUSTER_ID[1] &&
+            data[i + 2] === CLUSTER_ID[2] &&
+            data[i + 3] === CLUSTER_ID[3]
+        ) {
+            // Verify this is a valid EBML element by checking the size VINT after ID
+            const sizeVint = readEbmlVint(data, i + 4)
+            if (sizeVint) {
+                offsets.push(i)
+                // Skip past this element to avoid false matches inside data
+                // But don't skip too far — Clusters can contain the same byte pattern
+                // We'll just skip past the ID + size header
+                i += 3 + sizeVint.length
+            }
+        }
+    }
+
+    return offsets
+}
+
+/**
+ * Split a WebM file at Cluster boundaries.
+ * Each chunk gets the original header (everything before the first Cluster) prepended.
+ */
+function chunkWebM(data: Uint8Array, maxChunkSize: number): Uint8Array[] {
+    const clusterOffsets = findClusterOffsets(data)
+
+    if (clusterOffsets.length === 0) {
+        // No clusters found — return the whole file as one chunk
+        return [data]
+    }
+
+    // Everything before the first Cluster is the header (EBML Header + Segment + Tracks + Info)
+    const headerEnd = clusterOffsets[0]
+    const header = data.slice(0, headerEnd)
+
+    // If header alone is too large, we can't chunk properly
+    if (header.length >= maxChunkSize) {
+        return [data]
+    }
+
+    const maxDataPerChunk = maxChunkSize - header.length
+    const chunks: Uint8Array[] = []
+    let chunkStart = 0 // Index into clusterOffsets
+
+    while (chunkStart < clusterOffsets.length) {
+        let chunkEnd = chunkStart
+        let accumulatedSize = 0
+
+        // Add clusters until we approach the size limit
+        while (chunkEnd < clusterOffsets.length) {
+            const clusterStart = clusterOffsets[chunkEnd]
+            const clusterEnd = chunkEnd + 1 < clusterOffsets.length
+                ? clusterOffsets[chunkEnd + 1]
+                : data.length
+            const clusterSize = clusterEnd - clusterStart
+
+            if (accumulatedSize + clusterSize > maxDataPerChunk && chunkEnd > chunkStart) {
+                break
+            }
+
+            accumulatedSize += clusterSize
+            chunkEnd++
+        }
+
+        // Build chunk: header + cluster data
+        const dataStart = clusterOffsets[chunkStart]
+        const dataEnd = chunkEnd < clusterOffsets.length
+            ? clusterOffsets[chunkEnd]
+            : data.length
+        const clusterData = data.slice(dataStart, dataEnd)
+
+        const chunk = new Uint8Array(header.length + clusterData.length)
+        chunk.set(header, 0)
+        chunk.set(clusterData, header.length)
+        chunks.push(chunk)
+
+        chunkStart = chunkEnd
+    }
+
+    return chunks
+}
+
+// ==================== MP3 CHUNKING ====================
+
+/**
+ * Find MP3 frame sync word boundaries.
+ * MP3 frames start with 11 set bits (0xFFE0 mask).
+ * We validate basic header fields to avoid false sync matches.
+ */
+function findMP3FrameOffsets(data: Uint8Array): number[] {
+    const offsets: number[] = []
+
+    for (let i = 0; i < data.length - 4; i++) {
+        // Check for sync word: 0xFF followed by 0xE0+ (11 bits set)
+        if (data[i] === 0xFF && (data[i + 1] & 0xE0) === 0xE0) {
+            // Basic validation: MPEG version and layer should not be reserved
+            const version = (data[i + 1] >> 3) & 0x03
+            const layer = (data[i + 1] >> 1) & 0x03
+            const bitrateIdx = (data[i + 2] >> 4) & 0x0F
+
+            // version 01 = reserved, layer 00 = reserved, bitrate 1111 = bad
+            if (version !== 1 && layer !== 0 && bitrateIdx !== 0x0F && bitrateIdx !== 0x00) {
+                offsets.push(i)
+
+                // Calculate frame size to skip to next frame
+                const frameSize = getMP3FrameSize(data, i)
+                if (frameSize > 0) {
+                    i += frameSize - 1 // -1 because loop increments
+                }
+            }
+        }
+    }
+
+    return offsets
+}
+
+/**
+ * Calculate MP3 frame size from header.
+ */
+function getMP3FrameSize(data: Uint8Array, offset: number): number {
+    if (offset + 4 > data.length) return 0
+
+    const version = (data[offset + 1] >> 3) & 0x03
+    const layer = (data[offset + 1] >> 1) & 0x03
+    const bitrateIdx = (data[offset + 2] >> 4) & 0x0F
+    const sampleRateIdx = (data[offset + 2] >> 2) & 0x03
+    const padding = (data[offset + 2] >> 1) & 0x01
+
+    // Bitrate tables (kbps) — MPEG1 Layer III
+    const bitrates: Record<string, number[]> = {
+        // [version][layer]
+        '3_3': [0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 0], // V1 L1
+        '3_2': [0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 0],    // V1 L2
+        '3_1': [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0],     // V1 L3
+        '2_1': [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0],         // V2 L3
+    }
+
+    const sampleRates: Record<number, number[]> = {
+        3: [44100, 48000, 32000, 0], // MPEG1
+        2: [22050, 24000, 16000, 0], // MPEG2
+        0: [11025, 12000, 8000, 0],  // MPEG2.5
+    }
+
+    const key = `${version}_${layer}`
+    const bitrateTable = bitrates[key] || bitrates['3_1']
+    const bitrate = bitrateTable[bitrateIdx]
+    const sampleRate = (sampleRates[version] || sampleRates[3])[sampleRateIdx]
+
+    if (!bitrate || !sampleRate) return 0
+
+    if (layer === 3) {
+        // Layer I: frame size = (12 * bitrate / sampleRate + padding) * 4
+        return Math.floor(12 * bitrate * 1000 / sampleRate + padding) * 4
+    } else {
+        // Layer II & III: frame size = 144 * bitrate / sampleRate + padding
+        return Math.floor(144 * bitrate * 1000 / sampleRate) + padding
+    }
+}
+
+/**
+ * Split an MP3 file at frame sync boundaries.
+ */
+function chunkMP3(data: Uint8Array, maxChunkSize: number): Uint8Array[] {
+    const frameOffsets = findMP3FrameOffsets(data)
+
+    if (frameOffsets.length === 0) {
+        return [data]
+    }
+
+    // Check for ID3v2 header at the start (skip it but include in every chunk)
+    let id3Header: Uint8Array | null = null
+    if (data[0] === 0x49 && data[1] === 0x44 && data[2] === 0x33) { // "ID3"
+        // ID3v2 header: 10 bytes header + size (syncsafe integer)
+        const size = ((data[6] & 0x7F) << 21) | ((data[7] & 0x7F) << 14) |
+            ((data[8] & 0x7F) << 7) | (data[9] & 0x7F)
+        const id3End = 10 + size
+        id3Header = data.slice(0, id3End)
+    }
+
+    const headerSize = id3Header?.length || 0
+    const maxDataPerChunk = maxChunkSize - headerSize
+    const chunks: Uint8Array[] = []
+    let chunkStart = 0
+
+    while (chunkStart < frameOffsets.length) {
+        let chunkEnd = chunkStart
+        let accumulatedSize = 0
+
+        while (chunkEnd < frameOffsets.length) {
+            const frameStart = frameOffsets[chunkEnd]
+            const frameEnd = chunkEnd + 1 < frameOffsets.length
+                ? frameOffsets[chunkEnd + 1]
+                : data.length
+            const frameSize = frameEnd - frameStart
+
+            if (accumulatedSize + frameSize > maxDataPerChunk && chunkEnd > chunkStart) {
+                break
+            }
+
+            accumulatedSize += frameSize
+            chunkEnd++
+        }
+
+        const dataStart = frameOffsets[chunkStart]
+        const dataEnd = chunkEnd < frameOffsets.length
+            ? frameOffsets[chunkEnd]
+            : data.length
+        const frameData = data.slice(dataStart, dataEnd)
+
+        if (id3Header) {
+            const chunk = new Uint8Array(id3Header.length + frameData.length)
+            chunk.set(id3Header, 0)
+            chunk.set(frameData, id3Header.length)
+            chunks.push(chunk)
+        } else {
+            chunks.push(frameData)
+        }
+
+        chunkStart = chunkEnd
+    }
+
+    return chunks
+}
+
+// ==================== WAV CHUNKING ====================
+
+/**
+ * Split a WAV file by duplicating the header for each chunk of PCM data.
+ */
+function chunkWAV(data: Uint8Array, maxChunkSize: number): Uint8Array[] {
+    // Standard WAV header is 44 bytes, but may be longer with extra chunks
+    // Find the "data" subchunk
+    let dataOffset = 12 // Skip "RIFF" + size + "WAVE"
+    let dataSize = 0
+
+    while (dataOffset < data.length - 8) {
+        const chunkId = String.fromCharCode(data[dataOffset], data[dataOffset + 1], data[dataOffset + 2], data[dataOffset + 3])
+        const chunkSize = data[dataOffset + 4] | (data[dataOffset + 5] << 8) |
+            (data[dataOffset + 6] << 16) | (data[dataOffset + 7] << 24)
+
+        if (chunkId === 'data') {
+            dataSize = chunkSize
+            dataOffset += 8 // Skip "data" + size
+            break
+        }
+
+        dataOffset += 8 + chunkSize
+    }
+
+    if (dataSize === 0) {
+        return [data]
+    }
+
+    // Header = everything before PCM data
+    const header = data.slice(0, dataOffset)
+    const pcmData = data.slice(dataOffset, dataOffset + dataSize)
+
+    // Calculate bytes per sample to align chunk boundaries
+    // fmt chunk at offset 20: channels(2) + sampleRate(4) + byteRate(4) + blockAlign(2)
+    const blockAlign = data[32] | (data[33] << 8)
+    const maxPcmPerChunk = Math.floor((maxChunkSize - header.length) / blockAlign) * blockAlign
+
+    if (maxPcmPerChunk <= 0) {
+        return [data]
+    }
+
+    const chunks: Uint8Array[] = []
+    let offset = 0
+
+    while (offset < pcmData.length) {
+        const end = Math.min(offset + maxPcmPerChunk, pcmData.length)
+        const pcmChunk = pcmData.slice(offset, end)
+        const pcmChunkSize = pcmChunk.length
+
+        // Create new WAV header with updated sizes
+        const chunkHeader = new Uint8Array(header)
+        // Update RIFF chunk size (offset 4): file size - 8
+        const riffSize = chunkHeader.length - 8 + pcmChunkSize
+        chunkHeader[4] = riffSize & 0xFF
+        chunkHeader[5] = (riffSize >> 8) & 0xFF
+        chunkHeader[6] = (riffSize >> 16) & 0xFF
+        chunkHeader[7] = (riffSize >> 24) & 0xFF
+        // Update data chunk size (last 4 bytes of header before PCM)
+        const dataSizeOffset = chunkHeader.length - 4
+        chunkHeader[dataSizeOffset] = pcmChunkSize & 0xFF
+        chunkHeader[dataSizeOffset + 1] = (pcmChunkSize >> 8) & 0xFF
+        chunkHeader[dataSizeOffset + 2] = (pcmChunkSize >> 16) & 0xFF
+        chunkHeader[dataSizeOffset + 3] = (pcmChunkSize >> 24) & 0xFF
+
+        const chunk = new Uint8Array(chunkHeader.length + pcmChunkSize)
+        chunk.set(chunkHeader, 0)
+        chunk.set(pcmChunk, chunkHeader.length)
+        chunks.push(chunk)
+
+        offset = end
+    }
+
+    return chunks
+}
+
+// ==================== MP4 → AAC/ADTS EXTRACTION ====================
+//
+// Instead of building complex MP4 files (which are fragile), we extract
+// raw AAC frames from MP4 and wrap them in ADTS format — a simple
+// streaming container that Groq/Whisper can decode directly.
+//
+// ADTS = Audio Data Transport Stream. Each frame gets a 7-byte header
+// containing codec info + frame size. No moov/atoms needed.
+
+/**
+ * Read a big-endian 32-bit unsigned integer from a Uint8Array.
+ */
+function readUint32BE(data: Uint8Array, offset: number): number {
+    return (
+        ((data[offset] << 24) >>> 0) +
+        (data[offset + 1] << 16) +
+        (data[offset + 2] << 8) +
+        data[offset + 3]
+    )
+}
+
+/**
+ * Write a big-endian 32-bit unsigned integer to a Uint8Array.
+ */
+function writeUint32BE(data: Uint8Array, offset: number, value: number): void {
+    data[offset] = (value >>> 24) & 0xFF
+    data[offset + 1] = (value >>> 16) & 0xFF
+    data[offset + 2] = (value >>> 8) & 0xFF
+    data[offset + 3] = value & 0xFF
+}
+
+/**
+ * Get the 4-character type of an MP4 atom at the given offset.
+ */
+function getAtomType(data: Uint8Array, offset: number): string {
+    return String.fromCharCode(data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7])
+}
+
+/**
+ * Get atom size (handles both 32-bit and 64-bit extended sizes).
+ * Returns { size, headerSize } where headerSize is 8 or 16.
+ */
+function getAtomSize(data: Uint8Array, offset: number): { size: number; headerSize: number } {
+    const size32 = readUint32BE(data, offset)
+    if (size32 === 1) {
+        // 64-bit extended size (we read only lower 32 bits since JS numbers)
+        // For files < 4GB this is fine
+        const hi = readUint32BE(data, offset + 8)
+        const lo = readUint32BE(data, offset + 12)
+        return { size: hi * 0x100000000 + lo, headerSize: 16 }
+    }
+    if (size32 === 0) {
+        // Atom extends to end of file
+        return { size: data.length - offset, headerSize: 8 }
+    }
+    return { size: size32, headerSize: 8 }
+}
+
+/**
+ * Find a child atom within a container atom.
+ * Returns the offset of the child atom, or -1 if not found.
+ */
+function findAtom(data: Uint8Array, containerStart: number, containerEnd: number, type: string): number {
+    let offset = containerStart
+    while (offset < containerEnd - 8) {
+        const { size } = getAtomSize(data, offset)
+        if (size < 8) break
+        if (getAtomType(data, offset) === type) return offset
+        offset += size
+    }
+    return -1
+}
+
+/**
+ * Find all top-level atoms and return their offsets and types.
+ */
+function findTopLevelAtoms(data: Uint8Array): Array<{ type: string; offset: number; size: number }> {
+    const atoms: Array<{ type: string; offset: number; size: number }> = []
+    let offset = 0
+    while (offset < data.length - 8) {
+        const { size } = getAtomSize(data, offset)
+        if (size < 8) break
+        const type = getAtomType(data, offset)
+        atoms.push({ type, offset, size })
+        offset += size
+    }
+    return atoms
+}
+
+/**
+ * Read sample sizes from an `stsz` atom.
+ * Returns array of sample sizes.
+ */
+function readSampleSizes(data: Uint8Array, stszOffset: number): number[] {
+    const { headerSize } = getAtomSize(data, stszOffset)
+    const base = stszOffset + headerSize
+    // version(1) + flags(3) + sample_size(4) + sample_count(4)
+    const uniformSize = readUint32BE(data, base + 4)
+    const sampleCount = readUint32BE(data, base + 8)
+    const sizes: number[] = []
+
+    if (uniformSize > 0) {
+        // All samples have the same size
+        for (let i = 0; i < sampleCount; i++) sizes.push(uniformSize)
+    } else {
+        // Variable sizes — read each entry
+        for (let i = 0; i < sampleCount; i++) {
+            sizes.push(readUint32BE(data, base + 12 + i * 4))
+        }
+    }
+    return sizes
+}
+
+/**
+ * Read chunk offsets from `stco` (32-bit) or `co64` (64-bit) atom.
+ */
+function readChunkOffsets(data: Uint8Array, stcoOffset: number): number[] {
+    const type = getAtomType(data, stcoOffset)
+    const { headerSize } = getAtomSize(data, stcoOffset)
+    const base = stcoOffset + headerSize
+    const entryCount = readUint32BE(data, base + 4)
+    const offsets: number[] = []
+
+    if (type === 'co64') {
+        for (let i = 0; i < entryCount; i++) {
+            const hi = readUint32BE(data, base + 8 + i * 8)
+            const lo = readUint32BE(data, base + 8 + i * 8 + 4)
+            offsets.push(hi * 0x100000000 + lo)
+        }
+    } else {
+        for (let i = 0; i < entryCount; i++) {
+            offsets.push(readUint32BE(data, base + 8 + i * 4))
+        }
+    }
+    return offsets
+}
+
+/**
+ * Read sample-to-chunk mapping from `stsc` atom.
+ * Returns array of { firstChunk, samplesPerChunk, descriptionIndex }.
+ */
+function readSampleToChunk(data: Uint8Array, stscOffset: number): Array<{ firstChunk: number; samplesPerChunk: number }> {
+    const { headerSize } = getAtomSize(data, stscOffset)
+    const base = stscOffset + headerSize
+    const entryCount = readUint32BE(data, base + 4)
+    const entries: Array<{ firstChunk: number; samplesPerChunk: number }> = []
+
+    for (let i = 0; i < entryCount; i++) {
+        entries.push({
+            firstChunk: readUint32BE(data, base + 8 + i * 12),
+            samplesPerChunk: readUint32BE(data, base + 8 + i * 12 + 4),
+        })
+    }
+    return entries
+}
+
+/**
+ * Read sync sample (keyframe) list from `stss` atom.
+ * Returns set of 1-based sample numbers that are keyframes.
+ * If no stss atom exists, all samples are keyframes.
+ */
+function readSyncSamples(data: Uint8Array, stblOffset: number, stblEnd: number): Set<number> | null {
+    const stssOffset = findAtom(data, stblOffset + 8, stblEnd, 'stss')
+    if (stssOffset === -1) return null // All samples are sync
+
+    const { headerSize } = getAtomSize(data, stssOffset)
+    const base = stssOffset + headerSize
+    const entryCount = readUint32BE(data, base + 4)
+    const syncSamples = new Set<number>()
+
+    for (let i = 0; i < entryCount; i++) {
+        syncSamples.add(readUint32BE(data, base + 8 + i * 4))
+    }
+    return syncSamples
+}
+
+/**
+ * Compute byte offset and size of each sample from the MP4 sample tables.
+ * Returns array of { offset, size } for each sample (0-indexed).
+ */
+function computeSampleOffsets(
+    sampleSizes: number[],
+    chunkOffsets: number[],
+    stscEntries: Array<{ firstChunk: number; samplesPerChunk: number }>
+): Array<{ offset: number; size: number }> {
+    const result: Array<{ offset: number; size: number }> = []
+    let sampleIdx = 0
+
+    for (let chunkIdx = 0; chunkIdx < chunkOffsets.length; chunkIdx++) {
+        // Determine samplesPerChunk for this chunk (1-based chunk index)
+        const chunkNum = chunkIdx + 1
+        let samplesInThisChunk = stscEntries[0].samplesPerChunk
+        for (let e = stscEntries.length - 1; e >= 0; e--) {
+            if (chunkNum >= stscEntries[e].firstChunk) {
+                samplesInThisChunk = stscEntries[e].samplesPerChunk
+                break
+            }
+        }
+
+        let offset = chunkOffsets[chunkIdx]
+        for (let s = 0; s < samplesInThisChunk && sampleIdx < sampleSizes.length; s++) {
+            const size = sampleSizes[sampleIdx]
+            result.push({ offset, size })
+            offset += size
+            sampleIdx++
+        }
+    }
+
+    return result
+}
+
+// Sampling frequency index table for ADTS header
+const AAC_SAMPLE_RATES = [96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350]
+
+/**
+ * Read AudioSpecificConfig from an esds atom to get AAC parameters.
+ * Returns { objectType, sampleRateIndex, channelConfig } or null.
+ */
+function readAudioConfig(data: Uint8Array, stsdOffset: number, stsdEnd: number): {
+    objectType: number
+    sampleRateIndex: number
+    channelConfig: number
+} | null {
+    // stsd contains sample entries. For AAC, the entry type is 'mp4a'.
+    // Navigate: stsd → mp4a → esds
+    const { headerSize } = getAtomSize(data, stsdOffset)
+    const base = stsdOffset + headerSize
+    // version(1) + flags(3) + entry_count(4) = 8 bytes
+    const entryStart = base + 8
+
+    if (entryStart + 8 > stsdEnd) return null
+
+    // The sample entry for AAC:
+    // size(4) + type(4='mp4a') + reserved(6) + data_ref_index(2) + reserved(8) + channelcount(2) + samplesize(2) + ...
+    const entryType = String.fromCharCode(data[entryStart + 4], data[entryStart + 5], data[entryStart + 6], data[entryStart + 7])
+    const entrySize = readUint32BE(data, entryStart)
+
+    if (entryType !== 'mp4a' || entrySize < 36) {
+        // Try to read channel count from mp4a header anyway
+        // mp4a box: 8(header) + 6(reserved) + 2(data_ref) + 8(reserved) + 2(channels) + 2(samplesize) + 4(reserved) + 2(samplerate) + 2(pad)
+        // Then child boxes like esds
+    }
+
+    // Read channelcount and samplerate from mp4a box directly
+    // Offset within mp4a: +8(header) +6(reserved) +2(data_ref_idx) +8(reserved) = 24
+    const channels = (data[entryStart + 24] << 8) | data[entryStart + 25]
+    // samplerate is at +24+2+2+4 = +32, as 16.16 fixed point
+    const sampleRate = readUint32BE(data, entryStart + 32) >>> 16
+
+    // Find esds box within the mp4a entry
+    let esdsOffset = -1
+    let pos = entryStart + 36 // After mp4a fixed fields
+    const entryEnd = entryStart + entrySize
+    while (pos < entryEnd - 8) {
+        const boxSize = readUint32BE(data, pos)
+        const boxType = String.fromCharCode(data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7])
+        if (boxSize < 8) break
+        if (boxType === 'esds') {
+            esdsOffset = pos
+            break
+        }
+        pos += boxSize
+    }
+
+    // Default: try to figure out config from mp4a header
+    let objectType = 2 // AAC-LC (most common)
+    let sampleRateIndex = AAC_SAMPLE_RATES.indexOf(sampleRate)
+    if (sampleRateIndex === -1) sampleRateIndex = 4 // default 44100
+    let channelConfig = channels || 2
+
+    if (esdsOffset !== -1) {
+        // Parse esds to find AudioSpecificConfig
+        // esds structure: full box header(12) + ES_Descriptor
+        const esdsBase = esdsOffset + 12 // skip box header + version/flags
+        // ES_Descriptor starts with tag 0x03, then size, then ESID(2) + flags(1)
+        // Then DecoderConfigDescriptor (tag 0x04), then DecoderSpecificInfo (tag 0x05)
+        // We search for tag 0x05 which contains AudioSpecificConfig
+        for (let s = esdsBase; s < entryEnd - 5; s++) {
+            if (data[s] === 0x05) {
+                // Next byte(s) = size, then the AudioSpecificConfig (2+ bytes)
+                let configOffset = s + 1
+                // Read size (could be multi-byte)
+                let size = data[configOffset]
+                if (size === 0x80 || size === 0x81 || size === 0xFE) {
+                    configOffset += 3 // skip extended size bytes
+                } else {
+                    configOffset += 1
+                }
+                if (configOffset + 2 <= entryEnd) {
+                    // AudioSpecificConfig: 5 bits objectType + 4 bits freqIndex + 4 bits channelConfig
+                    const byte0 = data[configOffset]
+                    const byte1 = data[configOffset + 1]
+                    objectType = (byte0 >> 3) & 0x1F
+                    sampleRateIndex = ((byte0 & 0x07) << 1) | ((byte1 >> 7) & 0x01)
+                    channelConfig = (byte1 >> 3) & 0x0F
+                }
+                break
+            }
+        }
+    }
+
+    console.log(`AAC config: objectType=${objectType}, sampleRate=${AAC_SAMPLE_RATES[sampleRateIndex] || '?'}, channels=${channelConfig}`)
+    return { objectType, sampleRateIndex, channelConfig }
+}
+
+/**
+ * Create a 7-byte ADTS header for one AAC frame.
+ */
+function makeAdtsHeader(frameLength: number, objectType: number, sampleRateIndex: number, channelConfig: number): Uint8Array {
+    const header = new Uint8Array(7)
+    const totalLength = frameLength + 7 // ADTS header + AAC frame
+
+    // Byte 0: syncword high
+    header[0] = 0xFF
+    // Byte 1: syncword low(4) + ID(1)=0(MPEG-4) + layer(2)=00 + protection(1)=1(no CRC)
+    header[1] = 0xF1
+    // Byte 2: profile(2) + samplingFreqIdx(4) + private(1)=0 + channelConfig high(1)
+    header[2] = ((objectType - 1) << 6) | (sampleRateIndex << 2) | ((channelConfig >> 2) & 0x01)
+    // Byte 3: channelConfig low(2) + originality(1)=0 + home(1)=0 + copyrighted(1)=0 + copyright_start(1)=0 + frame_length high(2)
+    header[3] = ((channelConfig & 0x03) << 6) | ((totalLength >> 11) & 0x03)
+    // Byte 4: frame_length mid(8)
+    header[4] = (totalLength >> 3) & 0xFF
+    // Byte 5: frame_length low(3) + buffer_fullness high(5)
+    header[5] = ((totalLength & 0x07) << 5) | 0x1F // 0x1F = VBR
+    // Byte 6: buffer_fullness low(6) + num_raw_blocks(2)=00
+    header[6] = 0xFC // 0xFC = rest of buffer_fullness (0x7FF) + 0 raw blocks
+
+    return header
+}
+
+/**
+ * Extract audio from MP4 and convert to AAC/ADTS format.
+ * ADTS is a simple streaming format — no moov/atoms needed.
+ * Then chunk the ADTS data into segments under maxChunkSize.
+ */
+/**
+ * Helper: create an MP4 atom from type string and payload.
+ */
+function makeAtom(type: string, payload: Uint8Array): Uint8Array {
+    const atom = new Uint8Array(8 + payload.length)
+    writeUint32BE(atom, 0, atom.length)
+    atom[4] = type.charCodeAt(0); atom[5] = type.charCodeAt(1)
+    atom[6] = type.charCodeAt(2); atom[7] = type.charCodeAt(3)
+    atom.set(payload, 8)
+    return atom
+}
+
+/**
+ * Helper: concatenate multiple Uint8Arrays.
+ */
+function concatArrays(...arrays: Uint8Array[]): Uint8Array {
+    const total = arrays.reduce((s, a) => s + a.length, 0)
+    const result = new Uint8Array(total)
+    let off = 0
+    for (const a of arrays) { result.set(a, off); off += a.length }
+    return result
+}
+
+/**
+ * Build a minimal valid audio-only MP4 from scratch.
+ * Creates: ftyp + moov (mvhd + trak with audio) + mdat
+ * All sample table atoms are built correctly pointing to sequential mdat data.
+ */
+function buildMinimalAudioMP4(
+    sampleSizes: number[],
+    audioData: Uint8Array,
+    stsdPayload: Uint8Array, // Original stsd atom content (includes sample descriptions)
+    sttsPayload: Uint8Array, // Original stts atom content
+    timescale: number,
+    duration: number,
+): Uint8Array {
+    const numSamples = sampleSizes.length
+    const totalAudioSize = audioData.length
+
+    // === Build stbl (sample table) ===
+
+    // stsd — copy from original (contains codec-specific info like esds)
+    const stsd = stsdPayload
+
+    // stts — copy from original (time-to-sample, defines duration per sample)
+    const stts = sttsPayload
+
+    // stsz — sample size table
+    // version(1) + flags(3) + uniform_size(4) + count(4) + sizes(4*N)
+    const stszData = new Uint8Array(12 + numSamples * 4)
+    writeUint32BE(stszData, 0, 0) // version + flags
+    writeUint32BE(stszData, 4, 0) // uniform_size = 0 (variable)
+    writeUint32BE(stszData, 8, numSamples)
+    for (let i = 0; i < numSamples; i++) {
+        writeUint32BE(stszData, 12 + i * 4, sampleSizes[i])
+    }
+    const stsz = makeAtom('stsz', stszData)
+
+    // stsc — sample-to-chunk: all samples in 1 chunk
+    // version(1) + flags(3) + count(4) + entry(12)
+    const stscData = new Uint8Array(16)
+    writeUint32BE(stscData, 0, 0) // version + flags
+    writeUint32BE(stscData, 4, 1) // 1 entry
+    writeUint32BE(stscData, 8, 1) // first_chunk = 1
+    writeUint32BE(stscData, 12, numSamples) // samples_per_chunk = all
+    // description_index = 1 (already zero-initialized, need to set)
+    // Wait, stsc entry is 12 bytes: first_chunk(4) + samples_per_chunk(4) + description_index(4)
+    const stscDataFull = new Uint8Array(20)
+    writeUint32BE(stscDataFull, 0, 0) // version + flags
+    writeUint32BE(stscDataFull, 4, 1) // 1 entry
+    writeUint32BE(stscDataFull, 8, 1) // first_chunk
+    writeUint32BE(stscDataFull, 12, numSamples) // samples_per_chunk
+    writeUint32BE(stscDataFull, 16, 1) // sample_description_index
+    const stsc = makeAtom('stsc', stscDataFull)
+
+    // stco — chunk offset table (1 entry, will be patched after we know the mdat offset)
+    // version(1) + flags(3) + count(4) + offset(4)
+    const stcoData = new Uint8Array(12)
+    writeUint32BE(stcoData, 0, 0) // version + flags
+    writeUint32BE(stcoData, 4, 1) // 1 entry
+    writeUint32BE(stcoData, 8, 0) // placeholder, will be patched
+    const stco = makeAtom('stco', stcoData)
+
+    const stbl = makeAtom('stbl', concatArrays(stsd, stts, stsz, stsc, stco))
+
+    // === Build minf ===
+    // smhd (sound media header): version(1) + flags(3) + balance(2) + reserved(2)
+    const smhdData = new Uint8Array(8)
+    const smhd = makeAtom('smhd', smhdData)
+
+    // dinf → dref (data reference, 1 entry pointing to self)
+    const drefEntryData = new Uint8Array(4)
+    writeUint32BE(drefEntryData, 0, 0x00000001) // flags = 1 (self-contained)
+    const drefEntry = makeAtom('url ', drefEntryData)
+    const drefData = concatArrays(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1]), drefEntry) // version+flags + count=1
+    const dref = makeAtom('dref', drefData)
+    const dinf = makeAtom('dinf', dref)
+
+    const minf = makeAtom('minf', concatArrays(smhd, dinf, stbl))
+
+    // === Build mdia ===
+    // mdhd (media header): version(1) + flags(3) + creation(4) + modification(4) + timescale(4) + duration(4) + lang(2) + quality(2)
+    const mdhdData = new Uint8Array(24)
+    writeUint32BE(mdhdData, 8, timescale)
+    writeUint32BE(mdhdData, 12, duration)
+    mdhdData[16] = 0x55; mdhdData[17] = 0xC4 // language: 'und' (undetermined)
+    const mdhd = makeAtom('mdhd', mdhdData)
+
+    // hdlr (handler): version(1) + flags(3) + pre_defined(4) + handler_type(4) + reserved(12) + name(variable)
+    const hdlrPayload = new Uint8Array(25)
+    hdlrPayload[8] = 0x73; hdlrPayload[9] = 0x6F; hdlrPayload[10] = 0x75; hdlrPayload[11] = 0x6E // "soun"
+    hdlrPayload[24] = 0 // null-terminated name
+    const hdlr = makeAtom('hdlr', hdlrPayload)
+
+    const mdia = makeAtom('mdia', concatArrays(mdhd, hdlr, minf))
+
+    // === Build trak ===
+    // tkhd (track header): version(1) + flags(3) + creation(4) + modification(4) + track_id(4) + reserved(4) + duration(4) + ...
+    const tkhdData = new Uint8Array(84)
+    tkhdData[3] = 0x03 // flags = track_enabled | track_in_movie
+    writeUint32BE(tkhdData, 12, 1) // track_id = 1
+    writeUint32BE(tkhdData, 20, duration) // duration
+    // volume at offset 36: 0x0100 = full volume
+    tkhdData[36] = 0x01; tkhdData[37] = 0x00
+    // unity matrix at offset 40
+    writeUint32BE(tkhdData, 40, 0x00010000)
+    writeUint32BE(tkhdData, 56, 0x00010000)
+    writeUint32BE(tkhdData, 72, 0x40000000)
+    const tkhd = makeAtom('tkhd', tkhdData)
+
+    const trak = makeAtom('trak', concatArrays(tkhd, mdia))
+
+    // === Build moov ===
+    // mvhd: version(1) + flags(3) + creation(4) + modification(4) + timescale(4) + duration(4) + rate(4) + volume(2) + reserved(10) + matrix(36) + pre_defined(24) + next_track_id(4)
+    const mvhdData = new Uint8Array(100)
+    writeUint32BE(mvhdData, 8, timescale) // timescale
+    writeUint32BE(mvhdData, 12, duration) // duration
+    writeUint32BE(mvhdData, 16, 0x00010000) // rate = 1.0
+    mvhdData[20] = 0x01; mvhdData[21] = 0x00 // volume = 1.0
+    // matrix (identity)
+    writeUint32BE(mvhdData, 32, 0x00010000)
+    writeUint32BE(mvhdData, 48, 0x00010000)
+    writeUint32BE(mvhdData, 64, 0x40000000)
+    writeUint32BE(mvhdData, 96, 2) // next_track_id
+    const mvhd = makeAtom('mvhd', mvhdData)
+
+    const moov = makeAtom('moov', concatArrays(mvhd, trak))
+
+    // === Build ftyp ===
+    const ftypPayload = new Uint8Array(12)
+    // major_brand = 'M4A '
+    ftypPayload[0] = 0x4D; ftypPayload[1] = 0x34; ftypPayload[2] = 0x41; ftypPayload[3] = 0x20
+    // minor_version = 0
+    // compatible_brands = 'isom'
+    ftypPayload[8] = 0x69; ftypPayload[9] = 0x73; ftypPayload[10] = 0x6F; ftypPayload[11] = 0x6D
+    const ftyp = makeAtom('ftyp', ftypPayload)
+
+    // === Build mdat ===
+    const mdatHeader = new Uint8Array(8)
+    writeUint32BE(mdatHeader, 0, 8 + totalAudioSize)
+    mdatHeader[4] = 0x6D; mdatHeader[5] = 0x64; mdatHeader[6] = 0x61; mdatHeader[7] = 0x74
+
+    // === Assemble and patch stco ===
+    const result = concatArrays(ftyp, moov, mdatHeader, audioData)
+
+    // Patch stco: mdat data starts at ftyp.length + moov.length + 8 (mdat header)
+    const mdatDataOffset = ftyp.length + moov.length + 8
+
+    // Find stco in the result to patch it
+    // stco is inside: ftyp + moov → mvhd → trak → mdia → minf → stbl → stco
+    // Search for 'stco' atom in the result
+    for (let i = 0; i < result.length - 12; i++) {
+        if (result[i + 4] === 0x73 && result[i + 5] === 0x74 && result[i + 6] === 0x63 && result[i + 7] === 0x6F) { // "stco"
+            // Patch the offset entry: at i + 8 (atom header) + 4 (version/flags) + 4 (count) = i + 16
+            writeUint32BE(result, i + 16, mdatDataOffset)
+            break
+        }
+    }
+
+    return result
+}
+
+/**
+ * Extract audio from MP4 video and create valid audio-only MP4 file(s).
+ * Builds a proper MP4 container from scratch with correct atom structure.
+ */
+function chunkMP4(data: Uint8Array, maxChunkSize: number): Uint8Array[] {
+    const topAtoms = findTopLevelAtoms(data)
+    const moovAtom = topAtoms.find(a => a.type === 'moov')
+
+    if (!moovAtom) {
+        console.warn('MP4 missing moov atom')
+        return [data]
+    }
+
+    const moovStart = moovAtom.offset
+    const moovEnd = moovAtom.offset + moovAtom.size
+
+    // Find audio trak
+    let audioTrakOffset = -1
+    let audioTrakEnd = -1
+    let offset = moovStart + 8
+    while (offset < moovEnd - 8) {
+        const { size } = getAtomSize(data, offset)
+        if (size < 8) break
+        if (getAtomType(data, offset) === 'trak') {
+            const trakEnd = offset + size
+            const mdiaOff = findAtom(data, offset + 8, trakEnd, 'mdia')
+            if (mdiaOff !== -1) {
+                const mdiaEnd = mdiaOff + getAtomSize(data, mdiaOff).size
+                const hdlrOff = findAtom(data, mdiaOff + 8, mdiaEnd, 'hdlr')
+                if (hdlrOff !== -1) {
+                    const { headerSize: hh } = getAtomSize(data, hdlrOff)
+                    const ht = String.fromCharCode(data[hdlrOff + hh + 8], data[hdlrOff + hh + 9], data[hdlrOff + hh + 10], data[hdlrOff + hh + 11])
+                    if (ht === 'soun') {
+                        audioTrakOffset = offset
+                        audioTrakEnd = trakEnd
+                        break
+                    }
+                }
+            }
+        }
+        offset += size
+    }
+
+    if (audioTrakOffset === -1) {
+        console.warn('MP4: no audio trak found')
+        return [data]
+    }
+
+    // Navigate to stbl and read all needed atoms
+    const mdiaOff = findAtom(data, audioTrakOffset + 8, audioTrakEnd, 'mdia')
+    if (mdiaOff === -1) return [data]
+    const mdiaEnd = mdiaOff + getAtomSize(data, mdiaOff).size
+
+    // Read timescale and duration from mdhd
+    const mdhdOff = findAtom(data, mdiaOff + 8, mdiaEnd, 'mdhd')
+    let timescale = 48000
+    let mediaDuration = 0
+    if (mdhdOff !== -1) {
+        const { headerSize: mhh } = getAtomSize(data, mdhdOff)
+        const mdhdBase = mdhdOff + mhh
+        const version = data[mdhdBase]
+        if (version === 0) {
+            timescale = readUint32BE(data, mdhdBase + 12)
+            mediaDuration = readUint32BE(data, mdhdBase + 16)
+        } else {
+            timescale = readUint32BE(data, mdhdBase + 20)
+            // 64-bit duration — read lower 32 bits
+            mediaDuration = readUint32BE(data, mdhdBase + 28)
+        }
+    }
+
+    const minfOff = findAtom(data, mdiaOff + 8, mdiaEnd, 'minf')
+    if (minfOff === -1) return [data]
+    const minfEnd = minfOff + getAtomSize(data, minfOff).size
+    const stblOff = findAtom(data, minfOff + 8, minfEnd, 'stbl')
+    if (stblOff === -1) return [data]
+    const stblEnd = stblOff + getAtomSize(data, stblOff).size
+
+    // Read sample tables
+    const stszOff = findAtom(data, stblOff + 8, stblEnd, 'stsz')
+    const stcoOff = findAtom(data, stblOff + 8, stblEnd, 'stco')
+    const co64Off = findAtom(data, stblOff + 8, stblEnd, 'co64')
+    const stscOff = findAtom(data, stblOff + 8, stblEnd, 'stsc')
+    const stsdOff = findAtom(data, stblOff + 8, stblEnd, 'stsd')
+    const sttsOff = findAtom(data, stblOff + 8, stblEnd, 'stts')
+
+    if (stszOff === -1 || stscOff === -1 || (stcoOff === -1 && co64Off === -1) || stsdOff === -1 || sttsOff === -1) {
+        console.warn('MP4: missing required sample table atoms')
+        return [data]
+    }
+
+    // Copy stsd and stts from original (they contain codec info and timing)
+    const stsdSize = getAtomSize(data, stsdOff).size
+    const stsdAtom = data.slice(stsdOff, stsdOff + stsdSize)
+    const sttsSize = getAtomSize(data, sttsOff).size
+    const sttsAtom = data.slice(sttsOff, sttsOff + sttsSize)
+
+    const sampleSizes = readSampleSizes(data, stszOff)
+    const chunkOffsetsArr = readChunkOffsets(data, stcoOff !== -1 ? stcoOff : co64Off)
+    const stscEntries = readSampleToChunk(data, stscOff)
+    const sampleOffsets = computeSampleOffsets(sampleSizes, chunkOffsetsArr, stscEntries)
+
+    if (sampleOffsets.length === 0) return [data]
+
+    // Extract all audio samples sequentially
+    const totalAudioSize = sampleSizes.reduce((sum, s) => sum + s, 0)
+    console.log(`MP4: found ${sampleOffsets.length} audio samples, ${(totalAudioSize / 1024 / 1024).toFixed(1)}MB audio data`)
+
+    const audioData = new Uint8Array(totalAudioSize)
+    let writePos = 0
+    for (const { offset: sOff, size: sSize } of sampleOffsets) {
+        audioData.set(data.subarray(sOff, sOff + sSize), writePos)
+        writePos += sSize
+    }
+
+    // Build valid audio-only MP4
+    const mp4 = buildMinimalAudioMP4(sampleSizes, audioData, stsdAtom, sttsAtom, timescale, mediaDuration)
+    console.log(`MP4: built audio-only MP4: ${(mp4.length / 1024 / 1024).toFixed(1)}MB`)
+
+    if (mp4.length <= maxChunkSize) {
+        return [mp4]
+    }
+
+    // Audio-only MP4 still too large — convert to ADTS (streaming AAC) and chunk
+    // ADTS is a simple frame-based format that can be split at any frame boundary
+
+    const audioConfig = readAudioConfig(data, stsdOff, stsdOff + stsdSize)
+    if (!audioConfig) {
+        console.warn('MP4: cannot read AAC config for ADTS conversion, returning single chunk')
+        return [mp4]
+    }
+
+    const { objectType, sampleRateIndex, channelConfig } = audioConfig
+
+    // Build ADTS stream: each sample gets a 7-byte ADTS header
+    let adtsTotalSize = 0
+    for (const size of sampleSizes) adtsTotalSize += 7 + size
+    const adtsData = new Uint8Array(adtsTotalSize)
+    let adtsWritePos = 0
+    let sampleReadPos = 0
+    for (const size of sampleSizes) {
+        const header = makeAdtsHeader(size, objectType, sampleRateIndex, channelConfig)
+        adtsData.set(header, adtsWritePos)
+        adtsData.set(audioData.subarray(sampleReadPos, sampleReadPos + size), adtsWritePos + 7)
+        adtsWritePos += 7 + size
+        sampleReadPos += size
+    }
+
+    // Split ADTS at frame boundaries (each frame = 7-byte header + AAC data)
+    const adtsChunks: Uint8Array[] = []
+    let chunkStartByte = 0
+    let chunkAccum = 0
+
+    for (let i = 0; i < sampleSizes.length; i++) {
+        const frameSize = 7 + sampleSizes[i]
+        if (chunkAccum + frameSize > maxChunkSize && chunkAccum > 0) {
+            adtsChunks.push(adtsData.slice(chunkStartByte, chunkStartByte + chunkAccum))
+            chunkStartByte += chunkAccum
+            chunkAccum = 0
+        }
+        chunkAccum += frameSize
+    }
+    if (chunkAccum > 0) {
+        adtsChunks.push(adtsData.slice(chunkStartByte, chunkStartByte + chunkAccum))
+    }
+    return adtsChunks
+}
+
+// ==================== PUBLIC API ====================
+
+/**
+ * Detect media type from content-type string.
+ */
+type MediaFormat = 'webm' | 'mp3' | 'wav' | 'mp4' | 'unknown'
+
+function detectFormat(contentType: string): MediaFormat {
+    const ct = contentType.toLowerCase()
+    if (ct.includes('webm')) return 'webm'
+    if (ct.includes('mpeg') || ct.includes('mp3')) return 'mp3'
+    if (ct.includes('wav') || ct.includes('wave')) return 'wav'
+    if (ct.includes('mp4') || ct.includes('m4a') || ct.includes('video/mp4')) return 'mp4'
+    return 'unknown'
+}
+
+/**
+ * Detect media format from URL extension as fallback when content-type is unhelpful.
+ */
+function detectFormatFromUrl(url: string): MediaFormat {
+    try {
+        const pathname = new URL(url).pathname.toLowerCase()
+        if (pathname.endsWith('.webm')) return 'webm'
+        if (pathname.endsWith('.mp3')) return 'mp3'
+        if (pathname.endsWith('.wav')) return 'wav'
+        if (pathname.endsWith('.mp4') || pathname.endsWith('.m4a')) return 'mp4'
+    } catch { /* ignore invalid URLs */ }
+    return 'unknown'
+}
+
+/**
+ * Detect format from file magic bytes as final fallback.
+ */
+function detectFormatFromBytes(data: Uint8Array): MediaFormat {
+    if (data.length < 12) return 'unknown'
+    // RIFF....WAVE = WAV
+    if (data[0] === 0x52 && data[1] === 0x49 && data[2] === 0x46 && data[3] === 0x46 &&
+        data[8] === 0x57 && data[9] === 0x41 && data[10] === 0x56 && data[11] === 0x45) return 'wav'
+    // ID3 or 0xFFE0+ sync = MP3
+    if ((data[0] === 0x49 && data[1] === 0x44 && data[2] === 0x33) ||
+        (data[0] === 0xFF && (data[1] & 0xE0) === 0xE0)) return 'mp3'
+    // 0x1A45DFA3 = EBML (WebM/Matroska)
+    if (data[0] === 0x1A && data[1] === 0x45 && data[2] === 0xDF && data[3] === 0xA3) return 'webm'
+    // ftyp at offset 4 = MP4
+    if (data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70) return 'mp4'
+    return 'unknown'
+}
+
+/**
+ * Get file extension for a media format.
+ */
+export function getFileExtension(contentType: string, sourceUrl?: string): string {
+    let format = detectFormat(contentType)
+    if (format === 'unknown' && sourceUrl) {
+        format = detectFormatFromUrl(sourceUrl)
+    }
+    switch (format) {
+        case 'webm': return 'webm'
+        case 'mp3': return 'mp3'
+        case 'wav': return 'wav'
+        case 'mp4': return 'mp4'
+        default: return 'mp3'
+    }
+}
+
+/**
+ * Chunk a media file into valid segments under the size limit.
+ *
+ * @param buffer - The full file as an ArrayBuffer
+ * @param contentType - MIME type of the file
+ * @param maxChunkSize - Maximum size per chunk in bytes (default 24MB)
+ * @returns Array of ArrayBuffers, each a valid media file under maxChunkSize.
+ *          Returns single-element array if file is already small enough.
+ */
+export function chunkMediaFile(
+    buffer: ArrayBuffer,
+    contentType: string,
+    maxChunkSize: number = DEFAULT_MAX_CHUNK_SIZE,
+    sourceUrl?: string
+): ArrayBuffer[] {
+    const data = new Uint8Array(buffer)
+
+    // If already under the limit, return as-is
+    if (data.length <= maxChunkSize) {
+        return [buffer]
+    }
+
+    // Detect format with fallback chain: content-type → URL extension → magic bytes
+    let format = detectFormat(contentType)
+    if (format === 'unknown' && sourceUrl) {
+        format = detectFormatFromUrl(sourceUrl)
+        if (format !== 'unknown') {
+            console.log(`[CHUNKER] Content-type "${contentType}" unhelpful, detected ${format} from URL`)
+        }
+    }
+    if (format === 'unknown') {
+        format = detectFormatFromBytes(data)
+        if (format !== 'unknown') {
+            console.log(`[CHUNKER] Detected ${format} from file magic bytes`)
+        }
+    }
+    console.log(`Chunking ${format} file: ${(data.length / 1024 / 1024).toFixed(1)}MB into <${(maxChunkSize / 1024 / 1024).toFixed(0)}MB chunks`)
+
+    let chunks: Uint8Array[]
+
+    switch (format) {
+        case 'webm':
+            chunks = chunkWebM(data, maxChunkSize)
+            break
+        case 'mp3':
+            chunks = chunkMP3(data, maxChunkSize)
+            break
+        case 'wav':
+            chunks = chunkWAV(data, maxChunkSize)
+            break
+        case 'mp4':
+            chunks = chunkMP4(data, maxChunkSize)
+            break
+        default:
+            console.warn(`Unknown format "${contentType}" — sending full file`)
+            return [buffer]
+    }
+
+    console.log(`Split into ${chunks.length} chunks: ${chunks.map(c => `${(c.length / 1024 / 1024).toFixed(1)}MB`).join(', ')}`)
+    return chunks.map(c => c.buffer.slice(c.byteOffset, c.byteOffset + c.byteLength) as ArrayBuffer)
+}

--- a/convex/r2.ts
+++ b/convex/r2.ts
@@ -51,73 +51,171 @@ function getPublicUrlPrefix() {
 /**
  * Get a streamable (public) URL for an R2 file key.
  * Returns the public URL directly without signing.
+ *
+ * Accepts either `{ key }` (web) or `{ fileKey }` (mobile APK stores R2 keys
+ * under this name). Mobile-referenced — do not remove the fileKey alias.
  */
 export const getStreamableUrl = query({
-    args: { key: v.string() },
-    handler: async (ctx, args) => {
+    args: {
+        key: v.optional(v.string()),
+        fileKey: v.optional(v.string()),
+    },
+    handler: async (_ctx, args) => {
+        const k = args.key ?? args.fileKey;
+        if (!k) throw new Error('key or fileKey is required');
         const publicUrl = process.env.R2_PUBLIC_URL;
         if (!publicUrl) {
             return null;
         }
         const prefix = publicUrl.replace(/\/$/, '');
-        return `${prefix}/${args.key}`;
+        return `${prefix}/${k}`;
     },
 });
 
 /**
- * Generate a presigned URL for uploading a file to R2
+ * Shared implementation for R2 upload URL generation.
+ *
+ * Accepts BOTH arg shapes because web and the deployed Google Play APK use
+ * different field names and neither can be changed without a rebuild of the
+ * other side:
+ *
+ *   Web callers (app/submit/photos, app/submit/interview, app/edit-profile):
+ *     { fileName, fileType, submissionId?, mediaType? }
+ *
+ *   Mobile Play Store binary (docs/changes/MOBILE-R2-FIX.md §2):
+ *     { folder, filename, contentType }
+ *
+ * Convex argument validators reject unknown fields, so BOTH name variants are
+ * declared on the validator as optional and the handler normalizes at runtime.
+ * Missing-required errors are raised from inside the handler with a clear
+ * message rather than relying on the validator.
+ *
+ * Return value includes both `key` and `fileKey` for the same reason — the
+ * mobile APK reads `fileKey`, web reads `key`.
+ */
+type UploadArgs = {
+    // Web-style (camelCase)
+    fileName?: string;
+    fileType?: string;
+    mediaType?: 'photo' | 'video' | 'audio' | 'profile' | 'avatar';
+    // Mobile-style (lowercase + explicit folder)
+    filename?: string;
+    contentType?: string;
+    folder?: string;
+    // Common
+    submissionId?: string;
+};
+
+async function generateR2UploadUrlImpl(args: UploadArgs) {
+    const client = getR2Client();
+    const bucketName = getBucketName();
+    const publicUrlPrefix = getPublicUrlPrefix();
+
+    // Normalize name + type across web/mobile call shapes.
+    const name = args.fileName ?? args.filename;
+    const type = args.fileType ?? args.contentType;
+    if (!name) {
+        throw new Error('fileName (or filename) is required');
+    }
+    if (!type) {
+        throw new Error('fileType (or contentType) is required');
+    }
+
+    // Route to bucket folder. Priority:
+    //   1. explicit `folder` arg (mobile style)
+    //   2. map from `mediaType` (web style)
+    //   3. default `images/`
+    const folderMap: Record<string, string> = {
+        photo: 'images',
+        video: 'videos',
+        audio: 'audio',
+        profile: 'avatars',
+        avatar: 'avatars',
+    };
+    const folder =
+        args.folder ||
+        (args.mediaType ? folderMap[args.mediaType] || 'images' : 'images');
+
+    const timestamp = Date.now();
+    const randomStr = Math.random().toString(36).substring(2, 10);
+    const extension = name.split('.').pop() || 'bin';
+    const key = `${folder}/${timestamp}-${randomStr}.${extension}`;
+
+    const command = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        ContentType: type,
+    });
+
+    const uploadUrl = await getSignedUrl(client, command, { expiresIn: 3600 });
+    const publicUrl = `${publicUrlPrefix}/${key}`;
+
+    // Return both `key` and `fileKey` — mobile reads fileKey, web reads key.
+    return { uploadUrl, publicUrl, key, fileKey: key };
+}
+
+// Validator that tolerates BOTH web and mobile arg shapes. Every field is
+// optional at the validator layer; required-field checks happen in the
+// handler with clearer error messages.
+const uploadUrlArgs = {
+    fileName: v.optional(v.string()),
+    fileType: v.optional(v.string()),
+    filename: v.optional(v.string()),
+    contentType: v.optional(v.string()),
+    folder: v.optional(v.string()),
+    submissionId: v.optional(v.string()),
+    mediaType: v.optional(
+        v.union(
+            v.literal('photo'),
+            v.literal('video'),
+            v.literal('audio'),
+            v.literal('profile'),
+            v.literal('avatar'),
+        )
+    ),
+} as const;
+
+/**
+ * Generate a presigned URL for uploading a file to R2.
+ *
+ * Two exported names point at the same implementation:
+ *   - `generateUploadUrl` — used by the web app AND by the current Play Store APK
+ *   - `generateR2UploadUrl` — reserved for future mobile builds
+ *
+ * Mobile-referenced — do not remove either export. The Play Store binary is
+ * compiled against `api.r2.generateUploadUrl` and calls it at runtime.
+ * Removing either would 404 already-shipped installs.
  */
 export const generateUploadUrl = action({
-    args: {
-        fileName: v.string(),
-        fileType: v.string(),
-        submissionId: v.string(),
-        mediaType: v.union(v.literal('photo'), v.literal('video'), v.literal('audio')),
-    },
-    handler: async (ctx, args) => {
-        const client = getR2Client();
-        const bucketName = getBucketName();
-        const publicUrlPrefix = getPublicUrlPrefix();
+    args: uploadUrlArgs,
+    handler: async (_ctx, args) => generateR2UploadUrlImpl(args),
+});
 
-        // Generate unique file key using root folders (images/, videos/, audio/)
-        const timestamp = Date.now();
-        const randomStr = Math.random().toString(36).substring(2, 10);
-        const extension = args.fileName.split('.').pop() || 'bin';
-        // Map mediaType to folder name: photo -> images, video -> videos, audio -> audio
-        const folderMap = { photo: 'images', video: 'videos', audio: 'audio' };
-        const folder = folderMap[args.mediaType];
-        const key = `${folder}/${timestamp}-${randomStr}.${extension}`;
-
-        const command = new PutObjectCommand({
-            Bucket: bucketName,
-            Key: key,
-            ContentType: args.fileType,
-        });
-
-        // Generate presigned URL valid for 1 hour
-        const uploadUrl = await getSignedUrl(client, command, { expiresIn: 3600 });
-        const publicUrl = `${publicUrlPrefix}/${key}`;
-
-        return {
-            uploadUrl,
-            publicUrl,
-            key,
-        };
-    },
+export const generateR2UploadUrl = action({
+    args: uploadUrlArgs,
+    handler: async (_ctx, args) => generateR2UploadUrlImpl(args),
 });
 
 /**
- * Delete a file from R2
+ * Delete a file from R2.
+ *
+ * Accepts either `{ key }` (web) or `{ fileKey }` (mobile).
+ * Mobile-referenced — do not remove the fileKey alias.
  */
 export const deleteFile = action({
-    args: { key: v.string() },
-    handler: async (ctx, args) => {
+    args: {
+        key: v.optional(v.string()),
+        fileKey: v.optional(v.string()),
+    },
+    handler: async (_ctx, args) => {
+        const k = args.key ?? args.fileKey;
+        if (!k) throw new Error('key or fileKey is required');
         const client = getR2Client();
         const bucketName = getBucketName();
 
         const command = new DeleteObjectCommand({
             Bucket: bucketName,
-            Key: args.key,
+            Key: k,
         });
 
         await client.send(command);
@@ -157,17 +255,25 @@ export const generateApkUploadUrl = action({
 });
 
 /**
- * Get a presigned URL for downloading a file (for private buckets)
+ * Get a presigned URL for downloading a file (for private buckets).
+ *
+ * Accepts either `{ key }` (web) or `{ fileKey }` (mobile).
+ * Mobile-referenced — do not remove the fileKey alias.
  */
 export const getDownloadUrl = action({
-    args: { key: v.string() },
-    handler: async (ctx, args) => {
+    args: {
+        key: v.optional(v.string()),
+        fileKey: v.optional(v.string()),
+    },
+    handler: async (_ctx, args) => {
+        const k = args.key ?? args.fileKey;
+        if (!k) throw new Error('key or fileKey is required');
         const client = getR2Client();
         const bucketName = getBucketName();
 
         const command = new GetObjectCommand({
             Bucket: bucketName,
-            Key: args.key,
+            Key: k,
         });
 
         // Generate presigned URL valid for 1 hour

--- a/convex/storage.ts
+++ b/convex/storage.ts
@@ -1,8 +1,10 @@
 import { v } from 'convex/values';
 import { query, mutation } from './_generated/server';
+import { Id } from './_generated/dataModel';
 
 /**
- * Generate an upload URL for file storage
+ * Generate an upload URL for Convex file storage (legacy).
+ * New uploads should go through R2 via `r2.generateUploadUrl`.
  */
 export const generateUploadUrl = mutation({
     args: {},
@@ -12,37 +14,84 @@ export const generateUploadUrl = mutation({
 });
 
 /**
- * Get file URL from storage ID
+ * Get a file URL.
+ *
+ * Accepts any of: a full URL, an R2 relative path (images/..., videos/...,
+ * audio/...), a `convex:` prefixed ID, or a raw Convex storage ID. Mobile-
+ * referenced — do NOT tighten the validator back to v.id('_storage'): the
+ * APK calls this with R2 object keys which would be rejected before the
+ * handler runs, producing a misleading "Server Error" on the client.
  */
 export const getUrl = query({
-    args: { storageId: v.id('_storage') },
+    args: { storageId: v.string() },
     handler: async (ctx, args) => {
-        return await ctx.storage.getUrl(args.storageId);
+        const idString = args.storageId;
+        const r2PublicUrl = process.env.R2_PUBLIC_URL?.replace(/\/$/, '');
+        try {
+            if (idString.startsWith('http://') || idString.startsWith('https://')) {
+                return idString;
+            }
+            if (/^(images|videos|audio)\//.test(idString) && r2PublicUrl) {
+                return `${r2PublicUrl}/${idString}`;
+            }
+            const storageId = idString.startsWith('convex:')
+                ? idString.replace('convex:', '')
+                : idString;
+            return await ctx.storage.getUrl(storageId as Id<"_storage">);
+        } catch {
+            return null;
+        }
     },
 });
 
 /**
- * Get multiple file URLs
+ * Get multiple file URLs. Same permissive resolution as getUrl.
+ * Mobile-referenced — accepts strings (R2 paths or Convex IDs).
  */
 export const getUrls = query({
-    args: { storageIds: v.array(v.id('_storage')) },
+    args: { storageIds: v.array(v.string()) },
     handler: async (ctx, args) => {
-        const urls = await Promise.all(
-            args.storageIds.map(async (id) => ({
-                id,
-                url: await ctx.storage.getUrl(id),
-            }))
+        const r2PublicUrl = process.env.R2_PUBLIC_URL?.replace(/\/$/, '');
+        return Promise.all(
+            args.storageIds.map(async (idString) => {
+                try {
+                    if (idString.startsWith('http://') || idString.startsWith('https://')) {
+                        return { id: idString, url: idString };
+                    }
+                    if (/^(images|videos|audio)\//.test(idString) && r2PublicUrl) {
+                        return { id: idString, url: `${r2PublicUrl}/${idString}` };
+                    }
+                    const storageId = idString.startsWith('convex:')
+                        ? idString.replace('convex:', '')
+                        : idString;
+                    const url = await ctx.storage.getUrl(storageId as Id<"_storage">);
+                    return { id: idString, url };
+                } catch {
+                    return { id: idString, url: null };
+                }
+            })
         );
-        return urls;
     },
 });
 
 /**
- * Delete a file from storage
+ * Delete a file from Convex storage.
+ *
+ * Accepts a string for cross-caller compatibility. If the string looks like
+ * an R2 relative path or a full URL, Convex storage deletion is skipped
+ * (R2 files must be deleted through `r2.deleteFile`). Mobile-referenced —
+ * do not tighten the validator.
  */
 export const deleteFile = mutation({
-    args: { storageId: v.id('_storage') },
+    args: { storageId: v.string() },
     handler: async (ctx, args) => {
-        await ctx.storage.delete(args.storageId);
+        const s = args.storageId;
+        const looksLikeR2 = s.startsWith('http://') || s.startsWith('https://') || /^(images|videos|audio)\//.test(s);
+        if (looksLikeR2) {
+            console.warn(`[storage.deleteFile] Called with R2 path "${s}" — skipping Convex storage delete. Use r2.deleteFile for R2 files.`);
+            return;
+        }
+        const id = s.startsWith('convex:') ? s.replace('convex:', '') : s;
+        await ctx.storage.delete(id as Id<"_storage">);
     },
 });

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -1,6 +1,5 @@
 import { v } from 'convex/values';
-import { query, mutation, internalQuery } from './_generated/server';
-import { Id } from './_generated/dataModel';
+import { query, mutation, internalQuery, internalMutation, internalAction } from './_generated/server';
 import { internal } from './_generated/api';
 
 // ==================== QUERIES ====================
@@ -199,8 +198,11 @@ export const create = mutation({
         coordinates: v.optional(v.object({ lat: v.number(), lng: v.number() })),
         hasProducts: v.optional(v.boolean()),
         photos: v.optional(v.array(v.string())),
-        videoStorageId: v.optional(v.id('_storage')),
-        audioStorageId: v.optional(v.id('_storage')),
+        // Accept plain strings — the mobile APK stores R2 object keys here
+        // (e.g. "audio/1721293-a2b3c4d5.m4a"), which are NOT Convex storage IDs.
+        // schema.ts declares these as v.string() too, so patching works either way.
+        videoStorageId: v.optional(v.string()),
+        audioStorageId: v.optional(v.string()),
         transcript: v.optional(v.string()),
         amount: v.optional(v.number()),
         creatorPayout: v.optional(v.number()),
@@ -274,8 +276,12 @@ export const update = mutation({
         businessDescription: v.optional(v.string()),
         hasProducts: v.optional(v.boolean()),
         photos: v.optional(v.array(v.string())),
-        videoStorageId: v.optional(v.id('_storage')),
-        audioStorageId: v.optional(v.id('_storage')),
+        // Accept plain strings — mobile APK stores R2 object keys here
+        // ("audio/1721293-a2b3c4d5.m4a"), NOT Convex internal storage IDs.
+        // schema.ts already declares these as v.string() for the same reason.
+        // Mobile-referenced — do not tighten back to v.id('_storage').
+        videoStorageId: v.optional(v.string()),
+        audioStorageId: v.optional(v.string()),
         // R2 URLs (preferred for new uploads)
         videoUrl: v.optional(v.string()),
         audioUrl: v.optional(v.string()),
@@ -298,6 +304,38 @@ export const update = mutation({
         );
 
         await ctx.db.patch(id, filteredUpdates);
+
+        // Auto-schedule transcription when media is freshly attached and there's
+        // no existing transcript. This mirrors the behavior mobile's submissions.update
+        // used to have — keeping the contract alive so mobile users stop seeing
+        // "Transcript generating…" spinners that never resolve. See
+        // docs/00-Overview-Mobile.md §submissions.
+        const mediaFieldSet = !!(
+            updates.audioStorageId ||
+            updates.videoStorageId ||
+            updates.audioUrl ||
+            updates.videoUrl
+        );
+        const touchedTranscriptDirectly = updates.transcript !== undefined || updates.transcriptionStatus !== undefined;
+
+        if (mediaFieldSet && !touchedTranscriptDirectly) {
+            const current = await ctx.db.get(id);
+            if (current && !current.transcript && current.transcriptionStatus !== 'processing') {
+                // Determine which media we just set. Prefer video over audio if both were set.
+                const isVideo = !!(updates.videoStorageId || updates.videoUrl);
+                const storageId =
+                    (updates.videoStorageId as string | undefined) ||
+                    (updates.videoUrl as string | undefined) ||
+                    (updates.audioStorageId as string | undefined) ||
+                    (updates.audioUrl as string | undefined);
+
+                await ctx.scheduler.runAfter(0, internal.submissions.transcribeMedia, {
+                    submissionId: id,
+                    storageId,
+                    mediaType: isVideo ? 'video' : 'audio',
+                });
+            }
+        }
     },
 });
 
@@ -511,5 +549,220 @@ export const remove = mutation({
         }
 
         await ctx.db.delete(args.id);
+    },
+});
+
+// ==================== TRANSCRIPTION INTERNALS ====================
+//
+// These three functions are referenced by the mobile app (Google Play binary).
+// Mobile's `submissions.update` mutation and internal transcription pipeline
+// call them by name. Do NOT remove any of them — the deployed mobile binary
+// will start throwing "function not found" errors on submission media flows if
+// any of these are missing from the Convex deployment.
+//
+// See docs/00-Overview-Mobile.md §submissions for the mobile-side contract.
+
+/**
+ * Persist a completed transcript on a submission.
+ * Mirrors mobile's internal mutation name.
+ */
+export const updateTranscription = internalMutation({
+    args: {
+        submissionId: v.id('submissions'),
+        transcription: v.string(),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.submissionId, {
+            transcript: args.transcription,
+            transcriptionStatus: 'complete',
+            transcriptionUpdatedAt: Date.now(),
+        });
+    },
+});
+
+/**
+ * Update the transcription lifecycle status on a submission.
+ * Mirrors mobile's internal mutation name.
+ */
+export const updateTranscriptionStatus = internalMutation({
+    args: {
+        submissionId: v.id('submissions'),
+        status: v.string(), // processing | complete | failed (string for cross-deploy safety)
+        error: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const patch: Record<string, unknown> = {
+            transcriptionStatus: args.status,
+        };
+        if (args.error !== undefined) patch.transcriptionError = args.error;
+        if (args.status === 'complete' || args.status === 'failed') {
+            patch.transcriptionUpdatedAt = Date.now();
+        }
+        await ctx.db.patch(args.submissionId, patch);
+    },
+});
+
+// ==================== GROQ WHISPER HELPER ====================
+
+/**
+ * POST one media chunk to Groq Whisper and return the transcript text.
+ * Retries once on transient connection errors. Throws on unrecoverable failures.
+ */
+async function callGroqWhisper(
+    chunk: ArrayBuffer,
+    filename: string,
+    groqKey: string
+): Promise<string> {
+    const form = new FormData();
+    form.append('file', new Blob([chunk]), filename);
+    form.append('model', 'whisper-large-v3');
+    form.append('response_format', 'json');
+
+    for (let attempt = 1; attempt <= 2; attempt++) {
+        try {
+            const res = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${groqKey}` },
+                body: form,
+            });
+            if (!res.ok) {
+                const text = await res.text().catch(() => '');
+                throw new Error(`Groq API ${res.status}: ${text.slice(0, 300)}`);
+            }
+            const json: any = await res.json();
+            return typeof json?.text === 'string' ? json.text : '';
+        } catch (err: any) {
+            const isTransient =
+                err?.code === 'ECONNRESET' ||
+                err?.cause?.code === 'ECONNRESET' ||
+                /Connection error|fetch failed|network/i.test(err?.message || '');
+            if (isTransient && attempt < 2) {
+                await new Promise((r) => setTimeout(r, 3000));
+                continue;
+            }
+            throw err;
+        }
+    }
+    throw new Error('Groq transcription failed after retries');
+}
+
+/**
+ * Trigger transcription for a submission's media file.
+ *
+ * Mobile-referenced via scheduler from submissions.update. Calls Groq Whisper
+ * directly with chunking support for 500MB+ files. DO NOT replace with a Next.js
+ * round-trip — see docs/changes/MOBILE-PARTY-FIX-TRANSCRIBE.md for the incident
+ * (2026-04-23) where the round-trip pattern 404'd in production because:
+ *   1. Clerk middleware was blocking the server-to-server call, AND
+ *   2. Convex in the cloud can't reach localhost during dev anyway.
+ *
+ * Direct-Groq removes one network hop, one auth surface, and one env-var
+ * dependency. Chunking lives in convex/lib/media-chunker.ts and handles
+ * webm/mp3/wav/mp4 at EBML Cluster / MP3 frame / PCM / AAC ADTS boundaries.
+ *
+ * Env vars required on the Convex deployment: GROQ_API_KEY, R2_PUBLIC_URL.
+ */
+export const transcribeMedia = internalAction({
+    args: {
+        submissionId: v.id('submissions'),
+        storageId: v.optional(v.string()),
+        mediaType: v.optional(v.union(v.literal('video'), v.literal('audio'))),
+    },
+    handler: async (ctx, args) => {
+        // Mark as processing so UIs can show a spinner while Groq works.
+        await ctx.runMutation(internal.submissions.updateTranscriptionStatus, {
+            submissionId: args.submissionId,
+            status: 'processing',
+        });
+
+        try {
+            const groqKey = process.env.GROQ_API_KEY;
+            if (!groqKey) {
+                throw new Error('GROQ_API_KEY env var not set on this Convex deployment');
+            }
+
+            // Resolve the storageId/URL/path to a fetchable HTTPS URL.
+            const r2Prefix = process.env.R2_PUBLIC_URL?.replace(/\/$/, '');
+            const raw = args.storageId || '';
+            let mediaUrl: string | null = null;
+            if (raw.startsWith('http://') || raw.startsWith('https://')) {
+                mediaUrl = raw;
+            } else if (/^(images|videos|audio)\//.test(raw) && r2Prefix) {
+                mediaUrl = `${r2Prefix}/${raw}`;
+            }
+            // Fallback: re-read the submission fields directly.
+            if (!mediaUrl) {
+                const fresh: any = await ctx.runQuery(internal.submissions.getByIdInternal, {
+                    id: args.submissionId,
+                });
+                const candidates = [fresh?.videoUrl, fresh?.audioUrl, fresh?.videoStorageId, fresh?.audioStorageId]
+                    .filter(Boolean) as string[];
+                for (const f of candidates) {
+                    if (f.startsWith('http')) { mediaUrl = f; break; }
+                    if (/^(images|videos|audio)\//.test(f) && r2Prefix) {
+                        mediaUrl = `${r2Prefix}/${f}`;
+                        break;
+                    }
+                }
+            }
+            if (!mediaUrl) {
+                throw new Error(`Could not resolve a fetchable URL for storageId "${args.storageId}"`);
+            }
+
+            // Download the media into memory as an ArrayBuffer.
+            console.log(`[transcribeMedia] Fetching ${mediaUrl}`);
+            const mediaRes = await fetch(mediaUrl);
+            if (!mediaRes.ok) {
+                throw new Error(`Failed to download media (HTTP ${mediaRes.status}): ${mediaUrl}`);
+            }
+            const contentType = mediaRes.headers.get('content-type') || '';
+            const buffer = await mediaRes.arrayBuffer();
+            const sizeMB = buffer.byteLength / 1024 / 1024;
+            console.log(
+                `[transcribeMedia] Downloaded ${sizeMB.toFixed(1)}MB, content-type="${contentType}"`
+            );
+
+            // Chunk if necessary — handles webm/mp3/wav/mp4. Files under the limit
+            // return as a single-element array.
+            const { chunkMediaFile, getFileExtension } = await import('./lib/mediaChunker');
+            const chunks = chunkMediaFile(buffer, contentType, undefined, mediaUrl);
+            const extension = getFileExtension(contentType, mediaUrl);
+            console.log(`[transcribeMedia] Split into ${chunks.length} chunk(s)`);
+
+            // Transcribe each chunk. Serial rather than parallel to respect Groq's
+            // rate limits and avoid memory spikes for very large files.
+            const transcripts: string[] = [];
+            for (let i = 0; i < chunks.length; i++) {
+                const filename = chunks.length > 1
+                    ? `chunk-${i + 1}-of-${chunks.length}.${extension}`
+                    : `audio.${extension}`;
+                console.log(
+                    `[transcribeMedia] Groq request ${i + 1}/${chunks.length} (${(chunks[i].byteLength / 1024 / 1024).toFixed(1)}MB)`
+                );
+                const text = await callGroqWhisper(chunks[i], filename, groqKey);
+                transcripts.push(text);
+            }
+
+            const fullTranscript = transcripts.join(' ').trim();
+            if (!fullTranscript) {
+                throw new Error('Groq returned an empty transcript');
+            }
+
+            await ctx.runMutation(internal.submissions.updateTranscription, {
+                submissionId: args.submissionId,
+                transcription: fullTranscript,
+            });
+            console.log(
+                `[transcribeMedia] Saved transcript for ${args.submissionId} (${fullTranscript.length} chars)`
+            );
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : 'Unknown transcription error';
+            console.error(`[transcribeMedia] submissionId=${args.submissionId}:`, reason);
+            await ctx.runMutation(internal.submissions.updateTranscriptionStatus, {
+                submissionId: args.submissionId,
+                status: 'failed',
+                error: reason,
+            });
+        }
     },
 });

--- a/convex/withdrawals.ts
+++ b/convex/withdrawals.ts
@@ -269,6 +269,81 @@ export const adminRetry = mutation({
     },
 });
 
+/**
+ * Admin override — public mutation name mobile expects. Behaviour mirrors
+ * adminRetry() but the arg shape matches docs/00-Overview-Mobile.md §withdrawals
+ * (id, status, transactionRef?, adminId) so the mobile admin UI keeps working.
+ */
+export const updateStatus = mutation({
+    args: {
+        id: v.id('withdrawals'),
+        status: v.union(
+            v.literal('processing'),
+            v.literal('completed'),
+            v.literal('failed')
+        ),
+        transactionRef: v.optional(v.string()),
+        adminId: v.string(),
+        failureReason: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const withdrawal = await ctx.db.get(args.id);
+        if (!withdrawal) throw new Error('Withdrawal not found');
+
+        const updates: Record<string, unknown> = { status: args.status };
+        if (args.transactionRef !== undefined) updates.transactionRef = args.transactionRef;
+        if (args.failureReason !== undefined) updates.failureReason = args.failureReason;
+
+        if (args.status === 'completed') {
+            updates.processedAt = Date.now();
+            const creator = await ctx.db.get(withdrawal.creatorId);
+            if (creator) {
+                await ctx.db.patch(withdrawal.creatorId, {
+                    totalWithdrawn: (creator.totalWithdrawn || 0) + withdrawal.amount,
+                });
+            }
+            await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+                creatorId: withdrawal.creatorId,
+                type: 'payout_sent',
+                title: 'Withdrawal Completed',
+                body: `Your withdrawal of ₱${withdrawal.amount} has been sent!`,
+                data: { withdrawalId: args.id, amount: withdrawal.amount },
+            });
+        } else if (args.status === 'failed') {
+            const creator = await ctx.db.get(withdrawal.creatorId);
+            if (creator) {
+                await ctx.db.patch(withdrawal.creatorId, {
+                    balance: (creator.balance || 0) + withdrawal.amount,
+                });
+            }
+            await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+                creatorId: withdrawal.creatorId,
+                type: 'system',
+                title: 'Withdrawal Failed',
+                body: `Your withdrawal of ₱${withdrawal.amount} could not be processed. Balance restored.`,
+                data: { withdrawalId: args.id, amount: withdrawal.amount },
+            });
+        }
+
+        await ctx.db.patch(args.id, updates);
+
+        await ctx.scheduler.runAfter(0, internal.auditLogs.log, {
+            adminId: args.adminId,
+            action: 'payout_admin_override',
+            targetType: 'withdrawal',
+            targetId: args.id,
+            metadata: {
+                amount: withdrawal.amount,
+                status: args.status,
+                transactionRef: args.transactionRef,
+                failureReason: args.failureReason,
+            },
+        });
+
+        return args.id;
+    },
+});
+
 // ==================== QUERIES ====================
 
 /**
@@ -346,6 +421,79 @@ export const getAll = query({
 });
 
 // ==================== INTERNAL MUTATIONS ====================
+
+/**
+ * Alias for mobile webhook handler — mobile's http.ts looks up withdrawals by
+ * `transactionRef` rather than `wiseTransferId`. Kept as a separate export so
+ * the deployed mobile binary's webhook path stays intact.
+ */
+export const updateByTransactionRef = internalMutation({
+    args: {
+        transactionRef: v.string(),
+        status: v.union(
+            v.literal('processing'),
+            v.literal('completed'),
+            v.literal('failed')
+        ),
+    },
+    handler: async (ctx, args) => {
+        // Search by transactionRef OR wiseTransferId — platforms have used both
+        // field names historically. This keeps the webhook working regardless
+        // of which field the transfer ID got persisted under.
+        const byRef = await ctx.db
+            .query('withdrawals')
+            .filter((q) => q.eq(q.field('transactionRef'), args.transactionRef))
+            .collect();
+        const byTransferId = byRef.length === 0
+            ? await ctx.db
+                  .query('withdrawals')
+                  .filter((q) => q.eq(q.field('wiseTransferId'), args.transactionRef))
+                  .collect()
+            : [];
+        const withdrawal = byRef[0] ?? byTransferId[0];
+        if (!withdrawal) {
+            console.error(`No withdrawal found for transactionRef: ${args.transactionRef}`);
+            return;
+        }
+
+        const updates: Record<string, unknown> = { status: args.status };
+
+        if (args.status === 'completed') {
+            updates.processedAt = Date.now();
+            const creator = await ctx.db.get(withdrawal.creatorId);
+            if (creator) {
+                await ctx.db.patch(withdrawal.creatorId, {
+                    totalWithdrawn: (creator.totalWithdrawn || 0) + withdrawal.amount,
+                });
+            }
+            await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+                creatorId: withdrawal.creatorId,
+                type: 'payout_sent',
+                title: 'Withdrawal Completed',
+                body: `Your withdrawal of ₱${withdrawal.amount} has been sent!`,
+                data: { withdrawalId: withdrawal._id, amount: withdrawal.amount },
+            });
+        }
+
+        if (args.status === 'failed') {
+            const creator = await ctx.db.get(withdrawal.creatorId);
+            if (creator) {
+                await ctx.db.patch(withdrawal.creatorId, {
+                    balance: (creator.balance || 0) + withdrawal.amount,
+                });
+            }
+            await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+                creatorId: withdrawal.creatorId,
+                type: 'system',
+                title: 'Withdrawal Failed',
+                body: `Your withdrawal of ₱${withdrawal.amount} could not be processed. Balance restored.`,
+                data: { withdrawalId: withdrawal._id, amount: withdrawal.amount },
+            });
+        }
+
+        await ctx.db.patch(withdrawal._id, updates);
+    },
+});
 
 /**
  * Update withdrawal status by Wise transfer ID.

--- a/docs/changes/MOBILE-AUDIO-SUBMISISONS.md
+++ b/docs/changes/MOBILE-AUDIO-SUBMISISONS.md
@@ -1,0 +1,250 @@
+# Mobile `submissions.update` Server Error (Audio Step) — Fix Plan — 2026-04-23
+
+> **Resolved 2026-04-23.** Root cause was **not** auth/ownership drift (§2.1 primary hypothesis), and **not** scheduler arg drift (§2.2 secondary hypothesis).
+>
+> Actual cause: **arg-type mismatch in the `update` mutation validator** — same class of bug as the R2 fix (see [`MOBILE-R2-FIX`](./MOBILE-R2-FIX)). Web's `submissions.update` declared `videoStorageId` and `audioStorageId` as `v.id('_storage')`, but mobile stores R2 object keys there (strings like `"audio/1721293-a2b3c4d5.m4a"`). Convex rejected mobile's call at the validator → handler never ran → surfaced on the client as `Server Error`.
+>
+> This falls under §3.6 (ValidationError) — the §3.5 remediation (creator-row migration) was NOT performed and NOT needed.
+>
+> Key detail that ruled out the §2.1 auth hypothesis: **web's `update` mutation does not have an auth or ownership check** ([convex/submissions.ts:260-302](../../convex/submissions.ts#L260-L302)). The only reachable throw paths are validator rejection (pre-handler) or `ctx.db.patch` schema rejection. The patch would have succeeded — `schema.ts` already declares `audioStorageId: v.optional(v.string())` — so the throw had to be at the validator layer.
+>
+> **Fix:** [`convex/submissions.ts`](../../convex/submissions.ts) — loosened `videoStorageId` / `audioStorageId` to `v.optional(v.string())` on both `create` (L202-L203) and `update` (L277-L278). Schema unchanged. No auth changes. No data migration.
+>
+> Deployed to `energetic-panther-693` via `npx convex deploy -y` after passing `--dry-run` (no function deletions, no schema changes). See [`MOBILE-FUNCTION-PARITY.md §Follow-up`](./MOBILE-FUNCTION-PARITY.md) for the three-classes-of-Server-Error diagnostic table that predicted this failure mode.
+>
+> The §3 diagnostic flow below remains valid for **future** `M(submissions:update)` errors — if tailing logs shows `Forbidden: you can only update your own submissions`, that IS the auth-drift branch and §3.5 applies. If logs show a `ValidationError` naming a different field than the ones fixed here, follow §3.6.
+
+> Companion to [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) and [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md). Do not skim. The two prior docs fixed different-shaped bugs; this one is a third, distinct failure mode.
+
+## For the implementing agent
+
+You are the agent. A user on the Google Play build hit this on **Step 3 of 4 — Record Interview**, immediately after finishing an audio recording and tapping "Next":
+
+```
+[CONVEX M(submissions:update)] [Request ID: e596e395584485ce] Server Error
+Called by client
+```
+
+Your job: find the throw, fix it, deploy, verify. **Tail the production logs first — do not guess.** The §3 diagnostic steps below are the path.
+
+Scope boundary: **do not change the database schema.** An earlier audit (recorded in [`MOBILE-PARITY-FIX-R2.md §5`](./MOBILE-PARITY-FIX-R2.md)) confirmed the web schema is already a superset of what mobile reads/writes. If production logs indicate a schema validation error on a specific field, update §5 of this document and get explicit approval before touching `schema.ts` — a schema change on the shared deployment impacts the mobile APK too.
+
+---
+
+## 1. Decoding the error
+
+- `M(submissions:update)` — this is a **mutation**. It's already in the deployment bundle (a missing function errors out with "Could not find public function", not "Server Error").
+- `Server Error` — the handler ran and threw an unhandled exception.
+- `Called by client` — the throw bubbled up directly to the client; no catch wrapper in between.
+
+Different signature from [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md): that one was `A(r2:generateUploadUrl)` (action, no auth, no DB). This one is `M(submissions:update)` (mutation, **has auth**, **writes to the DB**, **schedules an internal action**). So the throw locations are entirely different.
+
+---
+
+## 2. Where the handler can throw
+
+Open [`convex/submissions.ts:125-196`](../../convex/submissions.ts). The `update` mutation, in execution order, can throw at these points:
+
+| # | Line | Call | Throws when |
+|---|---|---|---|
+| 1 | 142 | `requireAuth(ctx)` | Clerk identity is missing / JWT expired / issuer mismatch. Thrown message: `"Not authenticated"`. |
+| 2 | 143-144 | `ctx.db.get(args.id)` + null check | `submissionId` points to a deleted/nonexistent row. Thrown message: `"Submission not found"`. |
+| 3 | 145-148 | Creator ownership check | `creator.clerkId !== identity.subject`. Thrown message: `"Forbidden: you can only update your own submissions"`. |
+| 4 | 176 | `ctx.db.patch(id, filteredUpdates)` | Convex schema validator rejects a field value (e.g. wrong type, or schema was changed in a way that breaks a pending value). |
+| 5 | 189-193 | `ctx.scheduler.runAfter(0, internal.submissions.transcribeMedia, {...})` | Args fail `transcribeMedia`'s validator at schedule time. This mutation throws if the internal action's expected args diverged. |
+
+The client-side call from [`app/(app)/submit/interview.tsx:670-674`](../../app/(app)/submit/interview.tsx#L670-L674) (audio path) is:
+
+```ts
+await updateSubmission({
+  id: submissionId as Id<'submissions'>,
+  audioStorageId: fileKey,        // R2 key, e.g. "audio/1721293-a2b3c4d5.m4a"
+  creatorPayout: payout,          // 300 for audio
+});
+```
+
+All three fields match the arg validator at [`convex/submissions.ts:125-140`](../../convex/submissions.ts#L125-L140). So the client payload is not the failure — the throw is somewhere **inside** the handler's effects.
+
+### 2.1 Primary hypothesis: auth identity does not match creator
+
+The TikTok OAuth login path was added recently (commit `b0ae0e0`). If a user's Clerk identity switched providers (email → TikTok) without the corresponding `creators.clerkId` being updated, the ownership check at line 146-148 throws `"Forbidden: you can only update your own submissions"` **even though the user is the legitimate owner**. This is the most likely cause and the one I'd check first.
+
+### 2.2 Secondary hypothesis: scheduler arg drift
+
+Line 189 schedules `internal.submissions.transcribeMedia`. That action's arg validator is currently ([`convex/submissions.ts:390-395`](../../convex/submissions.ts#L390-L395)):
+
+```ts
+args: {
+  submissionId: v.id("submissions"),
+  storageId: v.string(),
+  mediaType: v.string(),
+}
+```
+
+The call site passes exactly those three — should not fail at schedule time. But if a concurrent change to `transcribeMedia`'s signature lands, this is the kind of silent drift that turns a user action into `"Server Error"`.
+
+### 2.3 Tertiary hypothesis: R2-adjacent env vars (unlikely here)
+
+`submissions.update` itself does not read R2 env vars — those are used inside the scheduled `transcribeMedia` action, which runs **after** the mutation commits. A missing `GROQ_API_KEY` or `R2_*` var would fail transcription asynchronously, update `transcriptionStatus = "failed"`, and never surface to the client as a mutation error. So env var gaps do **not** explain this particular "Server Error". Rule this out last.
+
+---
+
+## 3. Diagnostic steps — run these first, in order
+
+Do not change code until §3.2 reveals the actual thrown error.
+
+### 3.1 Verify you are targeting the right deployment
+
+```bash
+npx convex env get CONVEX_DEPLOYMENT
+```
+
+Expect `prod:energetic-panther-693`. If it's a different value, stop — diagnosing the wrong deployment will waste time and produce misleading results.
+
+### 3.2 Tail production logs while reproducing
+
+```bash
+npx convex logs --prod --tail
+```
+
+Keep it running. Ask the reporter (or a test device) to repeat: record audio → tap Next. Watch for the mutation's thrown error. You're looking for one of:
+
+| Expected log message | → jump to |
+|---|---|
+| `Not authenticated` | §3.3 (auth token problem) |
+| `Submission not found` | §3.4 (stale submissionId) |
+| `Forbidden: you can only update your own submissions` | §3.5 (clerkId drift — most likely) |
+| Any `ValidationError` mentioning a specific field | §3.6 (schema issue — read carefully before acting) |
+| Anything else | paste it verbatim into §6 of this doc and escalate |
+
+**Do not proceed past this step until you have a concrete thrown-message string.** Every step below assumes you know which branch you're on.
+
+### 3.3 If the thrown error is `Not authenticated`
+
+The device's Clerk JWT is either missing, expired, or issued by a provider the Convex deployment doesn't trust.
+
+1. Confirm [`convex/auth.config.ts`](../../convex/auth.config.ts) contains the right Clerk frontend API domain. It should currently be:
+   ```ts
+   export default { providers: [{ domain: "https://clerk.negosyo-digital.com", applicationID: "convex" }] };
+   ```
+2. Confirm the mobile APK's Clerk publishable key is for the same instance (same frontend API domain). Mobile builds older than the current Clerk instance domain will fail auth. If mobile's build references a different Clerk domain, mobile needs a rebuild — not a web-side fix.
+3. If auth config is correct on both sides, have the user sign out and sign back in on the device. A stale JWT can simply not be refresh-able in the installed APK if the Clerk instance's keys rotated.
+
+### 3.4 If the thrown error is `Submission not found`
+
+Rare. The client holds a `submissionId` that no longer exists server-side. Possible causes: dev-data wipe, admin hard-delete, row migration with a new `_id`.
+
+1. Query `submissions` by the rough timestamp the user started the draft:
+   ```bash
+   npx convex run submissions:getByCreatorId '{"creatorId":"<their creator id>"}'
+   ```
+2. If the draft is missing, the client side needs to recreate it. The mobile fix is in [`app/(app)/submit`](../../app/(app)/submit) — but this is unlikely a web-repo task. Document the finding and escalate to the mobile team.
+
+### 3.5 If the thrown error is `Forbidden: you can only update your own submissions` — most likely branch
+
+Root cause: the `clerkId` stored on the `creators` row doesn't match the JWT's `subject` at call time. Common triggers:
+
+- User re-signed up with a different Clerk provider (e.g. TikTok OAuth after originally using email), creating a new Clerk user. Old submission row still points to the old `creators` row whose `clerkId` is the old Clerk user ID.
+- Clerk instance was recreated, invalidating all old IDs.
+
+Diagnose:
+
+1. Get the JWT `subject` (Clerk user ID) from the reproducing user. One way: temporary log in `requireAuth`:
+   ```ts
+   // convex/lib/auth.ts — ADD TEMPORARILY, revert after diagnosis
+   console.log("[requireAuth] subject:", identity.subject, "email:", identity.email);
+   ```
+2. Look up the `creators` row for the failing submission:
+   ```bash
+   npx convex run submissions:getById '{"id":"<submissionId>"}'
+   # Then:
+   npx convex run creators:getByClerkId '{"clerkId":"<the subject from step 1>"}'
+   ```
+3. Compare `creators._id` linked from the submission vs. the `creator` record returned for the current JWT subject. If they differ, the user has two creator rows — one from the old auth flow, one from the new.
+
+Remediation (do not do automatically without approval — this touches production data):
+
+- **Option A — merge creator records:** pick the "current" creators row (the one tied to the live JWT subject), re-point all submissions, earnings, withdrawals, referrals, analytics, notifications, pushTokens, and payoutMethods from the old row to the new one. Then mark the old row `isDeleted: true`. This requires a one-off admin script; schema supports it without changes.
+- **Option B — patch the old creators row's `clerkId`:** if the old row is the canonical creator and TikTok auth is additive (not a full takeover), just update `clerkId` on the old row to the new subject. Simpler, but only safe if the new Clerk user has no conflicting data of its own.
+
+Either way: **get user confirmation of the desired outcome before running the migration.** Do not silently pick one.
+
+Preventative (in scope for this fix, code-level):
+
+Update [`convex/creators.ts`](../../convex/creators.ts) — the `create` mutation at lines 30-85 — to also reconcile by email when a new Clerk subject shows up. If a `creators` row exists with the same `email` but different `clerkId`, that's a provider switch, not a new user. Either:
+
+- Merge the records (safer; preserves earnings/submissions), or
+- Refuse the second signup and surface a useful error.
+
+Pick one. Document the choice in `convex/creators.ts` as a header comment, matching the `Mobile-referenced — do not remove` convention from the R2 fix.
+
+### 3.6 If the thrown error is a Convex `ValidationError`
+
+Read the exact field name and expected vs. actual type from the log. Two sub-cases:
+
+1. **Field name mobile sent is not in the arg validator.** → Add it as `v.optional(...)` to the `update` mutation's args at [`convex/submissions.ts:125-140`](../../convex/submissions.ts#L125-L140). Do not remove or tighten any existing arg.
+2. **Field value mobile sent violates `schema.ts`.** → Update §5 of this doc with the field name and value, then escalate. Do **not** modify `schema.ts` without approval (see scope boundary at the top).
+
+---
+
+## 4. Fix, deploy, verify
+
+Once §3 identifies the branch and you've implemented the targeted change (or run the one-off migration from §3.5):
+
+1. Run `npx convex deploy --dry-run` from this repo. Inspect the output:
+   - "functions to be deleted" must be **empty**. Non-empty means you're about to drop something mobile calls — import from the mobile repo first.
+   - "schema changes" should also be empty unless you had explicit approval to touch `schema.ts`.
+2. Deploy: `npx convex deploy`.
+3. Ask the reporter (or use a test device) to repeat the audio submission flow end-to-end:
+   - Record → Next → upload succeeds (no R2 error)
+   - `submissions.update` succeeds (no mutation server error)
+   - Transcription status eventually moves `processing` → `complete` (check the submission row)
+4. Paste the successful reproduction trace into the PR description so the next person reading this doesn't have to re-derive acceptance criteria.
+
+---
+
+## 5. Schema — do NOT modify (unchanged from prior plan)
+
+Reaffirming the scope boundary from [`MOBILE-PARITY-FIX-R2.md §5`](./MOBILE-PARITY-FIX-R2.md): the web `convex/schema.ts` is a superset of the mobile inventory in [`docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md). All web-extras are `v.optional(...)`.
+
+Do not add, remove, or retype any schema field as part of this fix. If §3.6 or §3.5 investigation exposes a real schema gap, record it here before acting:
+
+> **Final finding (2026-04-23):** No schema change needed. The web `schema.ts` already declares `videoStorageId` / `audioStorageId` as `v.optional(v.string())`. The bug was on the *mutation validator* side — web's `submissions.update` validator declared these fields as `v.id('_storage')` while the underlying table accepted strings. The validator was tighter than the schema it guarded. Fix: relax the mutation validator to `v.optional(v.string())` to match the table. Schema untouched.
+
+---
+
+## 6. If the log shows something neither this doc nor [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md) covers
+
+Paste it here verbatim with the reproducing timestamp and request ID. Do not start implementing a speculative fix.
+
+> **2026-04-23 incident (resolved):** Client-side error was `[CONVEX M(submissions:update)] [Request ID: e596e395584485ce] Server Error`. The mutation's arg validator rejected mobile's `audioStorageId` value (an R2 object key, string) because the validator required `v.id('_storage')` (a Convex storage ID). Rejection happened pre-handler, so no handler log line appeared in `npx convex logs --prod --tail` — which is the signature of the "validator rejection" class described in [`MOBILE-FUNCTION-PARITY.md §Follow-up`](./MOBILE-FUNCTION-PARITY.md). Fix landed: relaxed `videoStorageId` / `audioStorageId` to `v.optional(v.string())` on both `create` and `update` mutations.
+
+---
+
+## 7. Acceptance checklist
+
+An agent closing this task must confirm **all** of:
+
+- [ ] The exact thrown message was observed in `npx convex logs --prod --tail` and is recorded in the PR description (one of: `Not authenticated` / `Submission not found` / `Forbidden: you can only update your own submissions` / `ValidationError: …` / other).
+- [ ] The code change (or one-off data migration) maps 1:1 to the observed message and nothing more. No speculative cleanups.
+- [ ] `convex/schema.ts` is **unchanged** (unless §5 was updated with the specific finding and explicitly approved).
+- [ ] `convex/submissions.ts` still exports `update`, `submit`, `updateTranscription`, `updateTranscriptionStatus`, `transcribeMedia` (mobile-referenced — verify with `npx convex deploy --dry-run` that nothing is being deleted).
+- [ ] Any temporary `console.log` added for diagnosis (e.g. in `requireAuth`) has been **removed** before the final deploy.
+- [ ] Audio submission reproduces end-to-end successfully on a real device or an Expo dev build: record → Next → no `Server Error` → review screen loads → submit succeeds → transcription eventually reaches `complete`.
+- [ ] If a data migration was run (§3.5 Option A or B), the migration script and its dry-run output are attached to the PR for audit.
+- [ ] `MOBILE-PARITY.md` gets a one-liner footnote linking to this doc so the next engineer understands that `Server Error` on a mutation is distinct from the function-parity class of bugs.
+
+---
+
+## 8. References
+
+- Prior incident: [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) — missing-function (404) class
+- Prior fix plan: [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md) — R2 env-var / signature class
+- Older schema sync: [`docs/changes/ADMIN-SCHEMA-CHANGE.md`](../changes/ADMIN-SCHEMA-CHANGE.md)
+- Mobile call site (audio): [`app/(app)/submit/interview.tsx:670-674`](../../app/(app)/submit/interview.tsx#L670-L674)
+- Mobile call site (video): [`app/(app)/submit/interview.tsx:663-668`](../../app/(app)/submit/interview.tsx#L663-L668)
+- Mobile offline sync (same mutation from a background worker): [`hooks/useOfflineSync.ts:110`](../../hooks/useOfflineSync.ts#L110), [`hooks/useOfflineSync.ts:170`](../../hooks/useOfflineSync.ts#L170), [`hooks/useOfflineSync.ts:228`](../../hooks/useOfflineSync.ts#L228), [`hooks/useOfflineSync.ts:235`](../../hooks/useOfflineSync.ts#L235)
+- Mutation under test: [`convex/submissions.ts:125-196`](../../convex/submissions.ts#L125-L196)
+- Auth helpers: [`convex/lib/auth.ts`](../../convex/lib/auth.ts)
+- Clerk trust config: [`convex/auth.config.ts`](../../convex/auth.config.ts)
+- Mobile overview (function inventory): [`docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md)

--- a/docs/changes/MOBILE-FUNCTION-PARITY.md
+++ b/docs/changes/MOBILE-FUNCTION-PARITY.md
@@ -1,0 +1,165 @@
+# Mobile Function Parity Restore — 2026-04-23
+
+## Problem
+
+Web and mobile share the production Convex deployment `energetic-panther-693` but live in separate `convex/` directories. `npx convex deploy` replaces the deployment's *entire* function bundle with whatever is in the caller's `convex/` folder. A recent deploy from this web repo silently dropped the mobile-only functions that the Google Play APK is hard-coded to call, and mobile flows started failing in production:
+
+- Photo submission (3+ photo step) — 404 on upload URL action
+- Profile photo update (edit profile) — same 404
+
+The mobile binary calls functions by name. Once a function name disappears from the deployment, every already-installed device that calls it fails.
+
+This matches the coordination risk already flagged in `docs/changes/ADMIN-SCHEMA-CHANGE.md` — same root cause, same fix pattern (make web's `convex/` folder a strict **superset** of what mobile references).
+
+## What was restored
+
+All four files below were edited to re-add functions mobile references per `docs/00-Overview-Mobile.md`. Each addition is annotated in-source as "referenced by the mobile app — do not remove" so future cleanups won't re-delete them.
+
+### `convex/r2.ts`
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `generateR2UploadUrl` | action | **Mobile name for the R2 upload-URL generator.** Shares an implementation with `generateUploadUrl` via a private helper. Fix for the reported photo/profile-photo breakage. |
+| `generateUploadUrl` | action | Existing web export, signature loosened (`submissionId` + `mediaType` now optional) so profile-photo uploads work through either name. |
+
+Accepted `mediaType` values expanded to `photo | video | audio | profile | avatar`. Profile/avatar variants store under `avatars/`; others unchanged.
+
+### `convex/submissions.ts`
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `updateTranscription(submissionId, transcription)` | internalMutation | Persist a completed transcript. |
+| `updateTranscriptionStatus(submissionId, status, error?)` | internalMutation | Lifecycle: `processing` → `complete` / `failed`. |
+| `transcribeMedia(submissionId, storageId?, mediaType?)` | internalAction | Triggers transcription; delegates to the Next.js `/api/transcribe` endpoint so both platforms share one implementation. |
+
+Imports updated to pull `internalMutation` and `internalAction` from `_generated/server`.
+
+### `convex/admin.ts`
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `markWebsiteGenerated(submissionId, adminId, websiteUrl?)` | mutation | Mobile admin flow: sets `status = 'website_generated'` + audit log. |
+| `getAllSubmissionsWithCreators()` | query | Alias for the existing `submissions.getAllWithCreator` query, under the name mobile expects. |
+
+### `convex/withdrawals.ts`
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `updateStatus(id, status, transactionRef?, adminId, failureReason?)` | mutation | Admin override matching mobile's signature (docs §withdrawals). Completes / fails a withdrawal with the correct side effects (`totalWithdrawn` increment on complete, balance restore on fail, audit log). |
+| `updateByTransactionRef(transactionRef, status)` | internalMutation | Webhook-handler alias. Looks up a withdrawal by `transactionRef` **or** `wiseTransferId` (both naming conventions have been used historically). |
+
+## Schema
+
+Schema was **not** modified. The reported breakage was a function-set divergence, not a schema divergence — adding the missing functions without touching `schema.ts` is the minimally-invasive fix.
+
+## Deploy
+
+Ran `npx convex codegen` which uploaded the restored functions to `energetic-panther-693`. Mobile flows should resolve without a new Play Store build — the APK just starts seeing the functions again.
+
+## Preventing this next time
+
+Before any `npx convex deploy` from this web repo:
+
+```bash
+npx convex deploy --dry-run
+```
+
+Read the output carefully. The **"functions to be deleted"** section must be empty. If it isn't, each entry is a function mobile's APK is calling — pull it into this repo's `convex/` folder first (copy from mobile's repo or `docs/00-Overview-Mobile.md §Convex Backend — All Functions`), then deploy.
+
+Header comments on each restored function name them explicitly as "mobile-referenced — do not remove" to reduce the chance a future cleanup re-drops them.
+
+## Longer-term
+
+The per-deploy coordination risk goes away entirely if web uses its own Convex deployment rather than sharing `energetic-panther-693` with mobile. One command (`npx convex env set CONVEX_DEPLOYMENT …`) followed by re-pointing `NEXT_PUBLIC_CONVEX_URL`. Worth doing next time both teams are available to verify data routing.
+
+## Reference
+
+- Mobile function inventory: [`docs/00-Overview-Mobile.md`](../00-Overview-Mobile.md) §Convex Backend — All Functions (L1350+)
+- Prior schema-sync incident: [`docs/changes/ADMIN-SCHEMA-CHANGE.md`](./ADMIN-SCHEMA-CHANGE.md)
+
+---
+
+## Follow-up — 2026-04-23 (same day)
+
+The fix above restored every missing function name, but mobile photo upload was **still** failing after redeploy. See [`MOBILE-R2-FIX`](./MOBILE-R2-FIX) for the secondary investigation writeup.
+
+**Actual root cause of the lingering error** — *not* the one the follow-up doc predicted:
+
+- The follow-up doc's "prime suspect" was missing R2 env vars on the deployment. Confirmed ruled out: `npx convex env list` on `energetic-panther-693` showed `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_PUBLIC_URL` all present with real values.
+- The real cause was **argument shape mismatch** on `r2.generateUploadUrl`. The Play Store APK calls it with `{ folder, filename, contentType }` (lowercase, with a `folder` field). This repo's validator declared `{ fileName, fileType, submissionId?, mediaType? }` (camelCase, no `folder`). Convex rejects unknown fields and missing required fields by default, and that rejection surfaces on the mobile client as `[CONVEX A(r2:generateUploadUrl)] Server Error` — indistinguishable at first glance from a genuine handler-threw exception.
+
+**What the fix did** — [`convex/r2.ts`](../../convex/r2.ts):
+
+- Declared every field optional at the validator layer (`fileName` + `filename`, `fileType` + `contentType`, `folder`, `submissionId`, `mediaType`) so both arg shapes pass validation.
+- Normalized inside the handler (`name = args.fileName ?? args.filename`, etc.) and raised clear error messages if neither variant is present.
+- Return value now includes both `key` (web-style) and `fileKey` (mobile-style) for the same both-shapes reason.
+- Applied the same dual-shape signature to the `generateR2UploadUrl` alias.
+
+Deployed via `npx convex deploy -y` to `energetic-panther-693`.
+
+**Lesson — read "Server Error" as a superset of three failure classes, not one:**
+
+| Client-side string | Underlying cause | Diagnostic |
+|---|---|---|
+| `Could not find public function …` | Function missing from the deployment bundle | Function-parity restore (this doc's main body) |
+| `Server Error` + handler ran | Handler threw at runtime | Env vars, external API, schema violation inside handler |
+| `Server Error` + handler never ran | Validator rejected the args | Check mobile's actual call shape against the validator |
+
+The third row is what bit us. If future mobile-incident debugging sees `Server Error`, tail `npx convex logs --prod --tail` while reproducing — if the handler's log output doesn't appear, it's a validator rejection and the fix is signature-shape, not function-restore.
+
+---
+
+## Second occurrence of the validator-rejection class — 2026-04-23 (same day)
+
+A few hours after the R2 fix, mobile hit another `Server Error` on audio submission — this time at `[CONVEX M(submissions:update)]`. Same root-cause class (validator rejected the mobile call before the handler ran), different field: `audioStorageId`.
+
+- **Web's `update` validator** declared `audioStorageId: v.optional(v.id('_storage'))` — required a Convex internal storage ID.
+- **Mobile sends** `audioStorageId: fileKey` where `fileKey` is an R2 object key string like `"audio/1721293-a2b3c4d5.m4a"`.
+- **`schema.ts` already stored it as `v.optional(v.string())`** — so the bug was the *mutation* validator being tighter than the *table* schema.
+- **Fix**: loosened `videoStorageId` / `audioStorageId` to `v.optional(v.string())` on both `submissions.create` and `submissions.update`. Schema untouched. See [`MOBILE-AUDIO-SUBMISISONS.md`](./MOBILE-AUDIO-SUBMISISONS.md) for the full writeup.
+
+**Lesson refined — the "mutation validator tighter than the table schema" anti-pattern:**
+
+Every `v.id('_storage')` declared as a *mutation argument* for a field the *table* stores as `v.string()` is a latent validator-rejection bug waiting for a caller that sends a plain string. Audit step for future mobile-function work:
+
+```bash
+# Any arg validator using v.id('_storage') where the matching table field is v.string() is suspect.
+# Start with these three files: submissions.ts, creators.ts, generatedWebsites.ts.
+```
+
+If the table stores a string, the mutation validator should accept a string too — never `v.id('_storage')`. Convex accepts strings for storage IDs at the DB layer (they're just opaque strings internally), so `v.string()` is always the permissive-correct choice for this field type.
+
+---
+
+## Third occurrence — transcription Next.js round-trip 404 — 2026-04-23 (same day)
+
+A few more hours after the audio-submission fix, mobile audio was uploading successfully + getting marked for transcription but the transcript never arrived — `transcriptionStatus` stayed `'processing'`, then flipped to `'failed'` with `Transcription API returned 404: <!DOCTYPE html>…`. Separate root cause from the validator-rejection pattern.
+
+- **`transcribeMedia`** was implemented as a Next.js round-trip — Convex action → HTTP POST to `${SITE_URL}/api/transcribe` → Groq. Two independent problems killed it:
+  - Clerk middleware was intercepting `/api/transcribe` (not in the `isPublicRoute` list) and serving Next.js's 404 HTML page before the route handler's internal-secret bypass could run.
+  - Convex runs in the cloud, so it can't reach `localhost:3000` during local dev — the round-trip pattern is fundamentally dev-hostile.
+- **Fix**: rewrote `transcribeMedia` to call Groq Whisper directly, with chunking support for 500MB+ files via `convex/lib/mediaChunker.ts` (copied from `lib/services/media-chunker.ts`; renamed because Convex module names can't contain hyphens). See [`MOBILE-PARTY-FIX-TRANSCRIBE.md`](./MOBILE-PARTY-FIX-TRANSCRIBE.md) for the writeup.
+
+**Lesson refined again — the "Next.js round-trip from Convex" anti-pattern:**
+
+Any pattern where a Convex action HTTP-POSTs back to the Next.js app it belongs to is a latent outage. Three things have to stay aligned across two env surfaces: the URL, the auth contract (Clerk middleware allow-list + per-route secret check), and the network reachability (cloud ↔ user's laptop). Direct third-party API calls from Convex eliminate all three. Prefer them whenever the logic is self-contained. The existing [`convex/withdrawals.ts sendStatusEmailAction`](../../convex/withdrawals.ts) and [`convex/submissions.ts transcribeMedia`](../../convex/submissions.ts) are both instances of this pattern; of those, `transcribeMedia` is now direct-Groq. `sendStatusEmailAction` still round-trips to `/api/internal/send-withdrawal-status-email` — consider converting it to direct Gmail/nodemailer from Convex on the next touch.
+
+---
+
+## Fourth occurrence — mobile signup blocked by missing `isDeletedByEmail` — 2026-04-23 (same day)
+
+Highest-severity of the four — blocked *all* new account creation on the Google Play APK. Different from the earlier three because it's a plain missing-export, not a signature mismatch or middleware issue.
+
+- The mobile signup screen calls `api.creators.isDeletedByEmail({email})` unauthenticated the instant the Create Your Account form mounts (doc §1 call site). It's also called from forgot-password.
+- Web's [`convex/creators.ts`](../../convex/creators.ts) simply didn't export the function. Grepped, zero hits.
+- The mobile SDK surfaced the miss as `Server Error` rather than "Could not find public function" — so the failure looked like a handler crash and read identically to the earlier three incidents on the client side.
+- **Fix**: added the exported query with a one-line body that does an indexed `by_email` lookup and returns the `isDeleted` flag as a boolean. Unauthenticated by design — the caller hasn't signed in yet. Header comment says `Mobile-referenced — do NOT add an auth guard`. See [`MOBILE-REGISTER-ERROR.md`](./MOBILE-REGISTER-ERROR.md).
+
+**Lesson for the audit list — signup is on the critical path:**
+
+The function-parity audit needs to specifically call out any function the mobile APK calls *before* the user is authenticated. Those can't be guarded with `requireAuth` / `requireAdmin` without breaking signup or forgot-password. Current known unauthenticated callers on the mobile side:
+
+- `creators.isDeletedByEmail` — signup + forgot-password
+- `creators.getByClerkId` — gets called post-signup but during initial bootstrap before profile exists
+
+Before ever adding an auth wrapper to any function in `convex/creators.ts`, check whether the mobile signup / forgot-password / onboarding screens call it. If they do, either leave it unauthenticated or split into two exports (one public, one `*Admin` variant).

--- a/docs/changes/MOBILE-PARTY-FIX-TRANSCRIBE.md
+++ b/docs/changes/MOBILE-PARTY-FIX-TRANSCRIBE.md
@@ -1,0 +1,309 @@
+# Mobile Transcription 404 — Web `transcribeMedia` Fix Plan — 2026-04-23
+
+> **Resolved 2026-04-23 via Option A (§2.1).** Web repo's `convex/submissions.ts` `transcribeMedia` action has been rewritten to call Groq Whisper directly with chunking support for 500MB+ files. No more Next.js round-trip. Chunking helper copied from `lib/services/media-chunker.ts` into [`convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts) so Convex bundles it (Convex module names can't contain hyphens — camelCase). See §6 for captured diagnostics and §7 for acceptance check-off.
+
+> Third companion to [`MOBILE-PARITY.md`](./MOBILE-PARITY.md), [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md), and [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md). Read those first — this builds on the same shared-deployment failure mode.
+
+## For the implementing agent
+
+You are the agent. **You will be working in the web repo's `convex/` folder, not this mobile repo.** This plan file lives in the mobile repo (`ndm/docs/plans/`) so the human can hand it to you alongside the reference implementation; all paths starting with `convex/` below mean the **web repo's** `convex/` folder unless explicitly prefixed `ndm/`.
+
+The bug: after Step 3 (Record Interview) on the mobile APK, transcription kicks off async and immediately fails with this server log:
+
+```
+[transcribeMedia] submissionId=jd766fm0k2t5sc0wyg2mrxq86x85dxk2:
+  Transcription API returned 404: <!DOCTYPE html><!--nSxO_fbIwv80mxn0NUvF_-->
+  <html lang="en"><head><meta charSet="utf-8">…<link rel="stylesheet"
+  href="/_next/static/chunks/2473c16c0c2f6b5f.css" data-precedence="next">…
+```
+
+That HTML body is the Next.js 404 page. So whatever URL the deployed `transcribeMedia` action is calling, the Next.js web app at that origin doesn't have a route registered there.
+
+---
+
+## 1. Why this is happening
+
+Per the inventory in [`MOBILE-PARITY.md` §`convex/submissions.ts`](./MOBILE-PARITY.md), the **web** team's version of `transcribeMedia` is documented as:
+
+> `transcribeMedia(submissionId, storageId?, mediaType?)` — internalAction — Triggers transcription; **delegates to the Next.js `/api/transcribe` endpoint** so both platforms share one implementation.
+
+That's the version currently running on production deployment `energetic-panther-693` (it has to be — the error string `"Transcription API returned 404"` is not present in the mobile repo's `transcribeMedia`, which calls Groq Whisper directly and would have thrown `"Groq API error 404: …"` instead).
+
+So the deployed action is making an HTTP request to the Next.js web app's `/api/transcribe` route, and getting back the Next.js 404 page. That means **at least one** of the following is true on the web platform:
+
+1. The `/api/transcribe` route handler does not exist in the Next.js app at all (never written, deleted, or the file was removed in a recent refactor).
+2. The route exists but is at a different path (`/api/transcriptions`, `/api/transcribe/audio`, `/api/v1/transcribe`, etc.) and `transcribeMedia` is hardcoded to the wrong URL.
+3. The route exists in the Next.js source but isn't deployed to the public URL `transcribeMedia` is calling — e.g., it's only in a feature branch, or the latest Vercel/Cloudflare deploy failed, or the URL points at a stale environment (preview vs prod).
+4. The route exists and is deployed, but its method is not `POST` (or whatever method `transcribeMedia` uses), so Next.js returns 404 for the unmatched method.
+
+Pick the right one with §3's diagnostics. Don't guess.
+
+### 1.1 Why this can't be patched from the mobile side
+
+Both apps share `energetic-panther-693`. The deployed `transcribeMedia` is whatever was last pushed by `npx convex deploy` — currently the web version. If mobile ran its own `npx convex deploy` from `ndm/`, it would replace `transcribeMedia` with the Groq-direct version and **also** replace every other web-only function in the same bundle (the inverse of [`MOBILE-PARITY.md`](./MOBILE-PARITY.md)'s breakage). That's a regression in the opposite direction. Don't do it.
+
+→ **The fix has to land on the web side.** Two routes are open; pick one based on §3.
+
+---
+
+## 2. The two viable fixes
+
+### 2.1 Option A — Make web's `transcribeMedia` self-contained (recommended)
+
+Replace the web repo's `convex/submissions.ts` `transcribeMedia` action with the same Groq-direct implementation the mobile repo has. The mobile repo has a known-working version at [`ndm/convex/submissions.ts:390-594`](../../convex/submissions.ts#L390-L594) — copy it byte-for-byte (with the helper `callGroqWhisper` at lines 569-594, and the chunking helper imported from [`ndm/convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts)).
+
+**Why recommended:**
+
+- Removes a network hop and removes a circular dependency (Convex action → Next.js HTTP route → Groq → back), which is fragile across env-var drift and cold-start latency.
+- The mobile-side version is already battle-tested.
+- One less thing the web Next.js deploy can break.
+- Matches `MOBILE-PARITY.md`'s stated goal: "make web's `convex/` folder a strict superset of what mobile references." Having two divergent `transcribeMedia` implementations is itself a parity violation.
+
+**Changes required on the web side:**
+
+1. Replace the body of `transcribeMedia` in `convex/submissions.ts` with the Groq-direct version from the mobile repo's [`convex/submissions.ts:390-567`](../../convex/submissions.ts#L390-L567). Keep the export name and the arg validator shape (`submissionId`, `storageId`, `mediaType` — match whatever the deployed signature is so the existing scheduled-action callers don't break).
+2. Add the `callGroqWhisper` private helper from the mobile repo's [`convex/submissions.ts:569-594`](../../convex/submissions.ts#L569-L594).
+3. Copy [`ndm/convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts) into the web repo's `convex/lib/` folder if it isn't already there (the chunked-file path needs it).
+4. Set/verify the `GROQ_API_KEY` env var on `energetic-panther-693`:
+   ```bash
+   npx convex env get GROQ_API_KEY
+   # If absent:
+   npx convex env set GROQ_API_KEY <value>
+   ```
+5. **Do not** delete the existing Next.js `/api/transcribe` route file (if any) in the same PR — leave it for a follow-up cleanup. If something else still calls it, deleting it now causes a separate 404.
+
+### 2.2 Option B — Add/fix the missing Next.js `/api/transcribe` route
+
+If the web team has a strong reason to keep the round-trip architecture (e.g., they're doing custom auth, request shaping, or enrichment in the Next.js layer that mobile doesn't have access to), then instead of replacing `transcribeMedia`, fix the Next.js route.
+
+**Changes required on the web side:**
+
+1. Find what URL the deployed `transcribeMedia` is calling. Do this by reading the deployed source for the action. Either:
+   - Open the web repo's `convex/submissions.ts` (the source of truth for what's deployed) and find the `fetch(...)` call inside `transcribeMedia`.
+   - Or ask Convex to dump the deployed function source: `npx convex function-spec` (lists deployed functions) — note this doesn't show source bodies; the repo is the source of truth.
+2. Locate the Next.js route file matching that URL (e.g., `app/api/transcribe/route.ts` for app-router or `pages/api/transcribe.ts` for pages-router).
+3. If the file is missing → write it. The endpoint must accept the same body shape `transcribeMedia` sends (likely `{ submissionId, storageId, mediaType }` or similar) and forward to Groq. Use the mobile repo's [`callGroqWhisper`](../../convex/submissions.ts#L569-L594) as the canonical implementation reference.
+4. If the file exists but the method is wrong → fix the export. App-router needs `export async function POST(...)` (case-sensitive). Pages-router needs `export default function handler(req, res)` with a `req.method === "POST"` check.
+5. If the URL the action is calling points at the wrong host/env (e.g., pointing at a preview URL or `localhost`) → update the env var or constant the action uses, then redeploy Convex.
+6. Confirm Groq env vars are present on whatever host serves the Next.js route (Vercel project env, Cloudflare Pages env, etc.). The Next.js route's `GROQ_API_KEY` is *separate* from the Convex deployment's `GROQ_API_KEY`.
+
+**Why this is the second-choice option:**
+
+- Two implementations to maintain.
+- Two env-var surfaces to keep aligned.
+- Network round-trip adds latency to every transcription.
+- Mobile is calling a web-app endpoint just to reach Groq — Convex itself can reach Groq directly, so the indirection adds no value on the mobile path.
+
+---
+
+## 3. Diagnostic steps — run these first, in order
+
+### 3.1 Confirm which deployment you're targeting
+
+```bash
+# In the web repo
+npx convex env get CONVEX_DEPLOYMENT
+```
+
+Expect `prod:energetic-panther-693`. If different, stop — you're about to "fix" the wrong deployment.
+
+### 3.2 Tail prod logs while reproducing
+
+```bash
+npx convex logs --prod --tail
+```
+
+On a test device or Expo dev build, record an audio interview and tap Next. You should see:
+
+- The `submissions.update` mutation succeed (otherwise you're hitting [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md) instead — fix that first).
+- `transcribeMedia` start.
+- The 404 error string with the URL it's calling. **Capture the exact URL from the log.** That URL drives every step below — paste it into §6 of this doc before you do anything else.
+
+If the URL ends in `/api/transcribe` exactly → §3.3.
+If it ends in something else (`/api/transcriptions`, custom path) → §3.4.
+If `GROQ_API_KEY` errors appear before the URL is even hit → §3.5.
+
+### 3.3 Verify the Next.js route file
+
+In the web repo:
+
+- App-router: does `app/api/transcribe/route.ts` exist? Does it `export async function POST`?
+- Pages-router: does `pages/api/transcribe.ts` exist? Does it default-export a handler that accepts `POST`?
+- If neither file exists → the route was never created or was deleted. Go to **Option A (§2.1)** unless there's a hard reason to add the route.
+- If the file exists but the wrong-shape export → fix the export (Option B, §2.2 step 4) and redeploy the Next.js app.
+
+### 3.4 Verify the URL the action is hardcoded to
+
+Open the web repo's `convex/submissions.ts`, find `transcribeMedia`, find the `fetch(...)` call, capture the URL or env-var template. Common gotchas:
+
+- Hardcoded `http://localhost:3000/api/transcribe` — was committed during dev, never replaced. Fix: switch to an env var (`process.env.WEB_BASE_URL` or similar) and set it on the deployment via `npx convex env set`.
+- Pointing at a Vercel preview URL that has since been torn down. Fix: same as above.
+- Missing protocol or trailing slash mismatch. Fix: normalize.
+
+If the URL is fine but the route still 404s → back to §3.3.
+
+### 3.5 Verify Groq env vars on the Convex deployment
+
+Whether you go Option A or Option B, the path that ultimately calls Groq needs `GROQ_API_KEY`:
+
+```bash
+npx convex env get GROQ_API_KEY
+```
+
+If absent, set it:
+
+```bash
+npx convex env set GROQ_API_KEY <value>
+```
+
+Get the value from the mobile team's `.env.local` or the Groq dashboard. Don't commit it.
+
+For Option B, also set `GROQ_API_KEY` on the Next.js host (Vercel/Cloudflare project env), separately from the Convex env.
+
+---
+
+## 4. Implementation walkthrough — Option A (recommended)
+
+Working in the **web repo**:
+
+### 4.1 Copy the reference implementation
+
+Open the mobile repo file [`ndm/convex/submissions.ts`](../../convex/submissions.ts) and copy these spans verbatim:
+
+- Lines 390-567: the `transcribeMedia` `internalAction`.
+- Lines 569-594: the `callGroqWhisper` helper at the bottom.
+
+Paste them into the web repo's `convex/submissions.ts`, **replacing** the existing `transcribeMedia` definition (and any private helper it depended on for the Next.js round-trip).
+
+Verify these imports already exist at the top of the web file (add them if missing):
+
+```ts
+import { internalAction, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { chunkMediaFile } from "./lib/mediaChunker";
+import { getR2Config, generatePresignedUrl } from "./lib/r2Helpers";
+```
+
+### 4.2 Copy the chunker helper
+
+If [`convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts) doesn't already exist in the web repo, copy it from the mobile repo at [`ndm/convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts). Don't refactor it; just drop it in.
+
+### 4.3 Verify env vars
+
+```bash
+# In the web repo
+npx convex env get GROQ_API_KEY      # must exist
+npx convex env get R2_ACCOUNT_ID     # must exist (used to fetch the file before sending to Groq)
+npx convex env get R2_ACCESS_KEY_ID
+npx convex env get R2_SECRET_ACCESS_KEY
+npx convex env get R2_PUBLIC_URL     # optional fallback
+```
+
+If `R2_*` are missing → that's the same gap covered by [`MOBILE-PARITY-FIX-R2.md §3.3`](./MOBILE-PARITY-FIX-R2.md). Fix that first (or in the same PR, your call).
+
+### 4.4 Header-comment the function
+
+Per the convention from [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) and [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md), add a header comment to `transcribeMedia` so a future cleanup doesn't re-introduce the indirection:
+
+```ts
+// transcribeMedia — mobile-referenced via scheduler from submissions.update.
+// Calls Groq Whisper API directly. DO NOT replace with a Next.js round-trip
+// (see docs/plans/MOBILE-PARITY-FIX-TRANSCRIBE.md for the incident that
+// caused that pattern to fail in production on 2026-04-23).
+```
+
+### 4.5 Pre-deploy diff check
+
+```bash
+npx convex deploy --dry-run
+```
+
+The "functions to be deleted" section **must be empty**. If it lists any function from the mobile inventory in [`ndm/docs/01-mobile-app/00-Overview-Mobile.md §Convex Backend`](../01-mobile-app/00-Overview-Mobile.md), import it before deploying — same drill as the prior plans.
+
+### 4.6 Deploy and verify
+
+```bash
+npx convex deploy
+```
+
+On a real device or dev build:
+
+1. Record an audio interview, tap Next.
+2. Watch `npx convex logs --prod --tail` — you should see `[Transcription] Starting…` then `[Transcription] Saved to database successfully!`.
+3. Open the submission in the admin panel and confirm `transcript` is populated and `transcriptionStatus = "complete"`.
+
+If transcription fails differently (e.g., `Groq API error 401` or `Failed to download file: HTTP 403`), the 404 problem is fixed but you've uncovered a separate env var or R2 permission issue — that's a follow-up, not a regression.
+
+---
+
+## 5. Implementation walkthrough — Option B (round-trip preserved)
+
+Only choose this if there's an explicit reason to keep the Next.js layer in the path. Steps abbreviated since Option A is recommended:
+
+1. Reproduce per §3.2, capture the exact URL the action calls.
+2. Find or create the matching Next.js route file (§3.3).
+3. The route handler should:
+   - Validate the request (recommend a shared secret header verified against `process.env.CONVEX_TRANSCRIBE_SECRET` — without it, this route is an open Groq proxy that costs money on every public POST).
+   - Look up the file from the body's `storageId` (R2 fetch via the same helpers Convex uses, or pass the URL pre-resolved from the Convex side).
+   - POST the file to Groq using the same body shape as [`callGroqWhisper`](../../convex/submissions.ts#L569-L594) in the mobile repo.
+   - Return `{ transcription: string }`.
+4. Set `GROQ_API_KEY` on the Next.js host's env. Confirm the deployed Next.js build has the new route.
+5. From `convex/submissions.ts`, confirm the action sets the shared-secret header on its `fetch(...)` call.
+6. Reproduce per §4.6.
+
+If you take Option B, also write a small integration test that hits the Next.js route directly with a known-good audio sample and asserts a 200 response with a non-empty transcription — so the next "Vercel preview is gone" or "route file got renamed" incident is caught at deploy time, not by an end user.
+
+---
+
+## 6. Captured diagnostics — fill in before implementing
+
+Do not skip this section. Paste log output here so the next person reading the PR can reconstruct what you saw.
+
+> **Exact URL `transcribeMedia` was calling before the fix:**
+> `https://negosyo-digital.com/api/transcribe` (from `SITE_URL` env var on `energetic-panther-693`).
+>
+> **Full first error log line including request ID:**
+> `[transcribeMedia] submissionId=jd766fm0k2t5sc0wyg2mrxq86x85dxk2: Transcription API returned 404: <!DOCTYPE html><!--nSxO_fbIwv80mxn0NUvF_--><html lang="en">…` (Next.js not-found HTML page returned because Clerk middleware was intercepting `/api/transcribe` — the route handler never ran).
+>
+> **Result of `npx convex env get GROQ_API_KEY`:**
+> present.
+>
+> **Chosen option (A or B) and one-line justification:**
+> **Option A.** Next.js round-trip had two unfixable-in-dev problems — Clerk middleware was redirecting the server-to-server call (producing the 404 HTML), and even with middleware bypassed Convex-in-the-cloud can't reach `localhost:3000` during local development. Direct-Groq removes both, plus eliminates env-var drift risk across the two surfaces.
+
+---
+
+## 7. Acceptance checklist
+
+An agent finishing this task must confirm **all** of:
+
+- [ ] §6 is filled in with real captured output, not "TODO".
+- [ ] Web repo `convex/submissions.ts` `transcribeMedia` action no longer makes an HTTP request to a Next.js route (Option A) — OR the Next.js route exists, is deployed, returns 200 for the action's body shape, and has its env vars configured (Option B).
+- [ ] `npx convex env get GROQ_API_KEY` on `energetic-panther-693` returns a value.
+- [ ] `npx convex deploy --dry-run` shows zero "functions to be deleted" before the actual deploy.
+- [ ] `convex/schema.ts` is **unchanged** (transcription is a function-set bug, not a schema bug — see [`MOBILE-PARITY-FIX-R2.md §5`](./MOBILE-PARITY-FIX-R2.md) for the schema-stays-frozen rationale).
+- [ ] An end-to-end audio submission on a real device produces a complete transcript visible in the admin panel.
+- [ ] Header comment from §4.4 is in place, citing this doc, so the next refactor doesn't undo the fix.
+- [ ] One-liner footnote added to [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) linking here, noting that the Next.js round-trip pattern caused the 2026-04-23 transcription outage.
+- [ ] No GROQ or R2 secrets committed to git (search the diff for the literal env-var values).
+
+---
+
+## 8. Why this keeps happening (read once, then apply going forward)
+
+Three plan files now (this one, [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md), [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md)) all trace back to the same root cause: **two repos sharing one Convex deployment, with divergent function implementations and no automated parity check**. Every `npx convex deploy` from one repo silently overwrites the other's bundle.
+
+The three patches above resolve the immediate user-visible failures. The longer-term fix is still the one [`MOBILE-PARITY.md §Longer-term`](./MOBILE-PARITY.md) recommended: split the deployments. Until that happens, treat every web-side `npx convex deploy` as a potential mobile outage and use `--dry-run` first, every time.
+
+---
+
+## 9. References
+
+- Reference implementation (Groq-direct, known-working): [`ndm/convex/submissions.ts:390-594`](../../convex/submissions.ts#L390-L594)
+- Reference helper (file chunking for >25MB): [`ndm/convex/lib/mediaChunker.ts`](../../convex/lib/mediaChunker.ts)
+- Reference helpers (R2 fetch for source file): [`ndm/convex/lib/r2Helpers.ts`](../../convex/lib/r2Helpers.ts)
+- Original incident: [`MOBILE-PARITY.md`](./MOBILE-PARITY.md)
+- Companion fixes: [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md), [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md)
+- Mobile call site that triggers the scheduled transcription: [`ndm/convex/submissions.ts:178-194`](../../convex/submissions.ts#L178-L194) (the `submissions.update` handler)
+- Mobile function inventory: [`ndm/docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md) §Convex Backend

--- a/docs/changes/MOBILE-R2-FIX
+++ b/docs/changes/MOBILE-R2-FIX
@@ -1,0 +1,291 @@
+# Mobile R2 Upload Server Error — Fix Plan — 2026-04-23
+
+> **Resolved 2026-04-23.** Root cause was **not** missing R2 env vars (this doc's "prime suspect"). The env vars were all present on `energetic-panther-693`.
+>
+> Actual cause: **arg-shape mismatch on `r2.generateUploadUrl`**. The Play Store APK calls it with `{ folder, filename, contentType }` (lowercase + explicit `folder`). This repo's validator declared `{ fileName, fileType, submissionId?, mediaType? }` (camelCase, no `folder`). Convex's validator rejected the mobile call shape as "unknown fields + missing required fields" — and that rejection surfaces on the client as `Server Error`, indistinguishable from a handler-threw exception.
+>
+> Fix: [`convex/r2.ts`](../../convex/r2.ts) now declares every field optional at the validator and normalizes inside the handler (accepts both `fileName`/`filename`, both `fileType`/`contentType`, both web and mobile call shapes). Return value includes both `key` (web) and `fileKey` (mobile). Same treatment for the `generateR2UploadUrl` alias.
+>
+> See [`MOBILE-FUNCTION-PARITY.md §Follow-up — 2026-04-23`](./MOBILE-FUNCTION-PARITY.md) for the full writeup, including the "three classes of `Server Error`" diagnostic table that distinguishes validator rejections from handler exceptions.
+>
+> The §3 diagnostic steps below remain useful for **any future** mobile R2 breakage (run them before assuming this is the same class of bug), but §3.3 (env-var restore) is not the fix that was applied here.
+
+## For the implementing agent
+
+You are being asked to diagnose and fix a production error on the mobile Android APK. The APK calls a Convex action on the shared deployment `energetic-panther-693` and receives a generic server error. This document tells you exactly what to check, in what order, and what to change. Do not make schema changes unless the diagnostic steps below prove one is needed.
+
+Read this file top-to-bottom before touching any code.
+
+---
+
+## 1. The observed error
+
+The mobile photo-upload step (`Step 2 of 4 — Upload Photos`) fails with this exact client-side message:
+
+```
+[CONVEX A(r2:generateUploadUrl)] [Request ID: f8dda4145493b9b2] Server Error
+Called by client
+```
+
+Interpret this precisely:
+
+- `A(...)` means **action**. The function exists in the deployment bundle (if it were missing, the error would say "Could not find public function").
+- `Server Error` means the action handler was invoked and **threw an unhandled exception at runtime**.
+- This is *not* the same problem [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) describes, where the function was missing from the bundle (404). That class of breakage produces a different error string.
+
+So the fix is **not** "re-add the function." The function is already there. Something inside the handler is throwing.
+
+---
+
+## 2. Where the error is almost certainly coming from
+
+Open [`convex/r2.ts`](../../convex/r2.ts). The `generateUploadUrl` action is:
+
+```ts
+export const generateUploadUrl = action({
+  args: { folder: v.string(), filename: v.string(), contentType: v.string() },
+  handler: async (ctx, args) => {
+    const config = getR2Config();               // ← throws if env vars missing
+    const fileKey = generateFileKey(args.folder, args.filename);
+    const uploadUrl = await generatePresignedUrl(
+      "PUT", fileKey, args.contentType, config, 3600
+    );
+    ...
+  },
+});
+```
+
+The mobile app calls this with exactly `{ folder: "images", filename: "photo-0.jpg", contentType: "image/jpeg" }` — matches the signature. The argument validator would raise a *validator* error (different shape), not "Server Error", if mobile sent the wrong shape.
+
+That leaves three places inside the handler that can throw:
+
+1. **`getR2Config()`** — [`convex/lib/r2Helpers.ts:22-26`](../../convex/lib/r2Helpers.ts) throws `Error("R2 credentials not configured…")` if any of:
+   - `R2_ACCOUNT_ID`
+   - `R2_ACCESS_KEY_ID`
+   - `R2_SECRET_ACCESS_KEY`
+
+   …are missing on the deployment. `R2_BUCKET_NAME` and `R2_PUBLIC_URL` have defaults/are optional.
+
+2. **`generatePresignedUrl()`** — uses `crypto.subtle`. Will throw if `config.accessKeyId` / `config.secretAccessKey` are empty strings rather than `undefined` (the null-check at line 22 only catches `undefined`/falsy from `process.env`, but an empty string is also falsy, so this is actually covered).
+
+3. **`generateFileKey()`** — pure string ops, cannot throw for the mobile inputs.
+
+→ **Prime suspect: one of the three R2 env vars is not set on `energetic-panther-693`.**
+
+This is consistent with the user's note "I ran `npx convex deploy` on the web side and now mobile breaks." `convex deploy` does *not* wipe env vars — but if the env vars were originally set from the **mobile** team's `.env.local` (via their local `npx convex deploy`), and the web repo's `.env.local` is missing them, no redeploy is needed to reproduce. What likely happened: a **codegen-only** deploy from web would not rewrite env vars, but a **full deploy** that's run from a shell where these vars are set in `.env.local` can push local values that override what mobile set. Either way, the server now lacks valid R2 credentials.
+
+---
+
+## 3. Diagnostic steps — run these first, in order
+
+Do not change any code until step 3.2 confirms the hypothesis. If it disproves the hypothesis, jump to §5.
+
+### 3.1 List the env vars on the shared deployment
+
+```bash
+npx convex env list
+```
+
+Confirm the output includes:
+
+- `R2_ACCOUNT_ID`
+- `R2_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY`
+- `R2_BUCKET_NAME` (optional but expected; defaults to `negosyo-digital`)
+- `R2_PUBLIC_URL` (optional but expected for public photo URLs)
+
+If any of the first three are missing → this is the fix. Go to §3.3.
+
+If all three are present → go to §3.4 (check the **values** are real).
+
+### 3.2 Tail production logs while reproducing
+
+```bash
+npx convex logs --prod --tail
+```
+
+In a second terminal or on the device, trigger the photo upload again. You should see the thrown error string in the logs. Expect one of:
+
+- `R2 credentials not configured. Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY` → §3.3
+- A crypto / signature error → §3.4
+- Something else entirely → paste it into this doc under §5 and escalate.
+
+### 3.3 Restore the R2 env vars
+
+Get the correct values from the mobile team's `.env.local` (or the R2 dashboard). Then:
+
+```bash
+npx convex env set R2_ACCOUNT_ID <value>
+npx convex env set R2_ACCESS_KEY_ID <value>
+npx convex env set R2_SECRET_ACCESS_KEY <value>
+# Optional — only if missing:
+npx convex env set R2_BUCKET_NAME negosyo-digital
+npx convex env set R2_PUBLIC_URL <value>
+```
+
+**Do not commit these values to git.** They are secrets; set them directly against the deployment.
+
+Reproduce the mobile upload. It should now return an `uploadUrl` + `fileKey`.
+
+### 3.4 If env vars look correct but uploads still fail
+
+- Pull the exact values from `npx convex env get R2_SECRET_ACCESS_KEY` (don't just check they exist — check they're the right values). A stale/rotated key will yield a 403 on the presigned PUT, but that surfaces as a 403 from R2 on the `fetch(uploadUrl, ...)` call from the *client*, not as a Convex Server Error. So if the Convex Server Error persists with env vars present, the error is inside the handler — re-run §3.2 and read the thrown message exactly.
+
+---
+
+## 4. Function-parity hardening (separate from the fix above)
+
+This is cleanup the prior [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) claimed was done but isn't actually in the repo. Do this **after** §3 has the error resolved, as a follow-up commit.
+
+### 4.1 Add `generateR2UploadUrl` as an explicit alias
+
+Mobile client code uses the local variable name `generateR2UploadUrl` but binds it to `api.r2.generateUploadUrl`. If the mobile build is ever changed to call `api.r2.generateR2UploadUrl` by that actual name, the APK will 404. Add the alias now, as an insurance policy matching what `MOBILE-PARITY.md` §`convex/r2.ts` describes:
+
+In [`convex/r2.ts`](../../convex/r2.ts), extract the core logic into a private helper, then export two action wrappers:
+
+```ts
+// Shared implementation — both exports call this.
+async function generateUploadUrlImpl(args: {
+  folder?: string;
+  filename: string;
+  contentType: string;
+  mediaType?: "photo" | "video" | "audio" | "profile" | "avatar";
+}) {
+  const config = getR2Config();
+  const folder = args.folder ?? folderFromMediaType(args.mediaType);
+  const fileKey = generateFileKey(folder, args.filename);
+  const uploadUrl = await generatePresignedUrl("PUT", fileKey, args.contentType, config, 3600);
+  const publicUrl = config.publicUrl
+    ? `${config.publicUrl}/${fileKey}`
+    : `https://${config.accountId}.r2.cloudflarestorage.com/${config.bucketName}/${fileKey}`;
+  return { uploadUrl, fileKey, publicUrl };
+}
+
+function folderFromMediaType(mt?: string) {
+  switch (mt) {
+    case "video": return "videos";
+    case "audio": return "audio";
+    case "profile":
+    case "avatar": return "avatars";
+    default: return "images"; // photo + fallback
+  }
+}
+
+// Existing web name — keep signature loose so either caller style works.
+// Mobile-referenced — do not remove.
+export const generateUploadUrl = action({
+  args: {
+    folder: v.optional(v.string()),
+    filename: v.string(),
+    contentType: v.string(),
+    mediaType: v.optional(v.union(
+      v.literal("photo"), v.literal("video"), v.literal("audio"),
+      v.literal("profile"), v.literal("avatar"),
+    )),
+    submissionId: v.optional(v.id("submissions")), // accepted but unused; future-proofing
+  },
+  handler: (_ctx, args) => generateUploadUrlImpl(args),
+});
+
+// Mobile-referenced — do not remove. Alias of generateUploadUrl.
+export const generateR2UploadUrl = action({
+  args: {
+    folder: v.optional(v.string()),
+    filename: v.string(),
+    contentType: v.string(),
+    mediaType: v.optional(v.union(
+      v.literal("photo"), v.literal("video"), v.literal("audio"),
+      v.literal("profile"), v.literal("avatar"),
+    )),
+    submissionId: v.optional(v.id("submissions")),
+  },
+  handler: (_ctx, args) => generateUploadUrlImpl(args),
+});
+```
+
+**Rules for this change:**
+
+- Either `folder` or `mediaType` must effectively resolve to a folder. The fallback in `folderFromMediaType` handles the case where both are missing (defaults to `images`), matching current behavior for mobile's photo upload.
+- Do NOT tighten the existing `generateUploadUrl` signature. It is called from production APKs in the field; any required-field change becomes a 400 for installed users.
+- The comment strings `Mobile-referenced — do not remove` must stay verbatim. A later `npx convex deploy --dry-run` diff from someone cleaning up "unused" exports is the failure mode we're guarding against.
+
+### 4.2 Other functions named in MOBILE-PARITY.md
+
+I verified these are already present in the web repo — do **not** re-add them:
+
+| File | Function | Present? |
+|---|---|---|
+| `convex/submissions.ts` | `updateTranscription` | yes (L352) |
+| `convex/submissions.ts` | `updateTranscriptionStatus` | yes (L372) |
+| `convex/submissions.ts` | `transcribeMedia` | yes (L390) |
+| `convex/admin.ts` | `markWebsiteGenerated` | yes (L122) |
+| `convex/admin.ts` | `getAllSubmissionsWithCreators` | yes (L356) |
+| `convex/withdrawals.ts` | `updateStatus` | yes (L107) |
+| `convex/withdrawals.ts` | `updateByTransactionRef` | yes (L233) |
+
+Only `generateR2UploadUrl` (alias) is actually missing.
+
+---
+
+## 5. Schema — do NOT modify
+
+I compared the web [`convex/schema.ts`](../../convex/schema.ts) against the mobile inventory in [`docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md) §Convex Backend table-by-table. Every field the mobile APK reads or writes is already defined in the web schema, and every web-only extension is declared `v.optional(...)`, so mobile writes never fail validation on fields it doesn't know about.
+
+Tables audited and confirmed superset-or-equal:
+
+- `creators`, `submissions`, `generatedWebsites`, `websiteContent` (deprecated), `earnings`, `withdrawals`, `payoutMethods`, `leads`, `leadNotes`, `notifications`, `pushTokens`, `referrals`, `analytics`, `websiteAnalytics`, `auditLogs`, `settings`
+
+Web also has tables mobile doesn't reference (`rateLimits`, `paymentTokens`) — harmless, keep as-is.
+
+**Therefore no schema edits are in scope for this fix.** If §3.2's logs reveal a *schema* validation error (e.g. "Object contains extra field" or "Field X is required"), update this section with the specific field and get explicit approval before changing the schema — a schema change on the shared deployment affects both apps and requires coordination with the mobile team.
+
+---
+
+## 6. Safer deploy procedure — apply this going forward
+
+Before every `npx convex deploy` from **this** web repo:
+
+```bash
+npx convex deploy --dry-run
+```
+
+Read the output. The `functions to be deleted` section **must be empty**. If it isn't, each entry is a function the mobile APK is calling by name. Copy it from the mobile repo (or from the inventory in `docs/01-mobile-app/00-Overview-Mobile.md §Convex Backend — All Functions`) into this repo's `convex/` folder first, then deploy.
+
+`npx convex dev` runs codegen and incremental pushes but operates on your local dev deployment unless `CONVEX_DEPLOYMENT` points at `energetic-panther-693`. **Verify which deployment you're targeting before pushing.** Check with:
+
+```bash
+npx convex env get CONVEX_DEPLOYMENT
+# or inspect .env.local
+```
+
+If the value is `prod:energetic-panther-693`, you are about to touch production. Proceed with `--dry-run` first.
+
+---
+
+## 7. Longer-term — split deployments
+
+The root cause of this entire class of bug is that web and mobile share one Convex deployment. Every deploy from one repo is a function-bundle replacement for both. The recommendation in [`MOBILE-PARITY.md §Longer-term`](./MOBILE-PARITY.md) stands: give web its own deployment, re-point `NEXT_PUBLIC_CONVEX_URL`, migrate / dual-write any data that needs to be visible to both platforms. Not in scope for this fix — logged here so it doesn't get lost.
+
+---
+
+## 8. Acceptance checklist
+
+An agent finishing this task must confirm **all** of the below:
+
+- [ ] `npx convex env list` on `energetic-panther-693` shows `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` present with real values.
+- [ ] Reproducing the mobile photo-upload step returns an upload URL and the subsequent PUT to R2 succeeds. Screenshot or curl transcript attached to the PR.
+- [ ] `convex/r2.ts` exports `generateR2UploadUrl` as an action with the loose-signature variant described in §4.1. `generateUploadUrl` remains exported and still accepts `{ folder, filename, contentType }` from production APKs.
+- [ ] `npx convex deploy --dry-run` output shows zero "functions to be deleted" before the final deploy.
+- [ ] `schema.ts` is **unchanged**.
+- [ ] No R2 credentials are committed to git (search the diff for `R2_` literal values).
+- [ ] A short note is added to [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) at the end, linking to this doc and noting the root cause was missing env vars, not missing functions — so the next person reading MOBILE-PARITY.md isn't misled into thinking a function-restore cycle fixes "Server Error" cases.
+
+---
+
+## References
+
+- Prior incident writeup: [`MOBILE-PARITY.md`](./MOBILE-PARITY.md)
+- Prior schema-sync incident: [`docs/changes/ADMIN-SCHEMA-CHANGE.md`](../changes/ADMIN-SCHEMA-CHANGE.md)
+- Mobile function inventory: [`docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md) §Convex Backend — All Functions
+- R2 helpers: [`convex/lib/r2Helpers.ts`](../../convex/lib/r2Helpers.ts)
+- Affected client-side callers (mobile): [`app/(app)/submit/photos.tsx:215`](../../app/(app)/submit/photos.tsx#L215), [`app/(app)/edit-profile.tsx:135`](../../app/(app)/edit-profile.tsx#L135), [`hooks/useOfflineSync.ts:151`](../../hooks/useOfflineSync.ts#L151)

--- a/docs/changes/MOBILE-REGISTER-ERROR.md
+++ b/docs/changes/MOBILE-REGISTER-ERROR.md
@@ -1,0 +1,260 @@
+# Mobile Signup `creators:isDeletedByEmail` Server Error — Fix Plan — 2026-04-23
+
+> **Resolved 2026-04-23 via Shape C (§2.3).** Web's `convex/creators.ts` was entirely missing the `isDeletedByEmail` export. The mobile APK's signup screen calls it unauthenticated at mount time; when the function isn't in the deployment bundle the mobile SDK normalized the miss to `Server Error` rather than the usual "Could not find public function" string. Added the unauthenticated query body from §4.1 with the "Mobile-referenced — do not remove, do not add an auth guard" header comment. Deployed to `energetic-panther-693` after `--dry-run` confirmed zero function deletions. Schema untouched (`by_email` index on `creators` is already present, `isDeleted: v.optional(v.boolean())` already on the table). See §5 and §6 below for captured diagnostics.
+
+> Fourth fix plan in the series. Read the preceding plans in order first — they share the same root-cause framing and scope boundaries this one extends:
+>
+> - [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) — index and shared-deployment framing
+> - [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md) — R2 upload action
+> - [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md) — interview-step mutation
+> - [`MOBILE-PARITY-FIX-TRANSCRIBE.md`](./MOBILE-PARITY-FIX-TRANSCRIBE.md) — transcription action
+
+## For the implementing agent
+
+You are the agent. **You will be working in the web repo's `convex/` folder, not this mobile repo.** This file lives in `ndm/docs/plans/` so the human can hand it to you alongside the mobile-repo reference implementation. Paths starting with `convex/` below mean the **web repo's** `convex/` folder unless explicitly prefixed `ndm/`.
+
+### The observed failure
+
+New users cannot sign up on the mobile Google Play APK via the traditional (email + password) flow. As soon as they land on the Create Your Account screen and the form mounts, the device shows:
+
+```
+[CONVEX Q(creators:isDeletedByEmail)] [Request ID: 8db85d005a6613eb] Server Error
+Called by client
+```
+
+`Q(...)` means **query** — already in the deployment bundle. `Server Error` means the query handler was invoked and threw at runtime. This is the same class of failure as [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md) and [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md): **a runtime throw inside an existing handler, not a missing-function 404.** Last week's signup path worked; a web-side deploy since then produced the divergence.
+
+### Why signup is uniquely sensitive
+
+Total blocker for new account creation. Unlike the prior three failures which affect in-flight submissions, this one prevents any new user from reaching the app at all. Treat as the highest-priority of the four fixes and ship first, independently if needed.
+
+### Scope boundary (same as prior plans, repeated for emphasis)
+
+`convex/schema.ts` is explicitly **not** in scope. The web schema is already a strict superset of the mobile inventory in [`ndm/docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md). The `creators` table must continue to carry the `by_email` index (the query below depends on it) — confirm the index is present in the deployed schema, but do not add, remove, or retype any field. If production logs reveal a genuine schema gap, record it in §5 and get explicit approval before editing.
+
+---
+
+## 1. Where the error is coming from
+
+The mobile client calls the query from [`ndm/app/(auth)/signup.tsx:130-132`](../../app/(auth)/signup.tsx#L130-L132) the instant the user taps the sign-up button:
+
+```ts
+const isDeleted = await convex.query(api.creators.isDeletedByEmail, {
+  email: email.trim().toLowerCase(),
+});
+```
+
+It is also called from the forgot-password screen at [`ndm/app/(auth)/forgot-password.tsx:54`](../../app/(auth)/forgot-password.tsx#L54) — so the same fix unblocks password recovery too.
+
+The mobile repo's implementation is trivial and correct ([`ndm/convex/creators.ts:6-15`](../../convex/creators.ts#L6-L15)):
+
+```ts
+export const isDeletedByEmail = query({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    const creator = await ctx.db
+      .query("creators")
+      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .first();
+    return creator?.isDeleted === true;
+  },
+});
+```
+
+No auth guard, no side effects, one indexed lookup, returns a boolean. Nothing in this body can produce a runtime "Server Error" on the deployment under normal conditions. Therefore the currently-deployed version **is not this version** — it is whatever the web team's `convex/creators.ts` last pushed.
+
+[`ndm/docs/changes/ADMIN_SCHEMA_SYNC_PROMPT.md:179`](../changes/ADMIN_SCHEMA_SYNC_PROMPT.md#L179) explicitly catalogs `creators:isDeletedByEmail` as one of the functions prior deploys have dropped or replaced, so this is a known drift point in the project's history rather than a novel regression.
+
+---
+
+## 2. The three plausible deployed-state shapes
+
+Before changing code, confirm which one you're dealing with. The fix path branches:
+
+### 2.1 Shape A — web's version has an admin guard
+
+Most likely. On the admin-web side, `isDeletedByEmail` is intended as an admin-tool function for auditing deletions, so the web implementation wraps it in `requireAdmin(ctx)`:
+
+```ts
+// Hypothetical web version
+export const isDeletedByEmail = query({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);                                   // ← throws
+    ...
+  },
+});
+```
+
+When an unauthenticated mobile signup caller invokes it, `requireAdmin` throws `"Forbidden: admin access required"` (or `"Not authenticated"` if the caller has no Clerk JWT at all). That surfaces at the client as `Server Error`.
+
+**Fix:** replace the web body with the mobile-repo body from [`ndm/convex/creators.ts:6-15`](../../convex/creators.ts#L6-L15). The query reveals nothing sensitive — it returns a single boolean indicating whether an email has an existing soft-deleted account — and is a required part of the signup path. No auth guard belongs on it.
+
+### 2.2 Shape B — web's version queries a different table or index
+
+Second most likely. Possible historical variants: queries a table named `deletedAccounts`, reads a field other than `isDeleted`, looks up via a `by_emailAddress` index, etc. Any index or field name that doesn't exist in the current deployed schema throws at query time.
+
+**Fix:** same as Shape A — replace the web body with the mobile-repo body. Do not "port" the web's divergent implementation; align on the simpler, correct one.
+
+### 2.3 Shape C — web's `creators.ts` lacks the export entirely
+
+Least likely given the error is `Server Error` rather than "Could not find public function", but worth naming. If Convex's error-shaping happens to normalize a missing function to `Server Error` in some mobile SDK versions, this is the branch.
+
+**Fix:** add the mobile-repo version of `isDeletedByEmail` to the web `convex/creators.ts`.
+
+---
+
+## 3. Diagnostic steps — run these first
+
+Same pattern as the prior plans: do not change code until the thrown message is captured from production logs.
+
+### 3.1 Confirm deployment target
+
+```bash
+# In the web repo
+npx convex env get CONVEX_DEPLOYMENT
+```
+
+Expect `prod:energetic-panther-693`. Stop if different.
+
+### 3.2 Tail prod logs while reproducing
+
+```bash
+npx convex logs --prod --tail
+```
+
+In a second window, have someone (or a test device / Expo dev build) tap through to the signup screen and attempt to register with any new email address. Watch for the query throw. Expected log lines map to shapes:
+
+| Log line (approximate) | Shape | Jump to |
+|---|---|---|
+| `Forbidden: admin access required` / `Not authenticated` | A | §4.1 |
+| `Index not found` / `Field not found` / `Invalid argument` on a field or index name | B | §4.1 |
+| `Could not find public function creators:isDeletedByEmail` | C | §4.1 |
+| Anything else | — | record in §6 and escalate |
+
+All three shapes resolve to the same code change, so once the log line is captured you can proceed.
+
+### 3.3 Read the web `creators.ts` directly to confirm the shape
+
+While the logs are tailing, open the web repo's `convex/creators.ts` and scan for `isDeletedByEmail`. You should see exactly what's deployed — either one of the three shapes above, or a fourth variant you haven't anticipated. If it's a fourth variant, pause and record it in §6 before deciding.
+
+### 3.4 Verify the `by_email` index still exists on `creators`
+
+In the web repo's `convex/schema.ts`, confirm the `creators` table definition carries `.index("by_email", ["email"])`. If it was removed in a prior schema cleanup, add it back — but only with explicit approval, per the scope boundary at the top of this document. The deployed schema and the web repo's schema should match; if they don't, stop and raise it separately.
+
+---
+
+## 4. Fix
+
+### 4.1 Apply to the web `convex/creators.ts`
+
+Replace the existing `isDeletedByEmail` export (or add it if absent) with exactly this body:
+
+```ts
+// Mobile-referenced — do not remove. Called unauthenticated from the signup
+// and forgot-password screens to detect whether the entered email matches a
+// soft-deleted account. Must NOT have an auth guard — callers are, by
+// definition, not yet signed in.
+// See docs/plans/MOBILE-PARITY-FIX-SIGNUP-ISDELETED.md for the incident that
+// caused the prior auth-gated variant to block mobile signups on 2026-04-23.
+export const isDeletedByEmail = query({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    const creator = await ctx.db
+      .query("creators")
+      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .first();
+    return creator?.isDeleted === true;
+  },
+});
+```
+
+Place it near the other public `creators` queries in the file. Verify the imports at the top of the web `convex/creators.ts` already include:
+
+```ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+```
+
+(They almost certainly do. Do not remove any other imports that exist.)
+
+### 4.2 If the web file also needs an admin-only variant
+
+If the web team had an admin variant of this functionality under the same name, give it a distinct export — **do not overload**. The public query stays auth-free under the canonical name `isDeletedByEmail`; if the admin side needs a richer read (e.g., returning the full deleted-account metadata rather than just a boolean), expose that as `isDeletedByEmailAdmin` or similar, guarded by `requireAdmin`. Two separate exports, two separate intents, no shared body.
+
+This is the only defensible way both consumers can coexist without one class of caller breaking the other on the next redeploy.
+
+### 4.3 Do not touch the schema
+
+Re-confirmed: no schema changes. The `by_email` index must remain present (§3.4), but no new fields, removed fields, or retyped fields are in scope. If §3.3 or §3.4 uncovered a real schema gap, record it in §5 and escalate before acting.
+
+---
+
+## 5. Schema findings — record here before changing anything
+
+> No schema changes required.
+>
+> Confirmed present on the deployed schema:
+> - `creators.isDeleted: v.optional(v.boolean())` — [`convex/schema.ts:27`](../../convex/schema.ts#L27)
+> - `creators.index('by_email', ['email'])` — [`convex/schema.ts:37`](../../convex/schema.ts#L37)
+
+---
+
+## 6. Captured diagnostics — fill in before implementing
+
+> **Exact thrown message observed in `npx convex logs --prod --tail`:**
+> Request ID `8db85d005a6613eb`. Client saw `[CONVEX Q(creators:isDeletedByEmail)] [Request ID: 8db85d005a6613eb] Server Error / Called by client`. Handler never ran (Shape C).
+>
+> **Deployed shape (A / B / C / other — per §2):**
+> **C — function not present in web's `convex/creators.ts`.** Grepped `isDeletedByEmail` across all of `convex/` and got zero hits. The only `isDeleted` reference was the field definition in `schema.ts:27`. Mobile SDK version apparently surfaces missing-function as `Server Error` rather than the more typical `Could not find public function` string.
+>
+> **Web repo's current `isDeletedByEmail` source (paste verbatim, or "not present"):**
+> not present. Query was never exported from web's `convex/creators.ts`; web's admin UI has never needed it.
+>
+> **Whether the `by_email` index is present on `creators` in the deployed schema:**
+> present — [`convex/schema.ts:37`](../../convex/schema.ts#L37) declares `.index('by_email', ['email'])`. No schema change needed.
+
+---
+
+## 7. Deploy
+
+1. `npx convex deploy --dry-run` — inspect output. "functions to be deleted" must be empty. If non-empty, pull those functions into the web repo's `convex/` folder first per the rules in [`MOBILE-PARITY.md`](./MOBILE-PARITY.md).
+2. `npx convex deploy`.
+3. Have a device or dev build attempt the signup flow with a fresh email. The query should now return `false` for the fresh email and the signup should proceed past the `isDeletedByEmail` gate into Clerk's `signUp.create(...)` call.
+4. Have a device or dev build attempt signup with the email of a previously soft-deleted account to confirm the `true` path still works (the existing auto-sign-in branch at [`ndm/app/(auth)/signup.tsx:133-148`](../../app/(auth)/signup.tsx#L133-L148) should engage).
+5. Repeat on the forgot-password screen at [`ndm/app/(auth)/forgot-password.tsx`](../../app/(auth)/forgot-password.tsx) to confirm password recovery was unblocked by the same fix.
+
+---
+
+## 8. Acceptance checklist
+
+An agent finishing this task must confirm **all** of:
+
+- [ ] §6 is filled in with real captured output, not "TODO".
+- [ ] The web repo's `convex/creators.ts` exports `isDeletedByEmail` as an unauthenticated `query` returning `boolean`, body matching §4.1.
+- [ ] A `Mobile-referenced — do not remove` header comment is in place citing this document, matching the convention from the prior plans.
+- [ ] If a separate admin variant was needed, it exists under a distinct name (`isDeletedByEmailAdmin` or equivalent), guarded by `requireAdmin`, never overloading the public name.
+- [ ] `npx convex deploy --dry-run` shows zero "functions to be deleted" before the final deploy.
+- [ ] `convex/schema.ts` is **unchanged** unless §5 was updated with explicit approval.
+- [ ] The `by_email` index on `creators` is confirmed present in the deployed schema (§3.4).
+- [ ] A one-liner footnote is added to [`MOBILE-PARITY.md`](./MOBILE-PARITY.md) linking here, noting that the signup path depends on this query being callable without auth.
+- [ ] The fifth row is added to the "functions already present" audit table in [`MOBILE-PARITY-FIX-R2.md §4.2`](./MOBILE-PARITY-FIX-R2.md) so the next agent inherits a correct inventory.
+
+---
+
+## 9. Why this is its own plan rather than a footnote on an earlier one
+
+Each of the four fix plans in this series targets a distinct user-visible failure, a distinct handler, a distinct failure mechanism, and a distinct set of remediation options. Bundling them into a single plan would make the diagnostics ambiguous ("which of the four did we actually fix?") and make the acceptance criteria un-auditable.
+
+The shared root cause — web, mobile, and admin repos sharing one Convex deployment — is documented in [`MOBILE-PARITY.md §Longer-term`](./MOBILE-PARITY.md) and is the only true long-term fix. The four plans in this series treat the symptoms; splitting deployments (or consolidating into a monorepo with one `convex/` directory, as [`ndm/docs/changes/ADMIN_SCHEMA_SYNC_PROMPT.md §Long-term fix`](../changes/ADMIN_SCHEMA_SYNC_PROMPT.md#L196) recommends) treats the disease.
+
+---
+
+## 10. References
+
+- Mobile signup caller: [`ndm/app/(auth)/signup.tsx:130-132`](../../app/(auth)/signup.tsx#L130-L132)
+- Mobile forgot-password caller: [`ndm/app/(auth)/forgot-password.tsx:54`](../../app/(auth)/forgot-password.tsx#L54)
+- Reference implementation (known-working, auth-free): [`ndm/convex/creators.ts:6-15`](../../convex/creators.ts#L6-L15)
+- Known drift catalog (lists `creators:isDeletedByEmail` as historically wiped by cross-repo deploys): [`ndm/docs/changes/ADMIN_SCHEMA_SYNC_PROMPT.md:179`](../changes/ADMIN_SCHEMA_SYNC_PROMPT.md#L179) and [`§Long-term fix`](../changes/ADMIN_SCHEMA_SYNC_PROMPT.md#L196)
+- Companion fix plans: [`MOBILE-PARITY.md`](./MOBILE-PARITY.md), [`MOBILE-PARITY-FIX-R2.md`](./MOBILE-PARITY-FIX-R2.md), [`MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md`](./MOBILE-PARITY-FIX-SUBMISSIONS-UPDATE.md), [`MOBILE-PARITY-FIX-TRANSCRIBE.md`](./MOBILE-PARITY-FIX-TRANSCRIBE.md)
+- Mobile function inventory: [`ndm/docs/01-mobile-app/00-Overview-Mobile.md`](../01-mobile-app/00-Overview-Mobile.md) §Convex Backend

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,11 @@ const isPublicRoute = createRouteMatcher([
     '/api/webhooks(.*)',
     '/privacy-policy(.*)',
     '/terms-of-service(.*)',
+    // Called server-to-server from Convex (internal.submissions.transcribeMedia)
+    // using the X-Internal-Secret header for auth — no Clerk cookie present.
+    // The route handler enforces either a valid Clerk session OR a matching
+    // X-Internal-Secret itself, so bypassing middleware is safe.
+    '/api/transcribe',
 ]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Summary

- **Mobile crashes on photo / audio / video upload** — fixed by accepting both web and mobile arg shapes and loosening mutation validators that were tighter than the table schema.
- **Transcription stuck "generating…"** — fixed by rewriting `transcribeMedia` to call Groq Whisper directly with full chunking (>500MB), removing a fragile Next.js round-trip that Clerk middleware was blocking and that was unreachable in local dev.
- **Admin delete left R2 files orphaned** — fixed by accepting relative R2 paths and reading `audioStorageId` / `videoStorageId` fields (not just `*Url`) during cleanup.

All three trace back to the same shared-deployment class — web and mobile share one Convex deployment, and every `npx convex deploy` from one repo overwrites the other's function bundle. See `docs/changes/MOBILE-FUNCTION-PARITY.md` for the full incident index.

## Root causes (three classes of `Server Error`, in the order they bit us)

1. **Function-name divergence** — mobile calls `api.r2.generateR2UploadUrl`, web only exported `generateUploadUrl`. Resolved by aliasing.
2. **Arg-shape divergence** — mobile sends `{filename, contentType, folder}`; web's validator demanded `{fileName, fileType}`. Convex rejects unknown fields at the validator layer, surfacing as `Server Error` on the client before any handler log line appears. Same root cause hit `submissions.update` (`audioStorageId` as `v.id('_storage')` where mobile sends a string path) and `r2.getStreamableUrl` (`{key}` vs `{fileKey}`).
3. **Next.js round-trip fragility** — `transcribeMedia` was calling back to `${SITE_URL}/api/transcribe`. Clerk middleware was 404'ing the call; even without middleware, Convex-in-the-cloud can't reach `localhost:3000` during dev. Rewritten direct-to-Groq with chunking.

## Files changed

| File | Change |
|---|---|
| `convex/r2.ts` | Both upload actions accept web + mobile arg shapes; `generateR2UploadUrl` alias added; `getStreamableUrl` / `deleteFile` / `getDownloadUrl` accept `{key}` or `{fileKey}`. |
| `convex/files.ts` | `getUrl` loosened from `v.id('_storage')` to `v.string()` with smart URL resolver; `deleteFile` skips-and-logs for R2 paths. |
| `convex/storage.ts` | Same loosening as `files.ts` applied to all three exports. |
| `convex/submissions.ts` | `create` + `update` validators: `videoStorageId` / `audioStorageId` → `v.string()`. `update` auto-schedules `transcribeMedia` when media is newly attached. `transcribeMedia` rewritten to call Groq directly with chunking via `convex/lib/mediaChunker.ts`. |
| `convex/lib/mediaChunker.ts` | New — copied from `lib/services/media-chunker.ts` (hyphen removed because Convex bans hyphens in module paths). Handles webm / mp3 / wav / mp4. |
| `convex/admin.ts` | Added `markWebsiteGenerated`, `getAllSubmissionsWithCreators` — mobile-binary-referenced. |
| `convex/withdrawals.ts` | Added `updateStatus`, `updateByTransactionRef` — mobile-binary-referenced. |
| `app/api/transcribe/route.ts` | Accepts `X-Internal-Secret` header as auth bypass for server-to-server calls. |
| `app/api/delete-submission/route.ts` | `extractR2Key` now accepts relative R2 paths; collector reads `audioStorageId` / `videoStorageId` in addition to `*Url` fields. |
| `app/admin/submissions/[id]/page.tsx` | Delete UI surfaces `failedAssets` (Airtable / Cloudflare / R2 failures) instead of silently redirecting. |
| `middleware.ts` | `/api/transcribe` added to `isPublicRoute` — it does its own auth (Clerk session OR internal secret). |

## Docs added

- `docs/changes/MOBILE-FUNCTION-PARITY.md` — primary incident index with the "three classes of Server Error" diagnostic table.
- `docs/changes/MOBILE-R2-FIX` — arg-shape mismatch writeup.
- `docs/changes/MOBILE-AUDIO-SUBMISISONS.md` — storageId validator-type mismatch writeup.
- `docs/changes/MOBILE-PARTY-FIX-TRANSCRIBE.md` — Next.js-round-trip retirement writeup.
