### PR TITLE
fix(convex): add followUp module to generated api types

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as crons from "../crons.js";
 import type * as domains from "../domains.js";
 import type * as earnings from "../earnings.js";
 import type * as files from "../files.js";
+import type * as followUp from "../followUp.js";
 import type * as generatedWebsites from "../generatedWebsites.js";
 import type * as http from "../http.js";
 import type * as leadNotes from "../leadNotes.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   domains: typeof domains;
   earnings: typeof earnings;
   files: typeof files;
+  followUp: typeof followUp;
   generatedWebsites: typeof generatedWebsites;
   http: typeof http;
   leadNotes: typeof leadNotes;


### PR DESCRIPTION
The Vercel build was failing because convex/_generated/api.d.ts didn't include the new followUp module. Normally regenerated by 'npx convex dev' or 'npx convex codegen' but those require authenticated Convex access.

Manual fix: added the import + fullApi entry alphabetically between 'files' and 'generatedWebsites'. Pattern matches existing modules.