### PR TITLE
Devpatch6

### DIFF
--- a/app/admin/components/AdminLayout.tsx
+++ b/app/admin/components/AdminLayout.tsx
@@ -6,9 +6,10 @@ import Link from "next/link"
 import Image from "next/image"
 import { useClerk } from "@clerk/nextjs"
 import { motion, AnimatePresence } from "framer-motion"
-import { 
+import {
     LayoutDashboard,
     Users,
+    UserCheck,
     CreditCard,
     History,
     Download,
@@ -29,6 +30,11 @@ const navItems = [
         label: "Creators",
         href: "/admin/creators",
         icon: Users,
+    },
+    {
+        label: "Pending Approvals",
+        href: "/admin/pending-approvals",
+        icon: UserCheck,
     },
     {
         label: "Leads",
@@ -71,7 +77,14 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     }
 
     return (
-        <div className="min-h-screen bg-[#fcfdfd] flex font-sans selection:bg-green-100 selection:text-green-900">
+        <div
+            className="editorial min-h-screen flex font-sans selection:bg-green-100 selection:text-green-900"
+            style={{
+                background: "var(--ed-paper)",
+                color: "var(--ed-ink)",
+                fontFamily: "var(--ed-sans)",
+            }}
+        >
             {/* Mobile sidebar overlay */}
             <AnimatePresence>
                 {sidebarOpen && (
@@ -85,12 +98,18 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 )}
             </AnimatePresence>
 
-            {/* Sidebar */}
-            <aside className={`
-                w-64 bg-emerald-950 border-r border-emerald-900 flex flex-col fixed inset-y-0 left-0 z-50
+            {/* Sidebar — ink surface with editorial paper accents */}
+            <aside
+                className={`
+                w-64 flex flex-col fixed inset-y-0 left-0 z-50
                 transition-all duration-300 ease-in-out shadow-[4px_0_24px_-4px_rgba(0,0,0,0.02)]
                 ${sidebarOpen ? "translate-x-0" : "-translate-x-full"} lg:translate-x-0
-            `}>
+            `}
+                style={{
+                    background: "var(--ed-ink)",
+                    borderRight: "1px solid rgba(255,255,255,0.06)",
+                }}
+            >
                 <div className="px-6 py-8 flex items-center justify-between mb-2">
                     <Link href="/admin" className="flex items-center gap-3 group">
                         <div className="relative w-10 h-10 transition-transform duration-500 group-hover:scale-110">
@@ -103,16 +122,37 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                             />
                         </div>
                         <div className="flex flex-col">
-                            <span className="text-base font-black text-white tracking-tight leading-none group-hover:text-emerald-300 transition-colors">NEGOSYO</span>
-                            <span className="text-[10px] font-bold text-emerald-400 uppercase tracking-[0.2em] mt-0.5">Digital Admin</span>
+                            <span
+                                className="text-2xl tracking-tight leading-none transition-colors italic"
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    color: "var(--ed-paper-3)",
+                                }}
+                            >
+                                Negosyo
+                            </span>
+                            <span
+                                className="text-[10px] uppercase mt-1"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.18em",
+                                    color: "var(--ed-accent-solid)",
+                                }}
+                            >
+                                Digital · Admin
+                            </span>
                         </div>
                     </Link>
-                    <button onClick={() => setSidebarOpen(false)} className="lg:hidden p-1.5 rounded-full hover:bg-emerald-900 text-emerald-400 transition-colors">
+                    <button
+                        onClick={() => setSidebarOpen(false)}
+                        className="lg:hidden p-1.5 rounded-full transition-colors"
+                        style={{ color: "var(--ed-paper-3)" }}
+                    >
                         <X size={20} />
                     </button>
                 </div>
 
-                <nav className="flex-1 px-4 py-4 space-y-1.5 overflow-y-auto">
+                <nav className="flex-1 px-4 py-4 space-y-1 overflow-y-auto">
                     {navItems.map((item) => {
                         const isActive = pathname === item.href
                         const Icon = item.icon
@@ -121,25 +161,33 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                                 key={item.href}
                                 href={item.href}
                                 onClick={() => setSidebarOpen(false)}
-                                className={`
-                                    flex items-center justify-between px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 group
-                                    ${isActive
-                                        ? "bg-emerald-800 text-emerald-50 shadow-sm shadow-emerald-900/50"
-                                        : "text-emerald-400 hover:bg-emerald-900 hover:text-emerald-100"}
-                                `}
+                                className="flex items-center justify-between px-4 py-3 rounded-xl text-sm transition-all duration-200 group"
+                                style={{
+                                    background: isActive ? "rgba(255,255,255,0.08)" : "transparent",
+                                    color: isActive ? "var(--ed-paper-3)" : "rgba(252,250,245,0.6)",
+                                    fontFamily: "var(--ed-sans)",
+                                    fontWeight: isActive ? 500 : 400,
+                                    letterSpacing: "-0.005em",
+                                }}
                             >
                                 <div className="flex items-center gap-3.5">
                                     <Icon
-                                        size={20}
-                                        className={`transition-colors ${isActive ? "text-emerald-200" : "text-emerald-500 group-hover:text-emerald-300"}`}
-                                        strokeWidth={isActive ? 2.5 : 2}
+                                        size={18}
+                                        strokeWidth={isActive ? 2 : 1.6}
+                                        style={{
+                                            color: isActive
+                                                ? "var(--ed-accent-solid)"
+                                                : "rgba(252,250,245,0.55)",
+                                            transition: "color .2s ease",
+                                        }}
                                     />
                                     <span>{item.label}</span>
                                 </div>
                                 {isActive && (
                                     <motion.div
                                         layoutId="active-pill"
-                                        className="w-1.5 h-1.5 rounded-full bg-emerald-400"
+                                        className="w-1.5 h-1.5 rounded-full"
+                                        style={{ background: "var(--ed-accent-solid)" }}
                                         transition={{ type: "spring", bounce: 0.2, duration: 0.6 }}
                                     />
                                 )}
@@ -149,23 +197,45 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 </nav>
 
                 <div className="px-4 py-6 mt-auto">
-                    <div className="p-4 rounded-2xl bg-emerald-900/50 border border-emerald-800/50 mb-4 lg:hidden">
+                    <div
+                        className="p-4 rounded-2xl mb-4 lg:hidden"
+                        style={{
+                            background: "rgba(255,255,255,0.04)",
+                            border: "1px solid rgba(255,255,255,0.08)",
+                        }}
+                    >
                         <div className="flex items-center gap-3 mb-2">
-                            <div className="w-8 h-8 rounded-full bg-emerald-800 flex items-center justify-center border border-emerald-700/50">
-                                <Users size={14} className="text-emerald-300" />
+                            <div
+                                className="w-8 h-8 rounded-full flex items-center justify-center"
+                                style={{
+                                    background: "rgba(255,255,255,0.08)",
+                                    border: "1px solid rgba(255,255,255,0.08)",
+                                }}
+                            >
+                                <Users size={14} style={{ color: "var(--ed-accent-solid)" }} />
                             </div>
-                            <span className="text-xs font-bold text-emerald-100">Quick Tools</span>
+                            <span
+                                className="text-[10px] uppercase"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.12em",
+                                    color: "var(--ed-paper-3)",
+                                }}
+                            >
+                                Quick Tools
+                            </span>
                         </div>
                     </div>
 
                     <button
                         onClick={handleLogout}
-                        className="
-                            flex items-center gap-3.5 px-4 py-3 rounded-xl text-sm font-semibold text-white
-                            hover:bg-red-500/10 hover:text-red-400 w-full transition-all duration-300 group
-                        "
+                        className="flex items-center gap-3.5 px-4 py-3 rounded-xl text-sm w-full transition-all duration-200 group"
+                        style={{
+                            color: "rgba(252,250,245,0.7)",
+                            fontFamily: "var(--ed-sans)",
+                        }}
                     >
-                        <LogOut size={20} className="text-white group-hover:text-red-400 transition-colors" />
+                        <LogOut size={18} strokeWidth={1.6} className="transition-colors group-hover:text-red-400" style={{ color: "rgba(252,250,245,0.55)" }} />
                         <span>Logout</span>
                     </button>
                 </div>
@@ -174,41 +244,103 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             {/* Main Content */}
             <main className="flex-1 lg:ml-64 min-w-0 min-h-screen flex flex-col relative">
                 {/* Header (Universal) */}
-                <header className={`
-                    sticky top-0 z-30 transition-all duration-300 
-                    ${scrolled ? "bg-white/80 backdrop-blur-md border-b border-gray-100 py-3" : "bg-transparent py-5"}
-                    px-4 sm:px-6 lg:px-8 flex items-center justify-between
-                `}>
+                <header
+                    className={`
+                        sticky top-0 z-30 transition-all duration-300
+                        ${scrolled ? "py-3" : "py-5"}
+                        px-4 sm:px-6 lg:px-8 flex items-center justify-between
+                    `}
+                    style={{
+                        background: scrolled ? "rgba(248,245,238,0.85)" : "transparent",
+                        borderBottom: scrolled ? "1px solid var(--ed-rule)" : "1px solid transparent",
+                        backdropFilter: scrolled ? "blur(12px)" : "none",
+                    }}
+                >
                     <div className="flex items-center gap-4">
-                        <button onClick={() => setSidebarOpen(true)} className="lg:hidden p-2 -ml-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
+                        <button
+                            onClick={() => setSidebarOpen(true)}
+                            className="lg:hidden p-2 -ml-2 rounded-lg transition-colors"
+                            style={{ color: "var(--ed-ink-3)" }}
+                        >
                             <Menu size={24} />
                         </button>
                         <div className="hidden lg:flex flex-col">
-                            <h2 className="text-sm font-bold text-gray-900">Overview</h2>
-                            <p className="text-[10px] text-gray-400 font-medium tracking-wide flex items-center gap-1.5">
-                                <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></span>
-                                LIVE SYSTEM MONITOR
+                            <h2
+                                className="text-sm"
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    color: "var(--ed-ink)",
+                                    fontSize: 18,
+                                }}
+                            >
+                                Overview
+                            </h2>
+                            <p
+                                className="flex items-center gap-1.5 mt-0.5"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    fontSize: 10,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                <span className="ed-live-dot"></span>
+                                Live system monitor
                             </p>
                         </div>
                     </div>
-                    
+
                     <div className="flex items-center gap-4">
-                        <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-white rounded-full border border-gray-100 shadow-sm">
-                            <div className="w-6 h-6 rounded-full bg-gradient-to-tr from-green-500 to-emerald-400 flex items-center justify-center text-[10px] font-bold text-white uppercase italic">
+                        <div
+                            className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-full"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                boxShadow: "var(--ed-shadow-sm)",
+                            }}
+                        >
+                            <div
+                                className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] uppercase"
+                                style={{
+                                    background: "var(--ed-ink)",
+                                    color: "var(--ed-paper-3)",
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.08em",
+                                }}
+                            >
                                 AD
                             </div>
-                            <span className="text-xs font-bold text-gray-700">Administrator</span>
-                            <ChevronRight size={12} className="text-gray-300" />
+                            <span
+                                className="text-xs"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    fontSize: 11,
+                                    letterSpacing: "0.08em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-2)",
+                                }}
+                            >
+                                Administrator
+                            </span>
+                            <ChevronRight size={12} style={{ color: "var(--ed-ink-3)" }} />
                         </div>
                     </div>
                 </header>
 
-                <div className="px-4 py-4 sm:px-6 lg:px-8 lg:py-6 flex-1">
-                    {children}
-                </div>
-                
-                <footer className="px-8 py-6 text-[10px] font-bold text-gray-300 uppercase tracking-widest text-center">
-                    &copy; 2026 NEGOSYO DIGITAL &bull; PREMIUM ADMIN PANEL
+                <div className="px-4 py-4 sm:px-6 lg:px-8 lg:py-6 flex-1">{children}</div>
+
+                <footer
+                    className="px-8 py-6 text-center"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        fontSize: 10,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}
+                >
+                    &copy; {new Date().getFullYear()} Negosyo Digital &bull; Admin
                 </footer>
             </main>
         </div>

--- a/app/admin/leads/LeadContentModal.tsx
+++ b/app/admin/leads/LeadContentModal.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useMutation, useAction } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { X, Loader2, Image as ImageIcon, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+const MAX_UPLOAD_BYTES = 2_000_000;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
+export type LeadContentModalLead = {
+    _id: Id<"leads">;
+    name: string;
+    adminDescription?: string | null;
+    externalPreviewUrl?: string | null;
+    previewImageUrl?: string | null;
+    previewImageStorageKey?: string | null;
+};
+
+/**
+ * Admin modal for editing a lead's social-card content. Mirrors the upload
+ * flow documented in WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md §10B:
+ *   1. file picked → client-side mime/size check
+ *   2. action returns presigned URL + public URL
+ *   3. PUT bytes to R2 directly
+ *   4. mutation saves URL/key + description/external link
+ *
+ * Mobile picks up the new content reactively via getDetailForMobileCRM.
+ */
+export default function LeadContentModal({
+    lead,
+    onClose,
+}: {
+    lead: LeadContentModalLead;
+    onClose: () => void;
+}) {
+    const generateUploadUrl = useAction(api.leads.generatePreviewImageUploadUrl);
+    const updateContent = useMutation(api.leads.updateAdminContent);
+
+    const [description, setDescription] = useState(lead.adminDescription ?? "");
+    const [externalUrl, setExternalUrl] = useState(lead.externalPreviewUrl ?? "");
+    const [imageUrl, setImageUrl] = useState(lead.previewImageUrl ?? "");
+    const [imageStorageKey, setImageStorageKey] = useState(lead.previewImageStorageKey ?? "");
+    const [uploading, setUploading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Close on Escape
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    async function handleImageSelected(file: File) {
+        setError(null);
+
+        if (!ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
+            setError(`Unsupported image type ${file.type}. Use JPEG, PNG, or WebP.`);
+            return;
+        }
+        if (file.size > MAX_UPLOAD_BYTES) {
+            setError(`Image too large (${(file.size / 1_000_000).toFixed(2)}MB). Max 2MB.`);
+            return;
+        }
+
+        setUploading(true);
+        try {
+            const { uploadUrl, publicUrl, storageKey } = await generateUploadUrl({
+                leadId: lead._id,
+                mimeType: file.type,
+                sizeBytes: file.size,
+            });
+
+            const putRes = await fetch(uploadUrl, {
+                method: "PUT",
+                headers: { "Content-Type": file.type },
+                body: file,
+            });
+            if (!putRes.ok) {
+                throw new Error(`R2 upload failed: ${putRes.status} ${putRes.statusText}`);
+            }
+
+            setImageUrl(publicUrl);
+            setImageStorageKey(storageKey);
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : "Image upload failed";
+            setError(msg);
+        } finally {
+            setUploading(false);
+        }
+    }
+
+    async function handleSave() {
+        setError(null);
+        setSaving(true);
+        try {
+            await updateContent({
+                id: lead._id,
+                description,
+                externalPreviewUrl: externalUrl,
+                previewImageUrl: imageUrl,
+                previewImageStorageKey: imageStorageKey,
+            });
+            toast.success("Lead content saved");
+            onClose();
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : "Save failed";
+            setError(msg);
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleClear() {
+        setSaving(true);
+        try {
+            setDescription("");
+            setExternalUrl("");
+            setImageUrl("");
+            setImageStorageKey("");
+            await updateContent({
+                id: lead._id,
+                description: "",
+                externalPreviewUrl: "",
+                previewImageUrl: "",
+                previewImageStorageKey: "",
+            });
+            toast.success("Lead content cleared");
+            onClose();
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : "Clear failed";
+            setError(msg);
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    const remaining = 500 - description.length;
+
+    return (
+        <div className="editorial fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <div
+                className="max-w-xl w-full overflow-hidden"
+                style={{
+                    background: "var(--ed-paper)",
+                    borderRadius: "var(--ed-radius-xl)",
+                    border: "1px solid var(--ed-rule)",
+                    boxShadow: "var(--ed-shadow-md)",
+                }}
+            >
+                <div
+                    className="flex items-start justify-between p-6"
+                    style={{ borderBottom: "1px solid var(--ed-rule)" }}
+                >
+                    <div>
+                        <div className="ed-eyebrow mb-2">Lead Detail · Content Editor</div>
+                        <h3 className="ed-display-sm" style={{ color: "var(--ed-ink)" }}>
+                            Curate the{" "}
+                            <em style={{ color: "var(--ed-accent)" }}>social card.</em>
+                        </h3>
+                        <p
+                            className="ed-body-sm mt-2"
+                            style={{ color: "var(--ed-ink-2)" }}
+                        >
+                            What mobile creators see for{" "}
+                            <strong style={{ color: "var(--ed-ink)" }}>{lead.name}</strong>.
+                        </p>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="transition-colors"
+                        style={{ color: "var(--ed-ink-3)" }}
+                        aria-label="Close"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <div className="p-6 space-y-4 max-h-[70vh] overflow-y-auto">
+                    {/* Description */}
+                    <div className="ed-card">
+                        <div className="ed-label mb-2 flex items-center justify-between">
+                            <span>Description</span>
+                            <span style={{ textTransform: "none", letterSpacing: "0.08em" }}>
+                                {remaining} chars left
+                            </span>
+                        </div>
+                        <textarea
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value.slice(0, 500))}
+                            placeholder="Marketing copy that appears in the mobile CRM card…"
+                            rows={4}
+                            className="w-full px-3 py-2 text-sm focus:outline-none resize-none"
+                            style={{
+                                background: "var(--ed-paper)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: "var(--ed-radius-sm)",
+                                fontFamily: "var(--ed-sans)",
+                                color: "var(--ed-ink)",
+                            }}
+                            maxLength={500}
+                        />
+                    </div>
+
+                    {/* External link */}
+                    <div className="ed-card">
+                        <div className="ed-label mb-2">External link</div>
+                        <input
+                            type="url"
+                            value={externalUrl}
+                            onChange={(e) => setExternalUrl(e.target.value)}
+                            placeholder="https://..."
+                            className="w-full px-3 py-2 text-sm focus:outline-none"
+                            style={{
+                                background: "var(--ed-paper)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: "var(--ed-radius-sm)",
+                                fontFamily: "var(--ed-sans)",
+                                color: "var(--ed-ink)",
+                            }}
+                        />
+                        <p
+                            className="mt-2 text-xs"
+                            style={{
+                                color: "var(--ed-ink-3)",
+                                fontFamily: "var(--ed-sans)",
+                            }}
+                        >
+                            Optional — must start with http:// or https://
+                        </p>
+                    </div>
+
+                    {/* Image */}
+                    <div className="ed-card">
+                        <div className="ed-label mb-2 flex items-center justify-between">
+                            <span>Preview image</span>
+                            <span style={{ textTransform: "none", letterSpacing: "0.08em" }}>
+                                Max 2MB · JPEG / PNG / WebP
+                            </span>
+                        </div>
+                        {imageUrl ? (
+                            <div className="relative inline-block">
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                    src={imageUrl}
+                                    alt="preview"
+                                    className="max-w-xs"
+                                    style={{
+                                        borderRadius: "var(--ed-radius-sm)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setImageUrl("");
+                                        setImageStorageKey("");
+                                    }}
+                                    className="absolute -top-2 -right-2 w-7 h-7 rounded-full flex items-center justify-center transition-colors"
+                                    style={{
+                                        background: "var(--ed-paper-3)",
+                                        border: "1px solid var(--ed-rule)",
+                                        boxShadow: "var(--ed-shadow-sm)",
+                                        color: "var(--ed-ink-3)",
+                                    }}
+                                    aria-label="Remove image"
+                                >
+                                    <Trash2 size={14} />
+                                </button>
+                            </div>
+                        ) : (
+                            <label
+                                className="flex items-center justify-center gap-2 px-4 py-8 cursor-pointer transition-colors"
+                                style={{
+                                    border: "2px dashed var(--ed-rule-strong)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                    background: "var(--ed-paper-2)",
+                                }}
+                            >
+                                {uploading ? (
+                                    <>
+                                        <Loader2
+                                            className="w-4 h-4 animate-spin"
+                                            style={{ color: "var(--ed-accent)" }}
+                                        />
+                                        <span className="ed-body-sm">Uploading…</span>
+                                    </>
+                                ) : (
+                                    <>
+                                        <ImageIcon
+                                            className="w-5 h-5"
+                                            style={{ color: "var(--ed-ink-3)" }}
+                                        />
+                                        <span className="ed-body-sm">Choose file…</span>
+                                    </>
+                                )}
+                                <input
+                                    type="file"
+                                    accept="image/jpeg,image/png,image/webp"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) handleImageSelected(file);
+                                    }}
+                                    disabled={uploading}
+                                    className="hidden"
+                                />
+                            </label>
+                        )}
+                    </div>
+
+                    {error && (
+                        <div
+                            className="px-4 py-3 text-sm"
+                            style={{
+                                background: "var(--ed-danger-bg)",
+                                border: "1px solid var(--ed-danger)",
+                                borderRadius: "var(--ed-radius-sm)",
+                                color: "var(--ed-danger)",
+                                fontFamily: "var(--ed-sans)",
+                            }}
+                        >
+                            {error}
+                        </div>
+                    )}
+                </div>
+
+                <div
+                    className="flex items-center justify-between gap-3 p-5"
+                    style={{
+                        borderTop: "1px solid var(--ed-rule)",
+                        background: "var(--ed-paper-2)",
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={handleClear}
+                        disabled={saving || uploading}
+                        className="text-sm font-medium transition-colors disabled:opacity-50"
+                        style={{
+                            color: "var(--ed-danger)",
+                            fontFamily: "var(--ed-sans)",
+                        }}
+                    >
+                        Clear content
+                    </button>
+                    <div className="flex items-center gap-3">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            disabled={saving || uploading}
+                            className="ed-door ed-door-ghost"
+                            style={{ minHeight: 40, padding: "8px 16px", fontSize: 13 }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSave}
+                            disabled={saving || uploading}
+                            className="ed-door ed-door-accent inline-flex items-center"
+                            style={{ minHeight: 40, padding: "8px 18px", fontSize: 13, gap: 8 }}
+                        >
+                            {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+                            {saving ? "Saving…" : "Save changes"}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -18,7 +18,9 @@ import {
     Pencil,
     Trash2,
     MoreVertical,
+    Image as ImageIcon,
 } from "lucide-react"
+import LeadContentModal, { type LeadContentModalLead } from "./LeadContentModal"
 
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
     new: { label: "New", color: "bg-blue-100 text-blue-700" },
@@ -63,6 +65,9 @@ export default function AdminLeadsPage() {
     // Delete confirmation state
     const [deletingLead, setDeletingLead] = useState<any>(null)
     const [deleting, setDeleting] = useState(false)
+
+    // Lead Content editor (mobile-CRM social card data)
+    const [contentLead, setContentLead] = useState<LeadContentModalLead | null>(null)
 
     // Action dropdown state
     const [activeActionId, setActiveActionId] = useState<string | null>(null)
@@ -366,12 +371,28 @@ export default function AdminLeadsPage() {
                                                             <MoreVertical size={16} />
                                                         </button>
                                                         {activeActionId === lead._id && (
-                                                            <div className="absolute right-0 mt-1 w-36 bg-white border border-gray-200 rounded-xl shadow-lg z-20 overflow-hidden">
+                                                            <div className="absolute right-0 mt-1 w-40 bg-white border border-gray-200 rounded-xl shadow-lg z-20 overflow-hidden">
                                                                 <button
                                                                     onClick={() => openEdit(lead)}
                                                                     className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                                                                 >
                                                                     <Pencil size={14} /> Edit
+                                                                </button>
+                                                                <button
+                                                                    onClick={() => {
+                                                                        setContentLead({
+                                                                            _id: lead._id,
+                                                                            name: lead.name,
+                                                                            adminDescription: lead.adminDescription ?? null,
+                                                                            externalPreviewUrl: lead.externalPreviewUrl ?? null,
+                                                                            previewImageUrl: lead.previewImageUrl ?? null,
+                                                                            previewImageStorageKey: lead.previewImageStorageKey ?? null,
+                                                                        })
+                                                                        setActiveActionId(null)
+                                                                    }}
+                                                                    className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                                                                >
+                                                                    <ImageIcon size={14} /> Content
                                                                 </button>
                                                                 <button
                                                                     onClick={() => openDelete(lead)}
@@ -619,6 +640,14 @@ export default function AdminLeadsPage() {
                             </div>
                         </div>
                     </div>
+                )}
+
+                {/* Lead Content editor (mobile-CRM social card) */}
+                {contentLead && (
+                    <LeadContentModal
+                        lead={contentLead}
+                        onClose={() => setContentLead(null)}
+                    />
                 )}
             </div>
         </AdminLayout>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -372,10 +372,18 @@ export default function AdminDashboard() {
                 </div>
             )}
 
-            {/* Page Title */}
-            <div className="mb-6 lg:mb-8">
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Submissions Dashboard</h1>
-                <p className="text-sm text-gray-500 mt-1">Manage and review business applications across the platform.</p>
+            {/* Page Title — editorial */}
+            <div className="mb-8 lg:mb-10">
+                <div className="ed-eyebrow mb-3">Dashboard · Submissions Overview</div>
+                <h1 className="ed-display-md" style={{ color: "var(--ed-ink)" }}>
+                    Manage <em style={{ color: "var(--ed-accent)" }}>business applications</em>.
+                </h1>
+                <p
+                    className="ed-body mt-3"
+                    style={{ color: "var(--ed-ink-2)", maxWidth: "60ch" }}
+                >
+                    Review submissions, watch revenue, and approve creators across the platform.
+                </p>
             </div>
 
             {/* Stats Cards (3 widgets, read-only) */}

--- a/app/admin/pending-approvals/page.tsx
+++ b/app/admin/pending-approvals/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { useAdminAuth } from "@/hooks/useAdmin";
+import AdminLayout from "../components/AdminLayout";
+import { Search, CheckCircle2, Loader2, UserCheck } from "lucide-react";
+import { toast } from "sonner";
+
+type PendingCreator = {
+    _id: Id<"creators">;
+    clerkId: string;
+    email: string;
+    firstName: string | null;
+    middleName: string | null;
+    lastName: string | null;
+    phone: string | null;
+    profileImage: string | null;
+    quizPassedAt: number;
+    createdAt: number | null;
+    referredByCode: string | null;
+    referredByName: string | null;
+};
+
+function timeAgo(ts: number): string {
+    const diffMs = Date.now() - ts;
+    const min = Math.floor(diffMs / 60_000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const days = Math.floor(hr / 24);
+    if (days < 30) return `${days}d ago`;
+    const months = Math.floor(days / 30);
+    return `${months}mo ago`;
+}
+
+function fullName(c: PendingCreator): string {
+    const parts = [c.firstName, c.middleName, c.lastName].filter(Boolean) as string[];
+    return parts.length > 0 ? parts.join(" ") : "(name not set)";
+}
+
+export default function PendingApprovalsPage() {
+    const { isAdmin, loading: authLoading } = useAdminAuth();
+    const pending = useQuery(api.creators.listPendingApproval, isAdmin ? {} : "skip") as
+        | PendingCreator[]
+        | undefined;
+    const approveCreator = useMutation(api.creators.approveCreator);
+
+    const [search, setSearch] = useState("");
+    const [approvingId, setApprovingId] = useState<string | null>(null);
+
+    const filtered = useMemo(() => {
+        if (!pending) return [];
+        const q = search.trim().toLowerCase();
+        if (!q) return pending;
+        return pending.filter(
+            (c) =>
+                fullName(c).toLowerCase().includes(q) ||
+                c.email.toLowerCase().includes(q) ||
+                (c.phone?.toLowerCase().includes(q) ?? false),
+        );
+    }, [pending, search]);
+
+    async function handleApprove(creator: PendingCreator) {
+        setApprovingId(String(creator._id));
+        try {
+            await approveCreator({ id: creator._id });
+            toast.success(`${fullName(creator)} approved — they're now a certified creator.`);
+        } catch (e: any) {
+            toast.error(e?.message ?? "Approval failed");
+        } finally {
+            setApprovingId(null);
+        }
+    }
+
+    if (authLoading) {
+        return (
+            <AdminLayout>
+                <div className="flex items-center justify-center py-32">
+                    <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+                </div>
+            </AdminLayout>
+        );
+    }
+
+    if (!isAdmin) return null;
+
+    return (
+        <AdminLayout>
+            <div className="space-y-6">
+                {/* Editorial header — mono eyebrow + serif display + body lede */}
+                <div className="flex items-start justify-between gap-6 flex-wrap">
+                    <div>
+                        <div className="flex items-center gap-3 mb-3">
+                            <span className="ed-eyebrow">
+                                Pending Approval · {String(pending?.length ?? 0).padStart(2, "0")} creators
+                            </span>
+                            <span className="ed-live-dot" />
+                        </div>
+                        <h1 className="ed-display-lg" style={{ color: "var(--ed-ink)" }}>
+                            Awaiting your{" "}
+                            <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>
+                                approval.
+                            </em>
+                        </h1>
+                        <p
+                            className="ed-body mt-3 flex items-start gap-2"
+                            style={{ maxWidth: "56ch" }}
+                        >
+                            <UserCheck className="w-4 h-4 mt-1 flex-shrink-0" style={{ color: "var(--ed-accent)" }} />
+                            <span>
+                                Creators who passed the onboarding quiz and are waiting for admin
+                                certification. Approving releases the mobile Pending Review gate.
+                            </span>
+                        </p>
+                    </div>
+                    <div className="text-right">
+                        <div
+                            className="ed-display-md"
+                            style={{ color: "var(--ed-ink)", fontVariantNumeric: "tabular-nums" }}
+                        >
+                            {pending?.length ?? "—"}
+                        </div>
+                        <div className="ed-label mt-1">waiting</div>
+                    </div>
+                </div>
+
+                <hr className="ed-rule" />
+
+                {/* Search */}
+                <div className="relative">
+                    <Search
+                        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+                        style={{ color: "var(--ed-ink-3)" }}
+                    />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search by name, email, or phone…"
+                        className="w-full pl-10 pr-4 py-3 text-sm focus:outline-none transition-colors"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            borderRadius: "var(--ed-radius-sm)",
+                            fontFamily: "var(--ed-sans)",
+                            color: "var(--ed-ink)",
+                        }}
+                    />
+                </div>
+
+                {/* Queue list */}
+                {pending === undefined ? (
+                    <div className="flex items-center justify-center py-16">
+                        <Loader2
+                            className="w-6 h-6 animate-spin"
+                            style={{ color: "var(--ed-ink-3)" }}
+                        />
+                    </div>
+                ) : filtered.length === 0 ? (
+                    <div className="ed-card-xl text-center">
+                        <CheckCircle2
+                            className="w-10 h-10 mx-auto mb-3"
+                            style={{ color: "var(--ed-accent)" }}
+                        />
+                        <h3
+                            className="ed-display-sm"
+                            style={{ color: "var(--ed-ink)" }}
+                        >
+                            {search ? (
+                                <>
+                                    No <em style={{ color: "var(--ed-accent)" }}>matches</em>
+                                </>
+                            ) : (
+                                <>
+                                    Inbox <em style={{ color: "var(--ed-accent)" }}>zero</em>.
+                                </>
+                            )}
+                        </h3>
+                        <p className="ed-body-sm mt-2" style={{ color: "var(--ed-ink-2)" }}>
+                            {search
+                                ? "Try a different search term."
+                                : "Every creator who passed the quiz has been approved. Nice."}
+                        </p>
+                    </div>
+                ) : (
+                    <div
+                        className="overflow-hidden"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            borderRadius: "var(--ed-radius-lg)",
+                        }}
+                    >
+                        <table className="w-full">
+                            <thead style={{ background: "var(--ed-paper-2)", borderBottom: "1px solid var(--ed-rule)" }}>
+                                <tr>
+                                    <th className="ed-label text-left px-6 py-3">Creator</th>
+                                    <th className="ed-label text-left px-6 py-3">Email</th>
+                                    <th className="ed-label text-left px-6 py-3">Phone</th>
+                                    <th className="ed-label text-left px-6 py-3">Waiting</th>
+                                    <th className="ed-label text-left px-6 py-3">Referrer</th>
+                                    <th className="ed-label text-right px-6 py-3">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {filtered.map((c, i) => {
+                                    const isApproving = approvingId === String(c._id);
+                                    return (
+                                        <tr
+                                            key={String(c._id)}
+                                            className="transition-colors hover:bg-[var(--ed-paper-2)]"
+                                            style={{
+                                                borderTop: i === 0 ? "none" : "1px solid var(--ed-rule)",
+                                            }}
+                                        >
+                                            <td className="px-6 py-4">
+                                                <div className="flex items-center gap-3">
+                                                    <div
+                                                        className="w-10 h-10 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0"
+                                                        style={{
+                                                            background: "var(--ed-paper-2)",
+                                                            border: "1px solid var(--ed-rule)",
+                                                        }}
+                                                    >
+                                                        {c.profileImage ? (
+                                                            // eslint-disable-next-line @next/next/no-img-element
+                                                            <img
+                                                                src={c.profileImage}
+                                                                alt={fullName(c)}
+                                                                className="w-full h-full object-cover"
+                                                            />
+                                                        ) : (
+                                                            <span
+                                                                style={{
+                                                                    fontFamily: "var(--ed-serif)",
+                                                                    fontSize: 16,
+                                                                    color: "var(--ed-ink-2)",
+                                                                }}
+                                                            >
+                                                                {(c.firstName?.[0] ?? c.email[0]).toUpperCase()}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    <div>
+                                                        <div
+                                                            className="text-sm"
+                                                            style={{
+                                                                fontFamily: "var(--ed-serif)",
+                                                                fontSize: 16,
+                                                                color: "var(--ed-ink)",
+                                                            }}
+                                                        >
+                                                            {fullName(c)}
+                                                        </div>
+                                                        <div className="ed-label mt-1">
+                                                            quiz passed {timeAgo(c.quizPassedAt)}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-6 py-4 text-sm" style={{ color: "var(--ed-ink-2)" }}>
+                                                {c.email}
+                                            </td>
+                                            <td className="px-6 py-4 text-sm" style={{ color: "var(--ed-ink-2)" }}>
+                                                {c.phone ?? "—"}
+                                            </td>
+                                            <td
+                                                className="px-6 py-4 text-sm whitespace-nowrap"
+                                                style={{
+                                                    fontFamily: "var(--ed-mono)",
+                                                    fontSize: 11,
+                                                    letterSpacing: "0.08em",
+                                                    color: "var(--ed-ink-2)",
+                                                }}
+                                            >
+                                                {timeAgo(c.quizPassedAt).toUpperCase()}
+                                            </td>
+                                            <td className="px-6 py-4 text-sm" style={{ color: "var(--ed-ink-2)" }}>
+                                                {c.referredByName ?? c.referredByCode ?? "—"}
+                                            </td>
+                                            <td className="px-6 py-4 text-right">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleApprove(c)}
+                                                    disabled={isApproving}
+                                                    className="ed-door ed-door-accent inline-flex items-center"
+                                                    style={{ minHeight: 38, padding: "8px 16px", fontSize: 13 }}
+                                                >
+                                                    {isApproving ? (
+                                                        <>
+                                                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                                                            <span style={{ marginLeft: 8 }}>Approving…</span>
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <CheckCircle2 className="w-3.5 h-3.5" />
+                                                            <span style={{ marginLeft: 8 }}>Approve</span>
+                                                        </>
+                                                    )}
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </AdminLayout>
+    );
+}

--- a/app/certification-quiz/page.tsx
+++ b/app/certification-quiz/page.tsx
@@ -137,8 +137,8 @@ export default function CertificationQuizPage() {
 
     if (!isLoaded || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -189,7 +189,10 @@ export default function CertificationQuizPage() {
     // ==================== PASS SCREEN ====================
     if (phase === "pass") {
         return (
-            <div className="min-h-screen bg-zinc-50 font-sans py-8 px-4 overflow-y-auto">
+            <div
+                className="editorial min-h-screen py-8 px-4 overflow-y-auto"
+                style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+            >
                 {/* Success header */}
                 <div
                     className={`text-center mb-8 transition-all duration-700 ease-out ${passAnimated ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'}`}
@@ -228,7 +231,10 @@ export default function CertificationQuizPage() {
     // ==================== FAIL SCREEN ====================
     if (phase === "fail") {
         return (
-            <div className="min-h-screen bg-white font-sans flex flex-col items-center justify-center px-4 text-center">
+            <div
+                className="editorial min-h-screen flex flex-col items-center justify-center px-4 text-center"
+                style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+            >
                 <div className="w-20 h-20 bg-zinc-100 rounded-full flex items-center justify-center mb-6">
                     <RotateCcw className="w-10 h-10 text-zinc-400" />
                 </div>
@@ -247,7 +253,10 @@ export default function CertificationQuizPage() {
 
     // ==================== QUIZ SCREEN ====================
     return (
-        <div className="min-h-screen bg-white font-sans pb-12">
+        <div
+            className="editorial min-h-screen pb-12"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <header className="px-4 pt-6 pb-4">
                 <div className="flex items-center gap-3 mb-4">
                     <Link href="/training-lessons" className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -77,8 +77,11 @@ export default function DashboardPage() {
         !creator.certifiedAt
     ) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div
+                className="min-h-screen flex items-center justify-center"
+                style={{ background: "var(--ed-paper)" }}
+            >
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -88,29 +91,66 @@ export default function DashboardPage() {
     const initials = `${(creator.firstName || "")[0] || ""}${(creator.lastName || "")[0] || ""}`.toUpperCase()
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-24 overflow-x-hidden">
+        <div
+            className="editorial min-h-screen pb-24 overflow-x-hidden"
+            style={{
+                background: "var(--ed-paper)",
+                color: "var(--ed-ink)",
+                fontFamily: "var(--ed-sans)",
+            }}
+        >
             {/* Header */}
             <header className="px-4 pt-6 pb-2">
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                        <Link href="/profile" className="w-10 h-10 bg-zinc-100 rounded-full flex items-center justify-center overflow-hidden border border-zinc-200">
+                        <Link
+                            href="/profile"
+                            className="w-10 h-10 rounded-full flex items-center justify-center overflow-hidden"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                            }}
+                        >
                             {creator.profileImage ? (
                                 <img src={creator.profileImage} alt="Profile" className="w-full h-full object-cover" />
                             ) : (
-                                <span className="text-sm font-bold text-zinc-500">{initials}</span>
+                                <span
+                                    className="text-sm"
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        color: "var(--ed-ink-2)",
+                                    }}
+                                >
+                                    {initials}
+                                </span>
                             )}
                         </Link>
                         <div>
-                            <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wide">Welcome back</p>
-                            <h1 className="text-lg font-bold text-zinc-900 leading-none">
-                                Mabuhay, {creator.firstName || "Creator"}!
+                            <p className="ed-label">Welcome back</p>
+                            <h1
+                                className="text-2xl leading-none mt-1"
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    color: "var(--ed-ink)",
+                                    letterSpacing: "-0.015em",
+                                }}
+                            >
+                                Mabuhay,{" "}
+                                <em style={{ color: "var(--ed-accent)" }}>
+                                    {creator.firstName || "Creator"}.
+                                </em>
                             </h1>
                         </div>
                     </div>
                     <div className="flex items-center gap-2">
                         <Link
                             href="/notifications"
-                            className="relative w-10 h-10 bg-white rounded-full flex items-center justify-center border border-zinc-200 text-zinc-500 hover:text-zinc-900 hover:border-zinc-300 transition-colors"
+                            className="relative w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                color: "var(--ed-ink-2)",
+                            }}
                         >
                             <Bell className="w-5 h-5" />
                             {(unreadCount ?? 0) > 0 && (
@@ -121,7 +161,12 @@ export default function DashboardPage() {
                         </Link>
                         <Link
                             href="/profile"
-                            className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-zinc-200 text-zinc-500 hover:text-zinc-900 hover:border-zinc-300 transition-colors"
+                            className="w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                color: "var(--ed-ink-2)",
+                            }}
                         >
                             <User className="w-5 h-5" />
                         </Link>
@@ -130,50 +175,138 @@ export default function DashboardPage() {
             </header>
 
             <main className="px-4 space-y-5">
-                {/* Balance Card */}
-                <div className="bg-zinc-900 text-white rounded-3xl p-5 relative overflow-hidden shadow-xl shadow-emerald-500/20 border border-emerald-500">
-                    {/* Abstract background effect */}
-                    <div className="absolute top-0 right-0 w-64 h-64 bg-emerald-500/10 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none"></div>
+                {/* Balance Card — ink surface with serif amount */}
+                <div
+                    className="rounded-3xl p-6 relative overflow-hidden"
+                    style={{
+                        background: "var(--ed-ink)",
+                        color: "var(--ed-paper-3)",
+                        boxShadow: "var(--ed-shadow-md)",
+                    }}
+                >
+                    <div className="absolute top-0 right-0 w-64 h-64 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none" style={{ background: "rgba(16, 185, 129, 0.12)" }}></div>
 
                     <div className="flex justify-between items-start mb-2 relative z-10">
-                        <span className="text-zinc-400 text-xs font-medium">Available Balance</span>
-                        <div className="w-7 h-7 rounded-full bg-zinc-800 flex items-center justify-center text-emerald-400">
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: "rgba(252,250,245,0.55)",
+                            }}
+                        >
+                            Available Balance
+                        </span>
+                        <div
+                            className="w-7 h-7 rounded-full flex items-center justify-center"
+                            style={{ background: "rgba(255,255,255,0.08)", color: "var(--ed-accent-solid)" }}
+                        >
                             <Wallet className="w-3.5 h-3.5" />
                         </div>
                     </div>
 
-                    <div className="mb-5 relative z-10">
-                        <span className="text-3xl font-bold tracking-tight">
-                            ₱ {creator.balance?.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) || '0.00'}
+                    <div className="mb-1 relative z-10 flex items-baseline gap-2">
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 20,
+                                color: "rgba(252,250,245,0.55)",
+                            }}
+                        >
+                            ₱
+                        </span>
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 56,
+                                lineHeight: 1.0,
+                                letterSpacing: "-0.025em",
+                                fontVariantNumeric: "tabular-nums",
+                            }}
+                        >
+                            {creator.balance?.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) || '0.00'}
                         </span>
                     </div>
                 </div>
 
-                {/* Quick Stats */}
+                {/* Quick Stats — paper-3 cards with mono labels + serif numbers */}
                 <div className="grid grid-cols-3 gap-3">
-                    <div className="bg-white p-3 rounded-2xl border border-zinc-200 shadow-sm text-center">
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider mb-1">Submissions</p>
-                        <p className="text-lg font-bold text-zinc-900">{submissions?.length ?? 0}</p>
-                    </div>
-                    <div className="bg-white p-3 rounded-2xl border border-zinc-200 shadow-sm text-center">
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider mb-1">In Review</p>
-                        <p className="text-lg font-bold text-yellow-600">
-                            {submissions?.filter((s: any) => s.status === 'submitted' || s.status === 'in_review').length ?? 0}
-                        </p>
-                    </div>
-                    <div className="bg-white p-3 rounded-2xl border border-zinc-200 shadow-sm text-center">
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider mb-1">Verified</p>
-                        <p className="text-lg font-bold text-emerald-600">
-                            {submissions?.filter((s: any) => s.status === 'approved' || s.status === 'paid' || s.status === 'deployed' || s.status === 'completed').length ?? 0}
-                        </p>
-                    </div>
+                    {[
+                        { label: "Submissions", value: submissions?.length ?? 0, tone: "ink" as const },
+                        { label: "In Review", value: submissions?.filter((s: any) => s.status === 'submitted' || s.status === 'in_review').length ?? 0, tone: "warn" as const },
+                        { label: "Verified", value: submissions?.filter((s: any) => s.status === 'approved' || s.status === 'paid' || s.status === 'deployed' || s.status === 'completed').length ?? 0, tone: "accent" as const },
+                    ].map((s) => (
+                        <div
+                            key={s.label}
+                            className="p-3 text-center"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: "var(--ed-radius-md)",
+                            }}
+                        >
+                            <p
+                                className="mb-1"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    fontSize: 9,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                {s.label}
+                            </p>
+                            <p
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    fontSize: 28,
+                                    lineHeight: 1.0,
+                                    fontVariantNumeric: "tabular-nums",
+                                    color:
+                                        s.tone === "accent" ? "var(--ed-accent)" :
+                                        s.tone === "warn" ? "var(--ed-warn)" :
+                                        "var(--ed-ink)",
+                                }}
+                            >
+                                {s.value}
+                            </p>
+                        </div>
+                    ))}
                 </div>
 
-                {/* Submission Status */}
+                {/* Submission Status — eyebrow + serif heading */}
                 <div>
                     <div className="flex items-center justify-between mb-3">
-                        <h2 className="text-base font-bold text-zinc-900">Recent Submissions</h2>
-                        <Link href="/submissions" className="text-xs font-semibold text-emerald-600 hover:text-emerald-700">View All</Link>
+                        <div>
+                            <p className="ed-label">§ Recent activity</p>
+                            <h2
+                                className="mt-1"
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    fontSize: 22,
+                                    lineHeight: 1.15,
+                                    letterSpacing: "-0.015em",
+                                    color: "var(--ed-ink)",
+                                }}
+                            >
+                                Recent <em style={{ color: "var(--ed-accent)" }}>submissions</em>
+                            </h2>
+                        </div>
+                        <Link
+                            href="/submissions"
+                            className="text-xs"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.12em",
+                                textTransform: "uppercase",
+                                color: "var(--ed-accent)",
+                            }}
+                        >
+                            View all →
+                        </Link>
                     </div>
                     <div className="space-y-3">
                         {recentSubmissions.map((sub: any) => {
@@ -202,15 +335,40 @@ export default function DashboardPage() {
 
                             return (
                                 <Link key={sub._id} href={`/submissions/${sub._id}`}>
-                                    <div className="bg-white rounded-2xl p-3 border border-zinc-200 shadow-sm flex items-center justify-between hover:border-zinc-300 hover:shadow-md transition-all cursor-pointer">
+                                    <div
+                                        className="p-3 flex items-center justify-between transition-all cursor-pointer hover:translate-y-[-1px]"
+                                        style={{
+                                            background: "var(--ed-paper-3)",
+                                            border: "1px solid var(--ed-rule)",
+                                            borderRadius: "var(--ed-radius-md)",
+                                        }}
+                                    >
                                         <div className="flex items-center gap-3">
                                             <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${getStatusBg()}`}>
                                                 {isDraft ? <Clock className="w-5 h-5" /> : <Store className="w-5 h-5" />}
                                             </div>
                                             <div>
-                                                <h3 className="font-bold text-sm text-zinc-900">{sub.businessName}</h3>
-                                                <p className="text-[10px] text-zinc-500">
-                                                    Submitted {new Date(sub._creationTime).toLocaleDateString()}
+                                                <h3
+                                                    style={{
+                                                        fontFamily: "var(--ed-serif)",
+                                                        fontSize: 17,
+                                                        lineHeight: 1.2,
+                                                        color: "var(--ed-ink)",
+                                                    }}
+                                                >
+                                                    {sub.businessName}
+                                                </h3>
+                                                <p
+                                                    className="mt-0.5"
+                                                    style={{
+                                                        fontFamily: "var(--ed-mono)",
+                                                        fontSize: 10,
+                                                        letterSpacing: "0.1em",
+                                                        textTransform: "uppercase",
+                                                        color: "var(--ed-ink-3)",
+                                                    }}
+                                                >
+                                                    {new Date(sub._creationTime).toLocaleDateString()}
                                                 </p>
                                             </div>
                                         </div>
@@ -222,8 +380,36 @@ export default function DashboardPage() {
                             )
                         })}
                         {recentSubmissions.length === 0 && (
-                            <div className="text-center py-6 bg-zinc-50/40 rounded-2xl border border-dashed border-zinc-200">
-                                <p className="text-zinc-500 text-xs">No submissions yet.</p>
+                            <div
+                                className="text-center py-8"
+                                style={{
+                                    background: "var(--ed-paper-2)",
+                                    border: "1px dashed var(--ed-rule-strong)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                }}
+                            >
+                                <p
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        fontSize: 16,
+                                        fontStyle: "italic",
+                                        color: "var(--ed-ink-2)",
+                                    }}
+                                >
+                                    No submissions yet.
+                                </p>
+                                <p
+                                    className="mt-1"
+                                    style={{
+                                        fontFamily: "var(--ed-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.14em",
+                                        textTransform: "uppercase",
+                                        color: "var(--ed-ink-3)",
+                                    }}
+                                >
+                                    Start by tapping the + button below
+                                </p>
                             </div>
                         )}
                     </div>

--- a/app/edit-profile/page.tsx
+++ b/app/edit-profile/page.tsx
@@ -107,8 +107,8 @@ export default function EditProfilePage() {
 
     if (!isLoaded || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -116,7 +116,10 @@ export default function EditProfilePage() {
     const initials = `${(creator?.firstName || "")[0] || ""}${(creator?.lastName || "")[0] || ""}`.toUpperCase()
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-12">
+        <div
+            className="editorial min-h-screen pb-12"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <header className="px-4 pt-6 pb-4">
                 <div className="flex items-center gap-3">
                     <Link href="/profile" className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors">

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,14 +4,17 @@
   --background: #ffffff;
   --foreground: #0a0a0a;
 
-  /* NEO LAB editorial palette */
-  --khaki: #f4ede1;        /* warm cream — primary surface */
-  --khaki-deep: #ebe2cf;   /* slightly deeper khaki for card surfaces */
-  --ink: #0f0e14;          /* near-black for dark sections */
-  --ink-soft: #1c1a24;     /* softer near-black for surfaces over ink */
-  /* Editorial green accent — replaces rust. Deep forest on khaki, sage on ink. */
-  --rust: #2d5a3f;         /* deep forest green — accent on light surfaces */
-  --rust-soft: #6b9678;    /* sage green — accent on dark surfaces */
+  /* Editorial Paper palette — aligned with the mobile design system
+     (see docs/changes/WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md §10.5).
+     Legacy var names (--khaki, --ink, --rust, --khaki-deep, --rust-soft) are
+     KEPT so pages that already reference them keep working — they just now
+     resolve to the new editorial values. New code should use --ed-* directly. */
+  --khaki: #F8F5EE;        /* warm off-white — page bg (was #f4ede1) */
+  --khaki-deep: #EFEBE0;   /* card surface (was #ebe2cf) */
+  --ink: #1B1C24;          /* near-black (was #0f0e14) */
+  --ink-soft: #3C3F4A;     /* softer ink for body emphasis (was #1c1a24) */
+  --rust: #047857;         /* emerald accent — primary CTA / italic display */
+  --rust-soft: #10B981;    /* emerald-solid — door-accent fills */
 }
 
 @theme inline {
@@ -63,6 +66,221 @@ body {
 [data-clerk-provider="tiktok"],
 [data-provider="tiktok"] {
   display: none !important;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   EDITORIAL PAPER design system (mobile-spec — separate from .neo landing).
+   Tokens are GLOBAL (no scope) so any page can opt into them by using the
+   `.editorial` wrapper class on a root element OR by referencing the CSS
+   variables directly. Utility classes (.ed-display, .ed-label, .ed-door,
+   .ed-card, .ed-pill, .ed-rule) are also global.
+
+   Color values match the mobile-side palette (RGB, not oklch) so admin and
+   mobile feel coherent. See docs/changes/WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md
+   §10.5 for the full token reference.
+   ────────────────────────────────────────────────────────────────────────── */
+:root {
+  /* Paper (surfaces) */
+  --ed-paper:   #F8F5EE;
+  --ed-paper-2: #EFEBE0;
+  --ed-paper-3: #FCFAF5;
+
+  /* Ink (text + primary dark surfaces) */
+  --ed-ink:   #1B1C24;
+  --ed-ink-2: #3C3F4A;
+  --ed-ink-3: #7A7E8A;
+
+  /* Emerald accent — primary CTA / italic display emphasis */
+  --ed-accent:        #047857;
+  --ed-accent-ink:    #064E3B;
+  --ed-accent-bg:     #D1FAE5;
+  --ed-accent-solid:  #10B981;
+
+  /* Business / system accent */
+  --ed-business:    #1F3654;
+  --ed-business-bg: #E4E9F0;
+  --ed-business-ink:#11203A;
+
+  /* Live (real-time markers — distinct from brand green) */
+  --ed-live:      #3FA86A;
+  --ed-live-soft: #D4EFDE;
+
+  /* Rules / dividers */
+  --ed-rule:        #E0D8C9;
+  --ed-rule-strong: #B7AC95;
+
+  /* Status */
+  --ed-warn:      #C68A12;
+  --ed-warn-bg:   #FBE9C4;
+  --ed-danger:    #B43A1F;
+  --ed-danger-bg: #F3D7CF;
+
+  /* Type stacks (re-use the variables loaded by next/font in layout.tsx) */
+  --ed-serif: var(--font-instrument-serif), "Instrument Serif", Georgia, serif;
+  --ed-sans:  var(--font-onest), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --ed-mono:  var(--font-mono), ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  /* Radius scale */
+  --ed-radius-xs: 8px;
+  --ed-radius-sm: 12px;
+  --ed-radius-md: 18px;
+  --ed-radius-lg: 24px;
+  --ed-radius-xl: 32px;
+  --ed-radius-pill: 999px;
+
+  /* Subtle warm shadow (no harsh elevation against paper bg) */
+  --ed-shadow-sm: 0 1px 2px rgba(27, 28, 36, .04), 0 4px 12px -6px rgba(27, 28, 36, .08);
+  --ed-shadow-md: 0 2px 6px rgba(27, 28, 36, .06), 0 12px 24px -10px rgba(27, 28, 36, .12);
+}
+
+/* Wrapper class — apply to a top-level element of a page/layout to opt into
+   paper background + ink text + Onest body font.
+   Use `.editorial` on the OUTER container, not on individual buttons. */
+.editorial {
+  background: var(--ed-paper);
+  color: var(--ed-ink);
+  font-family: var(--ed-sans);
+}
+
+/* Headlines (Instrument Serif). Use the size you need. */
+.ed-display    { font-family: var(--ed-serif); font-weight: 400; letter-spacing: -0.02em; }
+.ed-display-sm { font-family: var(--ed-serif); font-size: clamp(24px, 3vw, 28px);   line-height: 1.1;  letter-spacing: -0.015em; font-weight: 400; }
+.ed-display-md { font-family: var(--ed-serif); font-size: clamp(32px, 4vw, 40px);   line-height: 1.05; letter-spacing: -0.02em;  font-weight: 400; }
+.ed-display-lg { font-family: var(--ed-serif); font-size: clamp(40px, 5.5vw, 56px); line-height: 1.0;  letter-spacing: -0.025em; font-weight: 400; }
+.ed-display-xl { font-family: var(--ed-serif); font-size: clamp(56px, 8vw, 72px);   line-height: 0.95; letter-spacing: -0.025em; font-weight: 400; }
+.ed-display em, .ed-display-sm em, .ed-display-md em, .ed-display-lg em, .ed-display-xl em {
+  font-style: italic;
+  color: var(--ed-accent);
+}
+
+/* Body */
+.ed-body    { font-family: var(--ed-sans); font-size: 15px; line-height: 1.55; color: var(--ed-ink-2); }
+.ed-body-sm { font-family: var(--ed-sans); font-size: 13px; line-height: 1.5;  color: var(--ed-ink-2); }
+.ed-body-lg { font-family: var(--ed-sans); font-size: 17px; line-height: 1.55; color: var(--ed-ink-2); }
+
+/* Mono uppercase eyebrow label — the editorial signature */
+.ed-label,
+.ed-eyebrow {
+  font-family: var(--ed-mono);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ed-ink-3);
+}
+.ed-eyebrow { letter-spacing: 0.18em; }
+
+/* Doors — large primary CTAs (NEO LAB door pattern) */
+.ed-door {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  border-radius: var(--ed-radius-md);
+  border: 1px solid var(--ed-ink);
+  font-family: var(--ed-sans);
+  font-weight: 500;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  text-align: left;
+  line-height: 1.15;
+  cursor: pointer;
+  transition: transform .15s ease, background .15s ease, color .15s ease;
+  min-height: 48px;
+  background: var(--ed-ink);
+  color: var(--ed-paper-3);
+}
+.ed-door:hover:not(:disabled) { transform: translateY(-1px); }
+.ed-door:disabled { opacity: 0.5; cursor: not-allowed; }
+.ed-door-accent {
+  background: var(--ed-accent-solid);
+  border-color: var(--ed-accent-solid);
+  color: #fff;
+}
+.ed-door-ghost {
+  background: transparent;
+  color: var(--ed-ink);
+  border-color: var(--ed-ink);
+}
+.ed-door-ghost:hover:not(:disabled) {
+  background: var(--ed-ink);
+  color: var(--ed-paper-3);
+}
+.ed-door-caption {
+  display: block;
+  font-family: var(--ed-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  margin-bottom: 2px;
+}
+
+/* Card — paper-3 surface with warm rule border */
+.ed-card {
+  background: var(--ed-paper-3);
+  border: 1px solid var(--ed-rule);
+  border-radius: var(--ed-radius-md);
+  padding: 16px;
+}
+.ed-card-lg { border-radius: var(--ed-radius-lg); padding: 24px; }
+.ed-card-xl { border-radius: var(--ed-radius-xl); padding: 32px; }
+
+/* Pill — mono-labeled chip */
+.ed-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--ed-rule-strong);
+  background: var(--ed-paper-3);
+  border-radius: var(--ed-radius-pill);
+  font-family: var(--ed-mono);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ed-ink-2);
+  cursor: pointer;
+  transition: all .12s ease;
+}
+.ed-pill[aria-pressed="true"] {
+  background: var(--ed-ink);
+  color: var(--ed-paper-3);
+  border-color: var(--ed-ink);
+}
+.ed-pill:hover { border-color: var(--ed-ink); color: var(--ed-ink); }
+.ed-pill[aria-pressed="true"]:hover { color: var(--ed-paper-3); }
+
+/* Warm divider rule */
+.ed-rule        { height: 1px; background: var(--ed-rule);        width: 100%; border: 0; margin: 0; }
+.ed-rule-strong { height: 1px; background: var(--ed-rule-strong); width: 100%; border: 0; margin: 0; }
+
+/* LiveDot — pulsing real-time indicator */
+.ed-live-dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  background: var(--ed-live);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 var(--ed-live);
+  animation: ed-live-pulse 2s infinite;
+  flex-shrink: 0;
+}
+@keyframes ed-live-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(63, 168, 106, 0.6); }
+  70%  { box-shadow: 0 0 0 8px rgba(63, 168, 106, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(63, 168, 106, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ed-live-dot { animation: none; }
+}
+
+/* Mobile responsive — display sizes drop one notch on small viewports */
+@media (max-width: 768px) {
+  .ed-display-xl { font-size: 48px; line-height: 1.0; }
+  .ed-display-lg { font-size: 40px; line-height: 1.05; }
+  .ed-display-md { font-size: 28px; line-height: 1.1; }
 }
 
 /* ──────────────────────────────────────────────────────────────────────────

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -112,8 +112,8 @@ export default function NotificationsPage() {
 
     if (!isLoaded || creator === undefined || notifications === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -149,7 +149,10 @@ export default function NotificationsPage() {
     const hasUnread = notifications?.some((n: any) => !n.read)
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-12">
+        <div
+            className="editorial min-h-screen pb-12"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <header className="px-4 pt-6 pb-4">
                 <div className="flex items-center justify-between mb-4">
                     <div className="flex items-center gap-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,12 +48,6 @@ export default function Home() {
                 {/* § Process — Online Kit pipeline */}
                 <ProcessSection />
 
-                {/* § 04 — Pricing (₱1,000 / ₱1,500) */}
-                <BusinessPricingSection />
-
-                {/* § 05 — For creators (dark slab — ₱500 / ₱300 / ₱1,000) */}
-                <EarningsSection />
-
                 {/* § Manifesto — the 99% statement */}
                 <ManifestoSection />
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -128,8 +128,8 @@ export default function ProfilePage() {
 
     if (!isLoaded || !isSignedIn || creator === undefined || !creator) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -226,94 +226,217 @@ export default function ProfilePage() {
     ]
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-24 overflow-x-hidden">
+        <div
+            className="editorial min-h-screen pb-24 overflow-x-hidden"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <main className="px-4 py-6">
                 {/* Back Button */}
                 <div className="flex items-center justify-between mb-2">
                     <Link
                         href="/dashboard"
-                        className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors"
+                        className="w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            color: "var(--ed-ink-2)",
+                        }}
                     >
                         <ArrowLeft className="w-5 h-5" />
                     </Link>
                 </div>
 
-                {/* Profile Header */}
-                <div className="flex flex-col items-center mt-2 mb-6">
+                {/* Editorial eyebrow */}
+                <p className="ed-label mt-2">§ Your Profile</p>
+
+                {/* Profile Header — avatar + serif name */}
+                <div className="flex flex-col items-center mt-4 mb-8">
                     {creator.profileImage ? (
-                        <div className="w-24 h-24 rounded-full overflow-hidden border-4 border-white shadow-lg mb-3">
+                        <div
+                            className="w-28 h-28 rounded-full overflow-hidden mb-4"
+                            style={{
+                                border: "4px solid var(--ed-paper-3)",
+                                boxShadow: "var(--ed-shadow-md)",
+                            }}
+                        >
                             <img src={creator.profileImage} alt={fullName} className="w-full h-full object-cover" />
                         </div>
                     ) : (
-                        <div className="w-24 h-24 rounded-full bg-zinc-900 flex items-center justify-center text-white text-2xl font-bold border-4 border-white shadow-lg mb-3">
+                        <div
+                            className="w-28 h-28 rounded-full flex items-center justify-center mb-4"
+                            style={{
+                                background: "var(--ed-ink)",
+                                color: "var(--ed-paper-3)",
+                                border: "4px solid var(--ed-paper-3)",
+                                boxShadow: "var(--ed-shadow-md)",
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 36,
+                                lineHeight: 1.0,
+                            }}
+                        >
                             {initials}
                         </div>
                     )}
 
                     <div className="flex items-center gap-2">
-                        <h1 className="text-xl font-bold text-zinc-900">{fullName}</h1>
-                        {creator.certifiedAt && <BadgeCheck className="w-5 h-5 text-emerald-500" />}
+                        <h1
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 30,
+                                lineHeight: 1.1,
+                                letterSpacing: "-0.02em",
+                                color: "var(--ed-ink)",
+                            }}
+                        >
+                            {fullName}
+                        </h1>
+                        {creator.certifiedAt && <BadgeCheck className="w-5 h-5" style={{ color: "var(--ed-accent)" }} />}
                     </div>
 
-                    <p className="text-sm text-zinc-500 mt-0.5">{creator.email || user?.primaryEmailAddress?.emailAddress}</p>
+                    <p
+                        className="mt-1"
+                        style={{
+                            fontFamily: "var(--ed-sans)",
+                            fontSize: 14,
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        {creator.email || user?.primaryEmailAddress?.emailAddress}
+                    </p>
 
-                    {creator.referralCode && (
-                        <div className="mt-2 px-3 py-1 bg-zinc-100 rounded-full flex items-center gap-1.5">
-                            <Gift className="w-3 h-3 text-zinc-400" />
-                            <span className="text-xs font-bold text-zinc-900 font-mono tracking-wider">
-                                {creator.referralCode}
-                            </span>
-                        </div>
-                    )}
+                    <div className="flex flex-wrap items-center gap-2 mt-3">
+                        {creator.referralCode && (
+                            <div
+                                className="px-3 py-1 rounded-full flex items-center gap-1.5"
+                                style={{
+                                    background: "var(--ed-paper-3)",
+                                    border: "1px solid var(--ed-rule)",
+                                }}
+                            >
+                                <Gift className="w-3 h-3" style={{ color: "var(--ed-ink-3)" }} />
+                                <span
+                                    style={{
+                                        fontFamily: "var(--ed-mono)",
+                                        fontSize: 11,
+                                        letterSpacing: "0.14em",
+                                        color: "var(--ed-ink-2)",
+                                    }}
+                                >
+                                    {creator.referralCode}
+                                </span>
+                            </div>
+                        )}
 
-                    {creator.certifiedAt && (
-                        <div className="mt-2 px-3 py-1 bg-emerald-50 rounded-full flex items-center gap-1.5">
-                            <BadgeCheck className="w-3.5 h-3.5 text-emerald-600" />
-                            <span className="text-[10px] font-bold text-emerald-700 uppercase tracking-wider">
-                                Certified Creator
-                            </span>
-                        </div>
-                    )}
+                        {creator.certifiedAt && (
+                            <div
+                                className="px-3 py-1 rounded-full flex items-center gap-1.5"
+                                style={{ background: "var(--ed-accent-bg)" }}
+                            >
+                                <BadgeCheck className="w-3.5 h-3.5" style={{ color: "var(--ed-accent)" }} />
+                                <span
+                                    style={{
+                                        fontFamily: "var(--ed-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.14em",
+                                        textTransform: "uppercase",
+                                        color: "var(--ed-accent-ink)",
+                                    }}
+                                >
+                                    Certified Creator
+                                </span>
+                            </div>
+                        )}
+                    </div>
                 </div>
 
-                {/* Stats Strip */}
-                <div className="grid grid-cols-3 gap-3 mb-6">
-                    <div className="bg-white p-3 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <p className="text-lg font-bold text-zinc-900">{submissionCount}</p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Submissions</p>
-                    </div>
-                    <div className="bg-white p-3 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <p className="text-lg font-bold text-zinc-900">₱{formatCurrency(balance)}</p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Balance</p>
-                    </div>
-                    <div className="bg-white p-3 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <p className="text-lg font-bold text-zinc-900">₱{formatCurrency(totalEarned)}</p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Earned</p>
-                    </div>
+                {/* Stats Strip — serif numbers + mono labels */}
+                <div className="grid grid-cols-3 gap-3 mb-8">
+                    {[
+                        { value: submissionCount, label: "Submissions" },
+                        { value: `₱${formatCurrency(balance)}`, label: "Balance" },
+                        { value: `₱${formatCurrency(totalEarned)}`, label: "Earned" },
+                    ].map((s, i) => (
+                        <div
+                            key={i}
+                            className="p-4 text-center"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: "var(--ed-radius-md)",
+                            }}
+                        >
+                            <p
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    fontSize: 22,
+                                    lineHeight: 1.0,
+                                    fontVariantNumeric: "tabular-nums",
+                                    color: "var(--ed-ink)",
+                                }}
+                            >
+                                {s.value}
+                            </p>
+                            <p className="ed-label mt-1">{s.label}</p>
+                        </div>
+                    ))}
                 </div>
 
-                {/* Menu Sections */}
-                <div className="space-y-5">
+                {/* Menu Sections — paper cards with warm rule dividers */}
+                <div className="space-y-6">
                     {menuSections.map((section) => (
                         <div key={section.title}>
-                            <h2 className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider mb-2 px-1">
-                                {section.title}
-                            </h2>
-                            <div className="bg-white rounded-xl border border-zinc-100 shadow-sm overflow-hidden divide-y divide-zinc-100">
+                            <p className="ed-label mb-2 px-1">{section.title}</p>
+                            <div
+                                className="overflow-hidden"
+                                style={{
+                                    background: "var(--ed-paper-3)",
+                                    border: "1px solid var(--ed-rule)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                }}
+                            >
                                 {section.items.map((item: any, i: number) => {
                                     const Icon = item.icon
                                     const content = (
-                                        <div className="flex items-center justify-between px-4 py-3 hover:bg-zinc-50 transition-colors cursor-pointer">
+                                        <div
+                                            className="flex items-center justify-between px-4 py-3.5 transition-colors cursor-pointer"
+                                            style={{
+                                                borderTop: i === 0 ? "none" : "1px solid var(--ed-rule)",
+                                            }}
+                                        >
                                             <div className="flex items-center gap-3">
-                                                <Icon className={`w-5 h-5 ${item.iconColor || "text-zinc-400"}`} />
+                                                <Icon
+                                                    className={`w-5 h-5`}
+                                                    style={{
+                                                        color: item.iconColor ? undefined : "var(--ed-ink-3)",
+                                                    }}
+                                                />
                                                 <div>
-                                                    <span className="text-sm font-medium text-zinc-900 block">{item.label}</span>
+                                                    <span
+                                                        className="block"
+                                                        style={{
+                                                            fontFamily: "var(--ed-sans)",
+                                                            fontSize: 14,
+                                                            color: "var(--ed-ink)",
+                                                            fontWeight: 500,
+                                                        }}
+                                                    >
+                                                        {item.label}
+                                                    </span>
                                                     {item.sublabel && (
-                                                        <span className="text-[11px] text-zinc-400">{item.sublabel}</span>
+                                                        <span
+                                                            style={{
+                                                                fontFamily: "var(--ed-mono)",
+                                                                fontSize: 10,
+                                                                letterSpacing: "0.1em",
+                                                                color: "var(--ed-ink-3)",
+                                                            }}
+                                                        >
+                                                            {item.sublabel}
+                                                        </span>
                                                     )}
                                                 </div>
                                             </div>
-                                            <ChevronRight className="w-4 h-4 text-zinc-300" />
+                                            <ChevronRight className="w-4 h-4" style={{ color: "var(--ed-ink-3)" }} />
                                         </div>
                                     )
 
@@ -337,17 +460,38 @@ export default function ProfilePage() {
                 </div>
 
                 {/* Sign Out */}
-                <div className="mt-6">
+                <div className="mt-8">
                     <SignOutButton redirectUrl="/login">
-                        <button className="w-full flex items-center justify-center gap-2 h-12 rounded-xl border border-red-200 bg-white text-red-500 hover:bg-red-50 font-semibold transition-colors">
+                        <button
+                            className="w-full flex items-center justify-center gap-2 h-12 transition-colors"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-danger)",
+                                borderRadius: "var(--ed-radius-md)",
+                                color: "var(--ed-danger)",
+                                fontFamily: "var(--ed-sans)",
+                                fontWeight: 500,
+                                fontSize: 15,
+                            }}
+                        >
                             <LogOut className="w-5 h-5" />
                             Sign Out
                         </button>
                     </SignOutButton>
                 </div>
 
-                {/* Version */}
-                <p className="text-center text-[11px] text-zinc-300 mt-6">Negosyo Digital v1.0.0</p>
+                <p
+                    className="text-center mt-8"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        fontSize: 10,
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}
+                >
+                    Negosyo Digital · v1.0.0
+                </p>
             </main>
 
             {/* ==================== REFERRAL CODE MODAL ==================== */}

--- a/app/referrals/page.tsx
+++ b/app/referrals/page.tsx
@@ -55,16 +55,16 @@ export default function ReferralsPage() {
 
     if (!isLoaded || !isSignedIn || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
 
     if (!creator) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -111,107 +111,236 @@ export default function ReferralsPage() {
     }
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-24 overflow-x-hidden">
+        <div
+            className="editorial min-h-screen pb-24 overflow-x-hidden"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <main className="px-4 py-6">
                 {/* Back Button */}
                 <div className="flex items-center justify-between mb-2">
                     <Link
                         href="/dashboard"
-                        className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors"
+                        className="w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            color: "var(--ed-ink-2)",
+                        }}
                     >
                         <ArrowLeft className="w-5 h-5" />
                     </Link>
                 </div>
 
-                <div className="mb-6">
-                    <h1 className="text-2xl font-bold text-zinc-900 leading-tight">
-                        Referral <span className="text-emerald-500">Program</span>
+                {/* Editorial header */}
+                <div className="mb-6 mt-2">
+                    <p className="ed-label">§ Referral Program</p>
+                    <h1
+                        className="mt-2"
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 40,
+                            lineHeight: 1.05,
+                            letterSpacing: "-0.02em",
+                            color: "var(--ed-ink)",
+                        }}
+                    >
+                        Bring a creator, <em style={{ color: "var(--ed-accent)" }}>earn for years.</em>
                     </h1>
-                    <p className="text-zinc-500 text-sm mt-1">Invite creators and earn rewards.</p>
+                    <p
+                        className="mt-2"
+                        style={{
+                            fontFamily: "var(--ed-sans)",
+                            fontSize: 14,
+                            color: "var(--ed-ink-2)",
+                            lineHeight: 1.55,
+                            maxWidth: "48ch",
+                        }}
+                    >
+                        Share your code with a fellow creator. When their first submission lands, you both get paid.
+                    </p>
                 </div>
 
-                {/* Referral Code Card */}
-                <div className="bg-zinc-900 text-white rounded-3xl p-5 relative overflow-hidden shadow-xl shadow-zinc-900/20 mb-6">
-                    <div className="absolute top-0 right-0 w-64 h-64 bg-emerald-500/10 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none"></div>
+                {/* Referral Code Card — ink with mono code + copy door */}
+                <div
+                    className="rounded-3xl p-6 relative overflow-hidden mb-6"
+                    style={{
+                        background: "var(--ed-ink)",
+                        color: "var(--ed-paper-3)",
+                        boxShadow: "var(--ed-shadow-md)",
+                    }}
+                >
+                    <div className="absolute top-0 right-0 w-64 h-64 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none" style={{ background: "rgba(16, 185, 129, 0.12)" }}></div>
 
                     <div className="relative z-10">
-                        <p className="text-zinc-400 text-xs font-medium mb-1">Your Referral Code</p>
-                        <div className="flex items-center gap-3 mt-2">
-                            <span className="text-2xl font-bold tracking-widest font-mono">
+                        <p
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: "rgba(252,250,245,0.55)",
+                            }}
+                        >
+                            Your Referral Code
+                        </p>
+                        <div className="flex items-center gap-3 mt-3 flex-wrap">
+                            <span
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    fontSize: 40,
+                                    lineHeight: 1.0,
+                                    letterSpacing: "0.1em",
+                                }}
+                            >
                                 {creator.referralCode}
                             </span>
                             <button
                                 onClick={handleCopy}
-                                className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 rounded-lg text-xs font-semibold transition-colors"
+                                className="flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors"
+                                style={{
+                                    background: "rgba(255,255,255,0.06)",
+                                    fontFamily: "var(--ed-mono)",
+                                    fontSize: 10,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                }}
                             >
                                 {copied ? (
                                     <>
-                                        <Check className="w-3.5 h-3.5 text-emerald-400" />
-                                        <span className="text-emerald-400">Copied!</span>
+                                        <Check className="w-3.5 h-3.5" style={{ color: "var(--ed-accent-solid)" }} />
+                                        <span style={{ color: "var(--ed-accent-solid)" }}>Copied!</span>
                                     </>
                                 ) : (
                                     <>
-                                        <Copy className="w-3.5 h-3.5 text-zinc-400" />
-                                        <span className="text-zinc-400">Copy</span>
+                                        <Copy className="w-3.5 h-3.5" style={{ color: "rgba(252,250,245,0.6)" }} />
+                                        <span style={{ color: "rgba(252,250,245,0.6)" }}>Copy</span>
                                     </>
                                 )}
                             </button>
                         </div>
-                        <p className="text-zinc-500 text-[10px] mt-3">
-                            Share this code with other creators to earn referral bonuses.
+                        <p
+                            className="mt-4"
+                            style={{
+                                fontFamily: "var(--ed-sans)",
+                                fontSize: 12,
+                                color: "rgba(252,250,245,0.55)",
+                                lineHeight: 1.5,
+                            }}
+                        >
+                            Share this with other creators. When they sign up + land their first paid submission, ₱1,000 lands in your wallet.
                         </p>
                     </div>
                 </div>
 
-                {/* Stats Row */}
+                {/* Stats Row — paper-3 cards with mono labels + serif numbers */}
                 <div className="grid grid-cols-3 gap-3 mb-6">
-                    <div className="bg-white p-4 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <div className="w-8 h-8 bg-zinc-100 rounded-lg flex items-center justify-center mx-auto mb-2">
-                            <Users className="w-4 h-4 text-zinc-600" />
+                    {[
+                        { Icon: Users, value: stats?.total ?? 0, label: "Referred", tone: "ink" as const },
+                        { Icon: CheckCircle, value: stats?.qualified ?? 0, label: "Qualified", tone: "accent" as const },
+                        { Icon: Gift, value: `₱${(stats?.totalEarned ?? 0).toLocaleString()}`, label: "Rewards", tone: "warn" as const },
+                    ].map((s, i) => (
+                        <div
+                            key={i}
+                            className="p-4 text-center"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: "var(--ed-radius-md)",
+                            }}
+                        >
+                            <div
+                                className="w-8 h-8 rounded-lg flex items-center justify-center mx-auto mb-2"
+                                style={{
+                                    background:
+                                        s.tone === "accent" ? "var(--ed-accent-bg)" :
+                                        s.tone === "warn" ? "var(--ed-warn-bg)" :
+                                        "var(--ed-paper-2)",
+                                }}
+                            >
+                                <s.Icon
+                                    className="w-4 h-4"
+                                    style={{
+                                        color:
+                                            s.tone === "accent" ? "var(--ed-accent)" :
+                                            s.tone === "warn" ? "var(--ed-warn)" :
+                                            "var(--ed-ink-2)",
+                                    }}
+                                />
+                            </div>
+                            <p
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    fontSize: 22,
+                                    lineHeight: 1.0,
+                                    fontVariantNumeric: "tabular-nums",
+                                    color: "var(--ed-ink)",
+                                }}
+                            >
+                                {s.value}
+                            </p>
+                            <p className="ed-label mt-1">{s.label}</p>
                         </div>
-                        <p className="text-lg font-bold text-zinc-900">{stats?.total || 0}</p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Referred</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <div className="w-8 h-8 bg-emerald-50 rounded-lg flex items-center justify-center mx-auto mb-2">
-                            <CheckCircle className="w-4 h-4 text-emerald-600" />
-                        </div>
-                        <p className="text-lg font-bold text-zinc-900">{stats?.qualified || 0}</p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Qualified</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-xl shadow-sm border border-zinc-100 text-center">
-                        <div className="w-8 h-8 bg-yellow-50 rounded-lg flex items-center justify-center mx-auto mb-2">
-                            <Gift className="w-4 h-4 text-yellow-600" />
-                        </div>
-                        <p className="text-lg font-bold text-zinc-900">
-                            PHP {(stats?.totalEarned || 0).toLocaleString()}
-                        </p>
-                        <p className="text-[10px] text-zinc-500 font-medium uppercase tracking-wider">Rewards</p>
-                    </div>
+                    ))}
                 </div>
 
                 {/* Referred Creators */}
                 <div className="mb-6">
-                    <h2 className="text-base font-bold text-zinc-900 mb-3">Referred Creators</h2>
+                    <p className="ed-label">§ Your tree</p>
+                    <h2
+                        className="mt-1 mb-3"
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 22,
+                            lineHeight: 1.15,
+                            letterSpacing: "-0.015em",
+                            color: "var(--ed-ink)",
+                        }}
+                    >
+                        Referred <em style={{ color: "var(--ed-accent)" }}>creators</em>
+                    </h2>
                     <div className="space-y-3">
                         {referrals && referrals.length > 0 ? (
                             referrals.map((referral: any) => (
                                 <div
                                     key={referral._id}
-                                    className="bg-white rounded-xl p-3 border border-zinc-100 shadow-sm flex items-center justify-between"
+                                    className="p-3 flex items-center justify-between"
+                                    style={{
+                                        background: "var(--ed-paper-3)",
+                                        border: "1px solid var(--ed-rule)",
+                                        borderRadius: "var(--ed-radius-md)",
+                                    }}
                                 >
                                     <div className="flex items-center gap-3">
-                                        <div className="w-10 h-10 rounded-xl bg-zinc-100 flex items-center justify-center shrink-0">
-                                            <UserPlus className="w-5 h-5 text-zinc-500" />
+                                        <div
+                                            className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                                            style={{ background: "var(--ed-paper-2)" }}
+                                        >
+                                            <UserPlus className="w-5 h-5" style={{ color: "var(--ed-ink-2)" }} />
                                         </div>
                                         <div>
-                                            <h3 className="font-bold text-sm text-zinc-900">
+                                            <h3
+                                                style={{
+                                                    fontFamily: "var(--ed-serif)",
+                                                    fontSize: 16,
+                                                    lineHeight: 1.2,
+                                                    color: "var(--ed-ink)",
+                                                }}
+                                            >
                                                 {referral.referredName}
                                             </h3>
-                                            <p className="text-[10px] text-zinc-500">
+                                            <p
+                                                className="mt-0.5"
+                                                style={{
+                                                    fontFamily: "var(--ed-mono)",
+                                                    fontSize: 10,
+                                                    letterSpacing: "0.1em",
+                                                    textTransform: "uppercase",
+                                                    color: "var(--ed-ink-3)",
+                                                }}
+                                            >
                                                 Joined {formatDate(referral.createdAt)}
                                                 {referral.bonusAmount
-                                                    ? ` · PHP ${referral.bonusAmount.toLocaleString()} bonus`
+                                                    ? ` · ₱${referral.bonusAmount.toLocaleString()} bonus`
                                                     : ""}
                                             </p>
                                         </div>
@@ -220,8 +349,36 @@ export default function ReferralsPage() {
                                 </div>
                             ))
                         ) : (
-                            <div className="text-center py-6 bg-zinc-50 rounded-xl border border-dashed border-zinc-200">
-                                <p className="text-zinc-500 text-xs">No referrals yet. Share your code to get started!</p>
+                            <div
+                                className="text-center py-8"
+                                style={{
+                                    background: "var(--ed-paper-2)",
+                                    border: "1px dashed var(--ed-rule-strong)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                }}
+                            >
+                                <p
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        fontSize: 16,
+                                        fontStyle: "italic",
+                                        color: "var(--ed-ink-2)",
+                                    }}
+                                >
+                                    No referrals yet.
+                                </p>
+                                <p
+                                    className="mt-1"
+                                    style={{
+                                        fontFamily: "var(--ed-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.14em",
+                                        textTransform: "uppercase",
+                                        color: "var(--ed-ink-3)",
+                                    }}
+                                >
+                                    Share your code to get started
+                                </p>
                             </div>
                         )}
                     </div>
@@ -229,41 +386,70 @@ export default function ReferralsPage() {
 
                 {/* How it Works */}
                 <div>
-                    <h2 className="text-base font-bold text-zinc-900 mb-3">How it Works</h2>
+                    <p className="ed-label">§ How it works</p>
+                    <h2
+                        className="mt-1 mb-4"
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 22,
+                            lineHeight: 1.15,
+                            letterSpacing: "-0.015em",
+                            color: "var(--ed-ink)",
+                        }}
+                    >
+                        Three <em style={{ color: "var(--ed-accent)" }}>steps</em>.
+                    </h2>
                     <div className="space-y-4">
-                        <div className="flex gap-3">
-                            <div className="w-8 h-8 rounded-full bg-emerald-500 flex items-center justify-center shrink-0 text-white text-xs font-bold">
-                                1
+                        {[
+                            { n: "01", title: "Share your code", body: "Give your code to fellow creators who want to join Negosyo Digital." },
+                            { n: "02", title: "They sign up & submit", body: "Your referral signs up using your code and submits their first business." },
+                            { n: "03", title: "Earn your bonus", body: "Once their first submission is paid, ₱1,000 lands in your wallet." },
+                        ].map((step) => (
+                            <div
+                                key={step.n}
+                                className="flex gap-4 p-4"
+                                style={{
+                                    background: "var(--ed-paper-3)",
+                                    border: "1px solid var(--ed-rule)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                }}
+                            >
+                                <span
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        fontSize: 28,
+                                        lineHeight: 1.0,
+                                        color: "var(--ed-accent)",
+                                        flexShrink: 0,
+                                    }}
+                                >
+                                    {step.n}
+                                </span>
+                                <div>
+                                    <h3
+                                        style={{
+                                            fontFamily: "var(--ed-serif)",
+                                            fontSize: 17,
+                                            lineHeight: 1.2,
+                                            color: "var(--ed-ink)",
+                                        }}
+                                    >
+                                        {step.title}
+                                    </h3>
+                                    <p
+                                        className="mt-1"
+                                        style={{
+                                            fontFamily: "var(--ed-sans)",
+                                            fontSize: 13,
+                                            color: "var(--ed-ink-2)",
+                                            lineHeight: 1.55,
+                                        }}
+                                    >
+                                        {step.body}
+                                    </p>
+                                </div>
                             </div>
-                            <div>
-                                <h3 className="font-bold text-sm text-zinc-900">Share Your Code</h3>
-                                <p className="text-xs text-zinc-500 mt-0.5">
-                                    Give your referral code to fellow creators who want to join Negosyo Digital.
-                                </p>
-                            </div>
-                        </div>
-                        <div className="flex gap-3">
-                            <div className="w-8 h-8 rounded-full bg-emerald-500 flex items-center justify-center shrink-0 text-white text-xs font-bold">
-                                2
-                            </div>
-                            <div>
-                                <h3 className="font-bold text-sm text-zinc-900">They Sign Up & Submit</h3>
-                                <p className="text-xs text-zinc-500 mt-0.5">
-                                    Your referral signs up using your code and submits their first business.
-                                </p>
-                            </div>
-                        </div>
-                        <div className="flex gap-3">
-                            <div className="w-8 h-8 rounded-full bg-emerald-500 flex items-center justify-center shrink-0 text-white text-xs font-bold">
-                                3
-                            </div>
-                            <div>
-                                <h3 className="font-bold text-sm text-zinc-900">Earn Your Bonus</h3>
-                                <p className="text-xs text-zinc-500 mt-0.5">
-                                    Once their first submission is approved, you receive a referral bonus in your wallet.
-                                </p>
-                            </div>
-                        </div>
+                        ))}
                     </div>
                 </div>
             </main>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -88,8 +88,9 @@ export default function SignupPage() {
                                     card: "bg-transparent shadow-none p-0",
                                     headerTitle: "hidden",
                                     headerSubtitle: "hidden",
+                                    socialButtons: "w-full",
                                     socialButtonsBlockButton:
-                                        "border border-[#0f0e14]/15 bg-[#f4ede1] text-[#0f0e14] hover:bg-[#ebe2cf] hover:border-[#2d5a3f]/50 transition-colors rounded-xl",
+                                        "w-full border border-[#0f0e14]/15 bg-[#f4ede1] text-[#0f0e14] hover:bg-[#ebe2cf] hover:border-[#2d5a3f]/50 transition-colors rounded-xl",
                                     // Hide TikTok specifically — keep Google + others
                                     socialButtonsBlockButton__tiktok: "!hidden",
                                     socialButtonsProviderIcon__tiktok: "!hidden",

--- a/app/submissions/page.tsx
+++ b/app/submissions/page.tsx
@@ -30,8 +30,8 @@ export default function SubmissionsPage() {
 
     if (!isLoaded || !isSignedIn || creator === undefined || submissions === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gray-50">
-                <Loader2 className="w-8 h-8 animate-spin text-emerald-500" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="w-8 h-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -90,7 +90,10 @@ export default function SubmissionsPage() {
     }
 
     return (
-        <div className="min-h-screen bg-gray-50 font-sans pb-24 relative">
+        <div
+            className="editorial min-h-screen pb-24 relative"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <main className="px-4 py-6">
                 <div className="flex items-center justify-between mb-2">
                     <Link href="/dashboard" className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-gray-200 text-zinc-600 hover:text-zinc-900 transition-colors">

--- a/app/submit/info/page.tsx
+++ b/app/submit/info/page.tsx
@@ -133,8 +133,8 @@ export default function BusinessInfoPage() {
     // Loading state
     if (!isLoaded || !isSignedIn || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gray-50">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -143,14 +143,17 @@ export default function BusinessInfoPage() {
     if (!creator) {
         router.push("/onboarding")
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gray-50">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
 
     return (
-        <div className="min-h-screen bg-gray-50 flex flex-col">
+        <div
+            className="editorial min-h-screen flex flex-col"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             {/* Header */}
             <div className="p-4 flex items-center justify-between">
                 <button

--- a/app/submit/interview/page.tsx
+++ b/app/submit/interview/page.tsx
@@ -521,7 +521,14 @@ export default function InterviewUploadPage() {
     const hasRecordedPreview = recordedPreviewUrl !== null
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+        <div
+            className="editorial min-h-screen"
+            style={{
+                background: "linear-gradient(to bottom right, var(--ed-paper), var(--ed-paper-2))",
+                color: "var(--ed-ink)",
+                fontFamily: "var(--ed-sans)",
+            }}
+        >
             {/* Header */}
             <div className="bg-white/80 backdrop-blur-md border-b border-gray-200/50 px-4 py-3 sticky top-0 z-50">
                 <div className="flex items-center max-w-2xl mx-auto">

--- a/app/submit/photos/page.tsx
+++ b/app/submit/photos/page.tsx
@@ -237,8 +237,8 @@ export default function UploadPhotosPage() {
     // Loading state
     if (!isLoaded || !isSignedIn || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gray-50">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -246,7 +246,10 @@ export default function UploadPhotosPage() {
     const totalCount = files.length + existingPhotos.length
 
     return (
-        <div className="min-h-screen bg-gray-50 flex flex-col">
+        <div
+            className="editorial min-h-screen flex flex-col"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             {/* Header */}
             <div className="p-4 flex items-center justify-between">
                 <button

--- a/app/submit/review/page.tsx
+++ b/app/submit/review/page.tsx
@@ -179,8 +179,8 @@ export default function ReviewSubmissionPage() {
     // Loading state
     if (!isLoaded || !isSignedIn || creator === undefined || submission === undefined) {
         return (
-            <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -194,7 +194,10 @@ export default function ReviewSubmissionPage() {
     const payout = hasVideo ? 500 : (hasAudio ? 300 : 0)
 
     return (
-        <div className="min-h-screen bg-gray-50 flex flex-col">
+        <div
+            className="editorial min-h-screen flex flex-col"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             {/* Header */}
             <div className="p-4 flex items-center justify-between">
                 <button

--- a/app/submit/success/page.tsx
+++ b/app/submit/success/page.tsx
@@ -111,14 +111,17 @@ export default function SubmissionSuccessPage() {
     // Loading state - wait for submission to load too
     if (!isLoaded || !isSignedIn || creator === undefined || (submissionId && submission === undefined)) {
         return (
-            <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
 
     return (
-        <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6">
+        <div
+            className="editorial min-h-screen flex flex-col items-center justify-center p-6"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <div className="max-w-md w-full text-center space-y-8">
                 {/* Success Animation/Icon */}
                 <div className="relative">

--- a/app/training-lessons/page.tsx
+++ b/app/training-lessons/page.tsx
@@ -69,7 +69,10 @@ export default function TrainingLessonsPage() {
     const [openIndex, setOpenIndex] = useState(0)
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-12">
+        <div
+            className="editorial min-h-screen pb-12"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <header className="px-4 pt-6 pb-4">
                 <div className="flex items-center gap-3 mb-4">
                     <Link href="/training" className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors">

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -39,14 +39,17 @@ export default function TrainingPage() {
 
     if (!isLoaded || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-12">
+        <div
+            className="editorial min-h-screen pb-12"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <header className="px-4 pt-6 pb-2">
                 <Link href="/dashboard" className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors">
                     <ArrowLeft className="w-5 h-5" />

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -85,16 +85,16 @@ export default function WalletPage() {
 
     if (!isLoaded || !isSignedIn || creator === undefined) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
 
     if (!creator) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-white">
-                <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
             </div>
         )
     }
@@ -217,72 +217,158 @@ export default function WalletPage() {
     }
 
     return (
-        <div className="min-h-screen bg-white font-sans pb-24 overflow-x-hidden">
+        <div
+            className="editorial min-h-screen pb-24 overflow-x-hidden"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
             <main className="px-4 py-6">
                 {/* Back Button */}
                 <div className="flex items-center justify-between mb-2">
                     <Link
                         href="/dashboard"
-                        className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm border border-zinc-200 text-zinc-600 hover:text-zinc-900 transition-colors"
+                        className="w-10 h-10 rounded-full flex items-center justify-center transition-colors"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            color: "var(--ed-ink-2)",
+                        }}
                     >
                         <ArrowLeft className="w-5 h-5" />
                     </Link>
                 </div>
 
-                <div className="mb-6">
-                    <h1 className="text-2xl font-bold text-zinc-900 leading-tight">
-                        My <span className="text-emerald-500">Wallet</span>
+                {/* Editorial header */}
+                <div className="mb-6 mt-2">
+                    <p className="ed-label">§ Wallet · Withdrawals</p>
+                    <h1
+                        className="mt-2"
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 40,
+                            lineHeight: 1.05,
+                            letterSpacing: "-0.02em",
+                            color: "var(--ed-ink)",
+                        }}
+                    >
+                        Your <em style={{ color: "var(--ed-accent)" }}>earnings.</em>
                     </h1>
-                    <p className="text-zinc-500 text-sm mt-1">Manage your earnings and withdrawals.</p>
+                    <p
+                        className="mt-2"
+                        style={{
+                            fontFamily: "var(--ed-sans)",
+                            fontSize: 14,
+                            color: "var(--ed-ink-2)",
+                            lineHeight: 1.55,
+                            maxWidth: "44ch",
+                        }}
+                    >
+                        Track what you&apos;ve made, request a payout to Wise, see every transaction.
+                    </p>
                 </div>
 
-                {/* Balance Card */}
-                <div className="bg-zinc-900 text-white rounded-3xl p-5 relative overflow-hidden shadow-xl shadow-zinc-900/20 mb-6">
-                    <div className="absolute top-0 right-0 w-64 h-64 bg-emerald-500/10 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none"></div>
+                {/* Balance hero — ink with serif amount */}
+                <div
+                    className="rounded-3xl p-6 relative overflow-hidden mb-6"
+                    style={{
+                        background: "var(--ed-ink)",
+                        color: "var(--ed-paper-3)",
+                        boxShadow: "var(--ed-shadow-md)",
+                    }}
+                >
+                    <div className="absolute top-0 right-0 w-64 h-64 rounded-full blur-3xl -mr-16 -mt-16 pointer-events-none" style={{ background: "rgba(16, 185, 129, 0.12)" }}></div>
 
                     <div className="flex justify-between items-start mb-2 relative z-10">
-                        <span className="text-zinc-400 text-xs font-medium">Available Balance</span>
-                        <div className="w-7 h-7 rounded-full bg-zinc-800 flex items-center justify-center text-emerald-400">
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: "rgba(252,250,245,0.55)",
+                            }}
+                        >
+                            Available Balance
+                        </span>
+                        <div
+                            className="w-7 h-7 rounded-full flex items-center justify-center"
+                            style={{ background: "rgba(255,255,255,0.08)", color: "var(--ed-accent-solid)" }}
+                        >
                             <Wallet className="w-3.5 h-3.5" />
                         </div>
                     </div>
 
-                    <div className="mb-5 relative z-10">
-                        <span className="text-3xl font-bold tracking-tight">
-                            PHP {formatCurrency(balance)}
+                    <div className="mb-5 relative z-10 flex items-baseline gap-2">
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 20,
+                                color: "rgba(252,250,245,0.55)",
+                            }}
+                        >
+                            ₱
+                        </span>
+                        <span
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 56,
+                                lineHeight: 1.0,
+                                letterSpacing: "-0.025em",
+                                fontVariantNumeric: "tabular-nums",
+                            }}
+                        >
+                            {formatCurrency(balance)}
                         </span>
                     </div>
 
-                    <div className="flex gap-4 relative z-10">
-                        <div className="flex items-center gap-1.5">
-                            <TrendingUp className="w-3.5 h-3.5 text-emerald-400" />
+                    <div
+                        className="flex gap-6 relative z-10 pt-4"
+                        style={{ borderTop: "1px solid rgba(255,255,255,0.08)" }}
+                    >
+                        <div className="flex items-center gap-2">
+                            <TrendingUp className="w-3.5 h-3.5" style={{ color: "var(--ed-accent-solid)" }} />
                             <div>
-                                <p className="text-[10px] text-zinc-500">Total Earned</p>
-                                <p className="text-xs font-semibold">PHP {formatCurrency(totalEarned)}</p>
+                                <p style={{ fontFamily: "var(--ed-mono)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "rgba(252,250,245,0.55)" }}>
+                                    Earned
+                                </p>
+                                <p style={{ fontFamily: "var(--ed-serif)", fontSize: 16, fontVariantNumeric: "tabular-nums" }}>
+                                    ₱{formatCurrency(totalEarned)}
+                                </p>
                             </div>
                         </div>
-                        <div className="flex items-center gap-1.5">
-                            <TrendingDown className="w-3.5 h-3.5 text-orange-400" />
+                        <div className="flex items-center gap-2">
+                            <TrendingDown className="w-3.5 h-3.5" style={{ color: "#f4a261" }} />
                             <div>
-                                <p className="text-[10px] text-zinc-500">Withdrawn</p>
-                                <p className="text-xs font-semibold">PHP {formatCurrency(totalWithdrawn)}</p>
+                                <p style={{ fontFamily: "var(--ed-mono)", fontSize: 9, letterSpacing: "0.14em", textTransform: "uppercase", color: "rgba(252,250,245,0.55)" }}>
+                                    Withdrawn
+                                </p>
+                                <p style={{ fontFamily: "var(--ed-serif)", fontSize: 16, fontVariantNumeric: "tabular-nums" }}>
+                                    ₱{formatCurrency(totalWithdrawn)}
+                                </p>
                             </div>
                         </div>
                     </div>
                 </div>
 
-                {/* Withdraw Button */}
+                {/* Withdraw door — accent variant */}
                 <Button
                     onClick={handleStartWithdraw}
                     disabled={balance <= 0}
-                    className="w-full bg-emerald-500 hover:bg-emerald-600 text-white font-bold rounded-xl h-12 mb-2 shadow-lg shadow-emerald-500/20"
+                    className="ed-door ed-door-accent w-full mb-2"
+                    style={{ minHeight: 52, justifyContent: "center", fontSize: 15 }}
                 >
                     <ArrowDownRight className="w-5 h-5 mr-2" />
                     Withdraw Funds
                 </Button>
-                <p className="text-[11px] text-zinc-500 text-center mb-6">
+                <p
+                    className="text-center mb-6"
+                    style={{
+                        fontFamily: "var(--ed-sans)",
+                        fontSize: 11,
+                        color: "var(--ed-ink-3)",
+                    }}
+                >
                     Paid via Wise to{" "}
-                    <span className="font-semibold text-zinc-700">
+                    <span style={{ fontWeight: 600, color: "var(--ed-ink-2)" }}>
                         {creator.wiseEmail || "your Wise email"}
                     </span>
                     . You receive the full amount — Wise transfer fees are on us.
@@ -290,38 +376,99 @@ export default function WalletPage() {
 
                 {/* Recent Earnings */}
                 <div className="mb-6">
-                    <h2 className="text-base font-bold text-zinc-900 mb-3">Recent Earnings</h2>
+                    <p className="ed-label">§ History</p>
+                    <h2
+                        className="mt-1 mb-3"
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 22,
+                            lineHeight: 1.15,
+                            letterSpacing: "-0.015em",
+                            color: "var(--ed-ink)",
+                        }}
+                    >
+                        Recent <em style={{ color: "var(--ed-accent)" }}>earnings</em>
+                    </h2>
                     <div className="space-y-3">
                         {earnings && earnings.length > 0 ? (
                             earnings.slice(0, 10).map((earning: any) => (
                                 <div
                                     key={earning._id}
-                                    className="bg-white rounded-xl p-3 border border-zinc-100 shadow-sm flex items-center justify-between"
+                                    className="p-3 flex items-center justify-between"
+                                    style={{
+                                        background: "var(--ed-paper-3)",
+                                        border: "1px solid var(--ed-rule)",
+                                        borderRadius: "var(--ed-radius-md)",
+                                    }}
                                 >
                                     <div className="flex items-center gap-3">
-                                        <div className="w-10 h-10 rounded-xl bg-emerald-50 flex items-center justify-center shrink-0">
-                                            <TrendingUp className="w-5 h-5 text-emerald-500" />
+                                        <div
+                                            className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                                            style={{ background: "var(--ed-accent-bg)" }}
+                                        >
+                                            <TrendingUp className="w-5 h-5" style={{ color: "var(--ed-accent)" }} />
                                         </div>
                                         <div>
-                                            <h3 className="font-bold text-sm text-zinc-900">{earning.businessName}</h3>
-                                            <p className="text-[10px] text-zinc-500">
+                                            <h3
+                                                style={{
+                                                    fontFamily: "var(--ed-serif)",
+                                                    fontSize: 16,
+                                                    lineHeight: 1.2,
+                                                    color: "var(--ed-ink)",
+                                                }}
+                                            >
+                                                {earning.businessName}
+                                            </h3>
+                                            <p
+                                                className="mt-0.5"
+                                                style={{
+                                                    fontFamily: "var(--ed-mono)",
+                                                    fontSize: 10,
+                                                    letterSpacing: "0.1em",
+                                                    textTransform: "uppercase",
+                                                    color: "var(--ed-ink-3)",
+                                                }}
+                                            >
                                                 {earning.type === "submission_approved"
                                                     ? "Submission"
                                                     : earning.type === "referral_bonus"
-                                                      ? "Referral Bonus"
-                                                      : "Lead Bonus"}{" "}
+                                                      ? "Referral"
+                                                      : "Lead"}{" "}
                                                 · {formatDate(earning.createdAt)}
                                             </p>
                                         </div>
                                     </div>
-                                    <span className="text-sm font-bold text-emerald-600">
-                                        +PHP {formatCurrency(earning.amount)}
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--ed-serif)",
+                                            fontSize: 18,
+                                            fontVariantNumeric: "tabular-nums",
+                                            color: "var(--ed-accent)",
+                                        }}
+                                    >
+                                        +₱{formatCurrency(earning.amount)}
                                     </span>
                                 </div>
                             ))
                         ) : (
-                            <div className="text-center py-6 bg-zinc-50 rounded-xl border border-dashed border-zinc-200">
-                                <p className="text-zinc-500 text-xs">No earnings yet.</p>
+                            <div
+                                className="text-center py-8"
+                                style={{
+                                    background: "var(--ed-paper-2)",
+                                    border: "1px dashed var(--ed-rule-strong)",
+                                    borderRadius: "var(--ed-radius-md)",
+                                }}
+                            >
+                                <p
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        fontSize: 16,
+                                        fontStyle: "italic",
+                                        color: "var(--ed-ink-2)",
+                                    }}
+                                >
+                                    No earnings yet.
+                                </p>
                             </div>
                         )}
                     </div>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as lib_cloudflare from "../lib/cloudflare.js";
 import type * as lib_fxRate from "../lib/fxRate.js";
 import type * as lib_hostinger from "../lib/hostinger.js";
 import type * as lib_mediaChunker from "../lib/mediaChunker.js";
+import type * as lib_phone from "../lib/phone.js";
 import type * as lib_wise from "../lib/wise.js";
 import type * as migrations_migrateContent from "../migrations/migrateContent.js";
 import type * as notifications from "../notifications.js";
@@ -68,6 +69,7 @@ declare const fullApi: ApiFromModules<{
   "lib/fxRate": typeof lib_fxRate;
   "lib/hostinger": typeof lib_hostinger;
   "lib/mediaChunker": typeof lib_mediaChunker;
+  "lib/phone": typeof lib_phone;
   "lib/wise": typeof lib_wise;
   "migrations/migrateContent": typeof migrations_migrateContent;
   notifications: typeof notifications;

--- a/convex/creators.ts
+++ b/convex/creators.ts
@@ -381,3 +381,106 @@ export const updateLastActive = mutation({
         }
     },
 });
+
+// ============================================================================
+// CREATOR VERIFICATION FLOW (admin-gated)
+//
+// Flow:
+//   1. Creator passes onboarding quiz → markQuizPassed sets quizPassedAt
+//   2. Mobile routes the creator to /pending-review (locked screen)
+//   3. Admin reviews on web admin panel and clicks "Approve"
+//   4. approveCreator sets certifiedAt → mobile gate releases automatically
+// ============================================================================
+
+/**
+ * Mobile-called when a creator finishes the onboarding quiz.
+ * Self-only — the calling Clerk identity must own the creator record.
+ * Idempotent: returns silently if already quiz-passed or already certified.
+ */
+export const markQuizPassed = mutation({
+    args: { id: v.id('creators') },
+    handler: async (ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+        const creator = await ctx.db.get(args.id);
+        if (!creator || creator.clerkId !== identity.subject) {
+            throw new Error('Forbidden: you can only update your own account');
+        }
+        if (creator.certifiedAt) return;
+        if (creator.quizPassedAt) return;
+        await ctx.db.patch(args.id, {
+            quizPassedAt: Date.now(),
+            lastActiveAt: Date.now(),
+        });
+    },
+});
+
+/**
+ * Admin-only: approve a creator that has passed the quiz.
+ * Sets certifiedAt and schedules a "certification" notification.
+ * Idempotent: returns silently if the creator is already certified.
+ */
+export const approveCreator = mutation({
+    args: { id: v.id('creators') },
+    handler: async (ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+        const me = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+
+        const creator = await ctx.db.get(args.id);
+        if (!creator) throw new Error('Creator not found');
+        if (creator.certifiedAt) return;
+
+        await ctx.db.patch(args.id, {
+            certifiedAt: Date.now(),
+            lastActiveAt: Date.now(),
+        });
+        await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+            creatorId: args.id,
+            type: 'certification' as const,
+            title: "You're approved!",
+            body: 'Welcome aboard. You can now submit businesses and earn from your interviews.',
+            data: { approvedByAdmin: true },
+        });
+    },
+});
+
+/**
+ * Admin-only: list creators awaiting approval (quiz passed, not yet certified).
+ * Sorted newest-pending-first so admins see the longest-waiting creators on top.
+ */
+export const listPendingApproval = query({
+    args: {},
+    handler: async (ctx) => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+        const me = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+
+        const all = await ctx.db.query('creators').collect();
+        return all
+            .filter((c) => c.quizPassedAt && !c.certifiedAt && !c.isDeleted)
+            .map((c) => ({
+                _id: c._id,
+                clerkId: c.clerkId,
+                email: c.email,
+                firstName: c.firstName ?? null,
+                middleName: c.middleName ?? null,
+                lastName: c.lastName ?? null,
+                phone: c.phone ?? null,
+                profileImage: c.profileImage ?? null,
+                quizPassedAt: c.quizPassedAt!,
+                createdAt: c.createdAt ?? null,
+                referredByCode: c.referredByCode ?? null,
+                referredByName: c.referredByName ?? null,
+            }))
+            .sort((a, b) => b.quizPassedAt - a.quizPassedAt);
+    },
+});

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -1,6 +1,13 @@
 import { v } from 'convex/values';
-import { query, mutation } from './_generated/server';
+import { query, mutation, action, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { normalizePhone } from './lib/phone';
+
+// Admin-curated lead-content image upload constraints
+const PREVIEW_IMAGE_MAX_BYTES = 2_000_000; // 2MB cap
+const ALLOWED_PREVIEW_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 // ==================== MUTATIONS ====================
 
@@ -229,6 +236,504 @@ export const getCountBySubmission = query({
             qualified: leads.filter((l) => l.status === 'qualified').length,
             converted: leads.filter((l) => l.status === 'converted').length,
             lost: leads.filter((l) => l.status === 'lost').length,
+        };
+    },
+});
+
+// ============================================================================
+// Inline auth helpers — web repo doesn't have a shared `lib/auth.ts`, so we
+// inline the same pattern the spec assumes (`requireAuth` / `requireAdmin`).
+// Typed as `any` so the helper accepts both QueryCtx and MutationCtx — every
+// Convex generated type uses different TableNamesInDataModel generics, and
+// hand-writing a union is more friction than the type signal is worth here.
+// ============================================================================
+async function requireIdentity(ctx: any) {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error('Not authenticated');
+    return identity;
+}
+
+async function requireAdminIdentity(ctx: any) {
+    const identity = await requireIdentity(ctx);
+    const me = await ctx.db
+        .query('creators')
+        .withIndex('by_clerk_id', (q: any) => q.eq('clerkId', identity.subject))
+        .first();
+    if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+    return identity;
+}
+
+// ----------------------------------------------------------------------------
+// MOBILE CRM VIEW QUERIES (team-wide social feed)
+//
+// Per product spec: every signed-in creator sees ALL leads in the database
+// (not just their own) and the original submitter is prominently surfaced on
+// each card. Admin-curated content (description / image / link) appears when
+// present and triggers the social-card render on mobile.
+//
+// These queries do NOT modify any existing data or behavior. They are
+// consumed only by the mobile CRM screens at app/(app)/leads/*.
+// ----------------------------------------------------------------------------
+
+/**
+ * Pure-function helper for rendering creator display names consistently.
+ * Exported so unit tests can exercise it without spinning up Convex.
+ * Format: "Firstname L." (e.g., "Maria S."). If only first name, returns it as-is.
+ * If both missing, returns "Unknown creator".
+ */
+export function formatCreatorDisplayName(
+    firstName: string | undefined | null,
+    lastName: string | undefined | null,
+): string {
+    const first = (firstName ?? '').trim();
+    const last = (lastName ?? '').trim();
+    if (!first && !last) return 'Unknown creator';
+    if (!last) return first;
+    return `${first} ${last[0]}.`;
+}
+
+export const listForMobileCRM = query({
+    args: {
+        search: v.optional(v.string()),
+        statusFilter: v.optional(
+            v.union(
+                v.literal('all'),
+                v.literal('new'),
+                v.literal('contacted'),
+                v.literal('qualified'),
+                v.literal('converted'),
+                v.literal('lost'),
+            ),
+        ),
+        onlyMine: v.optional(v.boolean()),
+    },
+    handler: async (ctx, args) => {
+        const identity = await requireIdentity(ctx);
+
+        const currentCreator = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!currentCreator) {
+            return {
+                leads: [],
+                stats: { total: 0, new: 0, contacted: 0, qualified: 0, converted: 0, lost: 0, mine: 0 },
+            };
+        }
+
+        // Show ALL leads in the database so the CRM feed reflects team output.
+        const allLeads = await ctx.db.query('leads').order('desc').collect();
+
+        // Stat rollup over the unfiltered set so badge counts remain accurate.
+        const stats = {
+            total: allLeads.length,
+            new: allLeads.filter((l) => l.status === 'new').length,
+            contacted: allLeads.filter((l) => l.status === 'contacted').length,
+            qualified: allLeads.filter((l) => l.status === 'qualified').length,
+            converted: allLeads.filter((l) => l.status === 'converted').length,
+            lost: allLeads.filter((l) => l.status === 'lost').length,
+            mine: allLeads.filter((l) => String(l.creatorId) === String(currentCreator._id)).length,
+        };
+
+        let filtered = allLeads;
+        if (args.onlyMine) {
+            filtered = filtered.filter((l) => String(l.creatorId) === String(currentCreator._id));
+        }
+
+        const statusFilter = args.statusFilter ?? 'all';
+        if (statusFilter !== 'all') {
+            filtered = filtered.filter((l) => l.status === statusFilter);
+        }
+
+        const search = args.search?.trim().toLowerCase();
+
+        // Cache submissions/creators to avoid repeated DB hits when the same id
+        // appears across many leads.
+        const submissionCache = new Map<string, any>();
+        const creatorCache = new Map<string, any>();
+        const allSubmissions = await ctx.db.query('submissions').collect();
+        for (const sub of allSubmissions) submissionCache.set(String(sub._id), sub);
+
+        const enriched = await Promise.all(
+            filtered.map(async (lead) => {
+                const submission = lead.submissionId
+                    ? (submissionCache.get(String(lead.submissionId)) ?? null)
+                    : null;
+
+                let creatorRecord: any = null;
+                if (lead.creatorId) {
+                    creatorRecord = creatorCache.get(String(lead.creatorId));
+                    if (!creatorRecord) {
+                        creatorRecord = await ctx.db.get(lead.creatorId);
+                        if (creatorRecord) creatorCache.set(String(lead.creatorId), creatorRecord);
+                    }
+                }
+
+                // Count distinct creators who interviewed the same business by normalized phone.
+                let interviewerCount = 0;
+                if (submission) {
+                    const targetPhone = normalizePhone(submission.ownerPhone);
+                    if (targetPhone) {
+                        const matches = allSubmissions.filter(
+                            (s) => normalizePhone(s.ownerPhone) === targetPhone,
+                        );
+                        const creatorIds = new Set(matches.map((s) => String(s.creatorId)));
+                        interviewerCount = creatorIds.size;
+                    }
+                }
+
+                const isMine = lead.creatorId
+                    ? String(lead.creatorId) === String(currentCreator._id)
+                    : false;
+
+                return {
+                    _id: lead._id,
+                    _creationTime: lead._creationTime,
+                    name: lead.name,
+                    phone: lead.phone,
+                    email: lead.email ?? null,
+                    source: lead.source,
+                    status: lead.status,
+                    createdAt: lead.createdAt,
+                    businessName: submission?.businessName ?? '(business unavailable)',
+                    businessType: submission?.businessType ?? null,
+                    businessCity: submission?.city ?? null,
+                    businessAddress: submission?.address ?? null,
+                    ownerName: submission?.ownerName ?? null,
+                    ownerPhone: submission?.ownerPhone ?? null,
+                    interviewerCount,
+                    websiteUrl: (submission as any)?.websiteUrl ?? null,
+                    submissionStatus: submission?.status ?? null,
+                    isHot: interviewerCount >= 3,
+                    submittedBy: creatorRecord
+                        ? {
+                              creatorId: String(creatorRecord._id),
+                              displayName: formatCreatorDisplayName(
+                                  creatorRecord.firstName,
+                                  creatorRecord.lastName,
+                              ),
+                              profileImage: creatorRecord.profileImage ?? null,
+                          }
+                        : null,
+                    isMine,
+                    // Admin-curated content (mobile renders social card when present)
+                    adminDescription: (lead as any).adminDescription ?? null,
+                    previewImageUrl: (lead as any).previewImageUrl ?? null,
+                    externalPreviewUrl: (lead as any).externalPreviewUrl ?? null,
+                    hasEnrichedContent: !!(
+                        (lead as any).adminDescription ||
+                        (lead as any).previewImageUrl ||
+                        (lead as any).externalPreviewUrl
+                    ),
+                };
+            }),
+        );
+
+        let result = enriched;
+        if (search) {
+            result = enriched.filter(
+                (row) =>
+                    row.name.toLowerCase().includes(search) ||
+                    row.phone.toLowerCase().includes(search) ||
+                    (row.email?.toLowerCase().includes(search) ?? false) ||
+                    row.businessName.toLowerCase().includes(search) ||
+                    (row.submittedBy?.displayName.toLowerCase().includes(search) ?? false),
+            );
+        }
+
+        return { leads: result, stats };
+    },
+});
+
+export const getDetailForMobileCRM = query({
+    args: { id: v.id('leads') },
+    handler: async (ctx, args) => {
+        const identity = await requireIdentity(ctx);
+
+        const currentCreator = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!currentCreator) return null;
+
+        const lead = await ctx.db.get(args.id);
+        if (!lead) return null;
+
+        const submitterCreator = lead.creatorId ? await ctx.db.get(lead.creatorId) : null;
+        const submission = lead.submissionId ? await ctx.db.get(lead.submissionId) : null;
+
+        let interviewers: Array<{
+            creatorId: string;
+            creatorName: string;
+            creatorProfileImage: string | null;
+            interviewedAt: number;
+            submissionId: string;
+            submissionStatus: string;
+            isMine: boolean;
+        }> = [];
+
+        if (submission) {
+            const targetPhone = normalizePhone(submission.ownerPhone);
+            if (targetPhone) {
+                const allSubs = await ctx.db.query('submissions').collect();
+                const matches = allSubs.filter(
+                    (s) => normalizePhone(s.ownerPhone) === targetPhone,
+                );
+                interviewers = await Promise.all(
+                    matches.map(async (s) => {
+                        const interviewerCreator = await ctx.db.get(s.creatorId);
+                        return {
+                            creatorId: String(s.creatorId),
+                            creatorName: formatCreatorDisplayName(
+                                interviewerCreator?.firstName,
+                                interviewerCreator?.lastName,
+                            ),
+                            creatorProfileImage: interviewerCreator?.profileImage ?? null,
+                            interviewedAt: s._creationTime,
+                            submissionId: String(s._id),
+                            submissionStatus: s.status,
+                            isMine: String(s.creatorId) === String(currentCreator._id),
+                        };
+                    }),
+                );
+                interviewers.sort((a, b) => b.interviewedAt - a.interviewedAt);
+            }
+        }
+
+        const notes = await ctx.db
+            .query('leadNotes')
+            .withIndex('by_lead', (q) => q.eq('leadId', args.id))
+            .order('desc')
+            .collect();
+
+        return {
+            lead: {
+                _id: lead._id,
+                _creationTime: lead._creationTime,
+                name: lead.name,
+                phone: lead.phone,
+                email: lead.email ?? null,
+                source: lead.source,
+                status: lead.status,
+                createdAt: lead.createdAt,
+            },
+            submittedBy: submitterCreator
+                ? {
+                      creatorId: String(submitterCreator._id),
+                      displayName: formatCreatorDisplayName(
+                          submitterCreator.firstName,
+                          submitterCreator.lastName,
+                      ),
+                      profileImage: submitterCreator.profileImage ?? null,
+                  }
+                : null,
+            isMine: lead.creatorId
+                ? String(lead.creatorId) === String(currentCreator._id)
+                : false,
+            business: submission
+                ? {
+                      submissionId: String(submission._id),
+                      businessName: submission.businessName,
+                      businessType: submission.businessType,
+                      ownerName: submission.ownerName,
+                      ownerPhone: submission.ownerPhone,
+                      ownerEmail: submission.ownerEmail ?? null,
+                      address: submission.address,
+                      city: submission.city,
+                      province: (submission as any).province ?? null,
+                      barangay: (submission as any).barangay ?? null,
+                      websiteUrl: (submission as any).websiteUrl ?? null,
+                      businessDescription: (submission as any).businessDescription ?? null,
+                      photos: (submission as any).photos ?? [],
+                      status: submission.status,
+                  }
+                : null,
+            adminContent: {
+                description: (lead as any).adminDescription ?? null,
+                previewImageUrl: (lead as any).previewImageUrl ?? null,
+                externalPreviewUrl: (lead as any).externalPreviewUrl ?? null,
+                updatedAt: (lead as any).adminUpdatedAt ?? null,
+                hasEnrichedContent: !!(
+                    (lead as any).adminDescription ||
+                    (lead as any).previewImageUrl ||
+                    (lead as any).externalPreviewUrl
+                ),
+            },
+            interviewers,
+            interviewerCount: interviewers.length,
+            notes: notes.map((n) => ({
+                _id: n._id,
+                content: n.content,
+                createdAt: n.createdAt,
+                creatorId: String(n.creatorId),
+            })),
+        };
+    },
+});
+
+// ----------------------------------------------------------------------------
+// ADMIN-CURATED LEAD CONTENT (Facebook-style social card data + image upload)
+// ----------------------------------------------------------------------------
+
+export const updateAdminContent = mutation({
+    args: {
+        id: v.id('leads'),
+        description: v.optional(v.string()),
+        externalPreviewUrl: v.optional(v.string()),
+        previewImageUrl: v.optional(v.string()),
+        previewImageStorageKey: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const identity = await requireAdminIdentity(ctx);
+        const lead = await ctx.db.get(args.id);
+        if (!lead) throw new Error('Lead not found');
+
+        const patch: Record<string, unknown> = {
+            adminUpdatedAt: Date.now(),
+            adminUpdatedBy: identity.subject,
+        };
+
+        if (args.description !== undefined) {
+            const trimmed = args.description.trim();
+            if (trimmed.length > 500) {
+                throw new Error('Description too long (max 500 characters)');
+            }
+            patch.adminDescription = trimmed === '' ? undefined : trimmed;
+        }
+
+        if (args.externalPreviewUrl !== undefined) {
+            const trimmed = args.externalPreviewUrl.trim();
+            if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+                throw new Error('External preview URL must start with http:// or https://');
+            }
+            patch.externalPreviewUrl = trimmed === '' ? undefined : trimmed;
+        }
+
+        if (args.previewImageUrl !== undefined) {
+            patch.previewImageUrl = args.previewImageUrl === '' ? undefined : args.previewImageUrl;
+        }
+
+        if (args.previewImageStorageKey !== undefined) {
+            patch.previewImageStorageKey =
+                args.previewImageStorageKey === '' ? undefined : args.previewImageStorageKey;
+        }
+
+        await ctx.db.patch(args.id, patch);
+    },
+});
+
+// Pure helpers — exported so unit tests can exercise them without Convex.
+export function validatePreviewImageUploadArgs(args: {
+    mimeType: string;
+    sizeBytes: number;
+}): { ok: true } | { ok: false; reason: string } {
+    if (!ALLOWED_PREVIEW_IMAGE_TYPES.includes(args.mimeType)) {
+        return {
+            ok: false,
+            reason: `Unsupported image type ${args.mimeType}. Allowed: ${ALLOWED_PREVIEW_IMAGE_TYPES.join(', ')}`,
+        };
+    }
+    if (args.sizeBytes <= 0) return { ok: false, reason: 'Image size must be positive' };
+    if (args.sizeBytes > PREVIEW_IMAGE_MAX_BYTES) {
+        return {
+            ok: false,
+            reason: `Image too large (${args.sizeBytes} bytes > ${PREVIEW_IMAGE_MAX_BYTES} byte limit)`,
+        };
+    }
+    return { ok: true };
+}
+
+export function buildPreviewImageStorageKey(
+    leadId: string,
+    mimeType: string,
+    now: number,
+): string {
+    const ext = mimeType.split('/')[1] ?? 'bin';
+    return `lead-previews/${leadId}/${now}.${ext}`;
+}
+
+export const generatePreviewImageUploadUrl = action({
+    args: {
+        leadId: v.id('leads'),
+        mimeType: v.string(),
+        sizeBytes: v.number(),
+    },
+    handler: async (ctx, args): Promise<{ uploadUrl: string; publicUrl: string; storageKey: string }> => {
+        // Action-context auth: query the admin role via internal query is overkill,
+        // so we resolve the calling identity + look it up directly.
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+        const me = await ctx.runQuery(internal.leads.getCreatorRoleByClerkIdInternal, {
+            clerkId: identity.subject,
+        });
+        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+
+        const validation = validatePreviewImageUploadArgs({
+            mimeType: args.mimeType,
+            sizeBytes: args.sizeBytes,
+        });
+        if (!validation.ok) throw new Error(validation.reason);
+
+        const accountId = process.env.R2_ACCOUNT_ID;
+        const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+        const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+        const bucketName = process.env.R2_BUCKET_NAME;
+        const publicBase = process.env.R2_PUBLIC_URL;
+        if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
+            throw new Error('R2 credentials not configured on this Convex deployment');
+        }
+        if (!publicBase) throw new Error('R2_PUBLIC_URL is not configured on this Convex deployment');
+
+        const storageKey = buildPreviewImageStorageKey(args.leadId, args.mimeType, Date.now());
+
+        const client = new S3Client({
+            region: 'auto',
+            endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+            credentials: { accessKeyId, secretAccessKey },
+        });
+        const command = new PutObjectCommand({
+            Bucket: bucketName,
+            Key: storageKey,
+            ContentType: args.mimeType,
+        });
+        const uploadUrl = await getSignedUrl(client, command, { expiresIn: 3600 });
+        const publicUrl = `${publicBase.replace(/\/$/, '')}/${storageKey}`;
+        return { uploadUrl, publicUrl, storageKey };
+    },
+});
+
+// Internal helper used by the action above (actions can't read the DB directly).
+export const getCreatorRoleByClerkIdInternal = internalQuery({
+    args: { clerkId: v.string() },
+    handler: async (ctx, args) => {
+        const me = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
+            .first();
+        return me ? { role: me.role ?? null } : null;
+    },
+});
+
+export const getDetailForAdmin = query({
+    args: { id: v.id('leads') },
+    handler: async (ctx, args) => {
+        await requireAdminIdentity(ctx);
+        const lead = await ctx.db.get(args.id);
+        if (!lead) return null;
+        const submission = lead.submissionId ? await ctx.db.get(lead.submissionId) : null;
+        const creator = lead.creatorId ? await ctx.db.get(lead.creatorId) : null;
+        return {
+            lead,
+            submission,
+            creator: creator
+                ? {
+                      _id: creator._id,
+                      firstName: creator.firstName ?? null,
+                      lastName: creator.lastName ?? null,
+                      email: creator.email,
+                      profileImage: creator.profileImage ?? null,
+                  }
+                : null,
         };
     },
 });

--- a/convex/lib/phone.ts
+++ b/convex/lib/phone.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalize a phone number into a canonical digit-string used for lead-business identity matching.
+ *
+ * Philippine number formats handled:
+ * - "0917 234 1234"   → "639172341234"
+ * - "+63 917 234 1234"→ "639172341234"
+ * - "+639172341234"   → "639172341234"
+ * - "9172341234"      → "639172341234"
+ *
+ * Anything else: returns the digits-only fallback. `null` only if input is empty/undefined.
+ */
+export function normalizePhone(raw: string | undefined | null): string | null {
+    if (!raw) return null;
+    const digits = raw.replace(/\D/g, '');
+    if (!digits) return null;
+
+    if (digits.startsWith('0') && digits.length === 11) return '63' + digits.slice(1);
+    if (digits.startsWith('63') && digits.length === 12) return digits;
+    if (digits.startsWith('9') && digits.length === 10) return '63' + digits;
+
+    return digits;
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -23,7 +23,8 @@ export default defineSchema({
         status: v.optional(v.string()),  // v.string() for cross-deploy safety
         profileImage: v.optional(v.string()),
         wiseEmail: v.optional(v.string()),
-        certifiedAt: v.optional(v.number()),
+        certifiedAt: v.optional(v.number()),     // Timestamp when admin APPROVED the creator
+        quizPassedAt: v.optional(v.number()),    // Timestamp when creator passed onboarding quiz (awaiting admin approval)
         isDeleted: v.optional(v.boolean()),
         deletedAt: v.optional(v.number()),
         // Admin-only extras (kept as optional, mobile doesn't have these)
@@ -309,6 +310,13 @@ export default defineSchema({
         message: v.optional(v.string()),
         status: v.string(), // "new" | "contacted" | "qualified" | "converted" | "lost"
         createdAt: v.number(),
+        // Admin-curated social content (mobile renders FB-style card when present)
+        adminDescription: v.optional(v.string()),         // marketing copy (max 500 chars enforced in mutation)
+        previewImageUrl: v.optional(v.string()),          // R2 public URL of uploaded image
+        previewImageStorageKey: v.optional(v.string()),   // R2 storage key (for replace / delete)
+        externalPreviewUrl: v.optional(v.string()),       // external link admin wants featured
+        adminUpdatedAt: v.optional(v.number()),
+        adminUpdatedBy: v.optional(v.string()),           // Clerk ID of admin who edited
     })
         .index('by_submission', ['submissionId'])
         .index('by_creator', ['creatorId'])

--- a/docs/changes/WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md
+++ b/docs/changes/WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md
@@ -1,0 +1,1858 @@
+# Web-side sync prompt — Mobile features rollout (CRM social feed + Creator Verification)
+
+> **Hand this entire document to the agent / developer working in the web repo's `convex/` folder. Do not run `npx convex deploy --prod` from the web repo until everything below is in place.**
+
+---
+
+## Context for the implementing agent
+
+You are working in the **web repo**, in its `convex/` folder AND its admin UI. This repo and the mobile app (`ndm/`) share the same Convex production deployment: `prod:energetic-panther-693`. The mobile team is shipping THREE coupled features plus a visual design system upgrade:
+
+1. **CRM Lead Social Feed** (mobile shows all leads with original-creator attribution + admin-curated cards)
+2. **Creator Verification Flow** (quiz pass → admin approval → certified). Adds a `quizPassedAt` field plus 3 new mutations
+3. **Admin-Curated Lead Content** (admin edits a lead with description/link/image; mobile renders FB-style social card). Adds 6 new lead fields plus 3 new functions including R2 image upload
+4. **Editorial Paper design system** (NEO LAB inspired) for the two new admin web surfaces — see Step 10.5 for the complete token reference + paste-ready CSS. Mobile-responsive guidance included so the admin works on tablets/phones too.
+
+Plus **schema-drift accommodations** for prod data that was failing strict validation before the mobile team could deploy:
+- `auditLogs.action` now also accepts `"payout_sent"` (in addition to `"payment_sent"`)
+- `withdrawals.accountHolderName` is now **optional** (legacy rows pre-2026 don't have it)
+- `withdrawals.reference` is now an optional field (legacy synonym for `transactionRef`)
+
+We need the web repo to match so the next web deploy doesn't wipe these out.
+
+**Critical rule for this task:** You are making **additive-only** changes — adding new schema fields (all `v.optional`), adding new function exports, and adding one new literal to an existing union. **Do not modify, rename, or remove any existing exports.** Do not remove any existing schema field. Do not touch any unrelated file. The goal is to make the web's `convex/` folder a strict superset of what's already deployed.
+
+---
+
+## Why this needs to happen
+
+If the web repo deploys without these additions, the next `npx convex deploy --prod` from web will remove the new mobile-side functions and revert the schema accommodations from the shared production deployment, causing:
+
+- Mobile's Leads tab to fail with `Function not found` errors
+- Mobile's pending-review screen to never unlock (no admin approval mutation in prod)
+- Mobile's admin-curated social cards to render as compact cards (no fields to render)
+- Convex push to fail at schema validation against existing prod data (`payout_sent` audit row, legacy withdrawal rows)
+
+All schema changes are **purely additive**:
+- 1 new optional field on `creators` (`quizPassedAt`)
+- 6 new optional fields on `leads` (admin content + audit fields)
+- 1 new union literal on `auditLogs.action` (`payout_sent`)
+- 1 field made optional + 1 new optional field on `withdrawals`
+
+The one schema change in this sync is **purely additive**: a new literal `"payout_sent"` is added to the existing `v.union(...)` validator for `auditLogs.action`. No existing literals are removed. No fields are added or removed. No indexes change.
+
+---
+
+## Step 1 — Apply three additive schema accommodations in `convex/schema.ts`
+
+**Why this is needed:** When the mobile team ran `npx convex dev` against the shared dev deployment, three prod-data drifts surfaced. All three are pre-existing — data was written under an earlier (looser) schema version and the current (stricter) schema no longer accepts those rows. To unblock both teams' dev pushes, we need the web repo's schema to match the additive accommodations the mobile team already applied to their copy.
+
+All three changes are **additive only**: no existing fields removed, no existing literals removed, no required field becomes more restrictive.
+
+### Step 1a — Add `payout_sent` to `auditLogs.action` union
+
+**Symptom that triggered this fix:**
+```
+Document with ID "p171wj9cqpvtmy4zej8sbf6z6d859mn9" in table "auditLogs" does not match the schema:
+Path: .action
+Value: "payout_sent"
+```
+
+**Action:** Open `convex/schema.ts`. Locate the `auditLogs` table. Inside its `action: v.union(...)` block, **add one new line** for `v.literal("payout_sent")` directly after the existing `v.literal("payment_sent")` line.
+
+**Before:**
+```typescript
+auditLogs: defineTable({
+  adminId: v.string(),
+  action: v.union(
+    v.literal("submission_approved"),
+    v.literal("submission_rejected"),
+    v.literal("website_generated"),
+    v.literal("website_deployed"),
+    v.literal("payment_sent"),
+    v.literal("submission_deleted"),
+    v.literal("creator_updated"),
+    v.literal("manual_override"),
+    v.literal("payment_confirmed"),
+    v.literal("transcription_regenerated"),
+    v.literal("images_enhanced"),
+  ),
+  // ... rest unchanged ...
+})
+```
+
+**After (one line added):**
+```typescript
+auditLogs: defineTable({
+  adminId: v.string(),
+  action: v.union(
+    v.literal("submission_approved"),
+    v.literal("submission_rejected"),
+    v.literal("website_generated"),
+    v.literal("website_deployed"),
+    v.literal("payment_sent"),
+    v.literal("payout_sent"), // TODO: dedupe with "payment_sent" — pick one canonical name (codebase otherwise uses "payout" / "creatorPayout")
+    v.literal("submission_deleted"),
+    v.literal("creator_updated"),
+    v.literal("manual_override"),
+    v.literal("payment_confirmed"),
+    v.literal("transcription_regenerated"),
+    v.literal("images_enhanced"),
+  ),
+  // ... rest unchanged ...
+})
+```
+
+### Step 1b — Make `withdrawals.accountHolderName` optional + add legacy `reference` field
+
+**Symptom that triggered this fix:**
+```
+Document with ID "qd707cw5jyvpj9zxmdaa417f998596a6" in table "withdrawals" does not match the schema:
+Object is missing the required field `accountHolderName`.
+```
+
+The affected row also contained a `reference: "PAYOUT-j573wkmh-..."` field not declared in the current schema (legacy synonym for `transactionRef`).
+
+**Action:** In `convex/schema.ts`, locate the `withdrawals` table. Make two changes:
+
+1. Change `accountHolderName: v.string()` to `accountHolderName: v.optional(v.string())`
+2. Immediately after that line, add `reference: v.optional(v.string())`
+
+**Before (excerpt — only the affected lines shown):**
+```typescript
+withdrawals: defineTable({
+  creatorId: v.id("creators"),
+  amount: v.number(),
+  payoutMethod: v.union(v.literal("wise_email"), v.literal("bank_transfer")),
+  accountDetails: v.string(),
+  wiseEmail: v.optional(v.string()),
+  accountHolderName: v.string(),  // ← currently required
+  status: v.union(/* ... */),
+  // ... rest of fields ...
+})
+```
+
+**After (two lines changed/added):**
+```typescript
+withdrawals: defineTable({
+  creatorId: v.id("creators"),
+  amount: v.number(),
+  payoutMethod: v.union(v.literal("wise_email"), v.literal("bank_transfer")),
+  accountDetails: v.string(),
+  wiseEmail: v.optional(v.string()),
+  accountHolderName: v.optional(v.string()), // Optional: legacy withdrawal rows (pre-2026) were written without this field
+  reference: v.optional(v.string()), // Optional: legacy field name for transactionRef on older withdrawal rows
+  status: v.union(/* ... */),
+  // ... rest of fields ...
+})
+```
+
+### Step 1c — Add `quizPassedAt` to `creators` table
+
+**Why:** Creator Verification flow needs this field to mark a creator as "quiz passed, awaiting admin approval". Mobile sets it via the new `markQuizPassed` mutation; admin clears the pending state by setting `certifiedAt` via `approveCreator`.
+
+**Action:** In `convex/schema.ts`, locate the `creators` table. Add one new line for `quizPassedAt` directly after `certifiedAt`.
+
+```typescript
+creators: defineTable({
+  // ... existing fields ...
+  certifiedAt: v.optional(v.number()), // Timestamp when admin APPROVED the creator
+  quizPassedAt: v.optional(v.number()), // Timestamp when creator passed onboarding quiz (awaiting admin approval)
+  // ... rest unchanged ...
+})
+```
+
+### Step 1d — Add 6 new optional fields to `leads` table (admin-curated content)
+
+**Why:** The mobile CRM renders any lead that has admin-curated content as a Facebook-style social card. These fields hold the description, image, link, and audit info.
+
+**Action:** In `convex/schema.ts`, locate the `leads` table. Add the 6 new lines at the end of the table definition, just before the `}).index(...)` indexes:
+
+```typescript
+leads: defineTable({
+  // ... existing fields ...
+  status: v.union(/* ... */),
+  createdAt: v.number(),
+  // Admin-curated social content (Feature B — Facebook-style card on mobile when present)
+  adminDescription: v.optional(v.string()),         // marketing copy (max 500 chars enforced in mutation)
+  previewImageUrl: v.optional(v.string()),          // R2 public URL of uploaded image
+  previewImageStorageKey: v.optional(v.string()),   // R2 storage key (for replace / delete)
+  externalPreviewUrl: v.optional(v.string()),       // external link admin wants featured
+  adminUpdatedAt: v.optional(v.number()),
+  adminUpdatedBy: v.optional(v.string()),           // Clerk ID of admin who edited
+}).index("by_submission", ["submissionId"])
+  // ... unchanged ...
+```
+
+### Important (applies to ALL accommodations in Step 1)
+
+- The `TODO` comments are intentional — they flag inconsistencies for future cleanup without forcing decisions now
+- Do NOT remove any existing literal or field
+- Do NOT change any other table, index, or field in this file
+- If `accountHolderName` is already optional in the web repo's schema, skip the part that makes it optional (the `reference` addition might still be needed)
+- If `payout_sent` is already in the union in the web repo's schema, skip Step 1a entirely
+- All new fields are `v.optional(...)` — backward compatible with existing data
+
+---
+
+## Step 2 — Add the phone normalization helper
+
+**Action:** Create a new file at `convex/lib/phone.ts` in the web repo with the exact contents below.
+
+**File path:** `convex/lib/phone.ts`
+
+```typescript
+/**
+ * Normalize a phone number into a canonical digit-string used for lead-business identity matching.
+ *
+ * Philippine number formats handled:
+ * - "0917 234 1234"   → "639172341234"
+ * - "+63 917 234 1234"→ "639172341234"
+ * - "+639172341234"   → "639172341234"
+ * - "9172341234"      → "639172341234"
+ *
+ * Anything else: returns the digits-only fallback. `null` only if input is empty/undefined.
+ */
+export function normalizePhone(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, "");
+  if (!digits) return null;
+
+  if (digits.startsWith("0") && digits.length === 11) return "63" + digits.slice(1);
+  if (digits.startsWith("63") && digits.length === 12) return digits;
+  if (digits.startsWith("9") && digits.length === 10) return "63" + digits;
+
+  return digits;
+}
+```
+
+If `convex/lib/` doesn't exist yet, create it. If the file already exists (it shouldn't, but check), do not overwrite — diff and merge.
+
+---
+
+## Step 3 — Add the import line at the top of `convex/leads.ts`
+
+**Action:** Open `convex/leads.ts`. Locate the existing import block at the top of the file. Add this single import line **after the existing imports** (do not reorder existing imports):
+
+```typescript
+import { normalizePhone } from "./lib/phone";
+```
+
+The result should look something like (your existing imports may differ — leave them as-is):
+
+```typescript
+import { mutation, query, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { getTodayString, getCurrentMonthString } from "./analytics";
+import { requireAuth, requireAdmin } from "./lib/auth";
+import { sanitizeText, sanitizePhone, sanitizeEmail } from "./lib/sanitize";
+import { normalizePhone } from "./lib/phone";  // ← ADD THIS LINE
+```
+
+---
+
+## Step 4 — Append the Mobile CRM view queries to the end of `convex/leads.ts`
+
+**Action:** Append the entire block below to the **end** of `convex/leads.ts` (after the last existing `export const ...` block). Do not insert it in the middle. Do not modify any existing export. The block adds:
+
+- A pure-function helper `formatCreatorDisplayName` — exported for testing
+- `listForMobileCRM` — returns ALL leads (team-wide social feed) enriched with original-submitter, admin-curated content, and interviewer-count
+- `getDetailForMobileCRM` — single-lead detail enriched with submittedBy, interviewers, notes, business, admin content
+
+This is the **final shipping version**. It supersedes any earlier listForMobileCRM you may already have added.
+
+```typescript
+// ----------------------------------------------------------------------------
+// MOBILE CRM VIEW QUERIES (team-wide social feed)
+//
+// Per product spec: every signed-in creator sees ALL leads in the database
+// (not just their own) and the original submitter is prominently surfaced on
+// each card. Admin-curated content (description / image / link) appears when
+// present and triggers the social-card render on mobile.
+//
+// These queries do NOT modify any existing data or behavior. They are
+// consumed only by the mobile CRM screens at app/(app)/leads/*.
+// ----------------------------------------------------------------------------
+
+/**
+ * Pure-function helper for rendering creator display names consistently.
+ * Exported so unit tests can exercise it without spinning up Convex.
+ * Format: "Firstname L." (e.g., "Maria S."). If only first name, returns it as-is.
+ * If both missing, returns "Unknown creator".
+ */
+export function formatCreatorDisplayName(
+  firstName: string | undefined | null,
+  lastName: string | undefined | null,
+): string {
+  const first = (firstName ?? "").trim();
+  const last = (lastName ?? "").trim();
+  if (!first && !last) return "Unknown creator";
+  if (!last) return first;
+  return `${first} ${last[0]}.`;
+}
+
+export const listForMobileCRM = query({
+  args: {
+    search: v.optional(v.string()),
+    statusFilter: v.optional(
+      v.union(
+        v.literal("all"),
+        v.literal("new"),
+        v.literal("contacted"),
+        v.literal("qualified"),
+        v.literal("converted"),
+        v.literal("lost"),
+      ),
+    ),
+    onlyMine: v.optional(v.boolean()), // When true, restrict to current creator's leads
+  },
+  handler: async (ctx, args) => {
+    const identity = await requireAuth(ctx);
+
+    const currentCreator = await ctx.db
+      .query("creators")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+    if (!currentCreator) {
+      return {
+        leads: [],
+        stats: { total: 0, new: 0, contacted: 0, qualified: 0, converted: 0, lost: 0, mine: 0 },
+      };
+    }
+
+    // Per product spec: show ALL leads in the database to all signed-in creators,
+    // so the CRM feed surfaces what the team as a whole has gathered. Each card
+    // prominently shows which creator originally submitted/interviewed the lead.
+    const allLeads = await ctx.db.query("leads").order("desc").collect();
+
+    // Stat rollup over the unfiltered set so badge counts remain accurate
+    // regardless of active filters
+    const stats = {
+      total: allLeads.length,
+      new: allLeads.filter((l) => l.status === "new").length,
+      contacted: allLeads.filter((l) => l.status === "contacted").length,
+      qualified: allLeads.filter((l) => l.status === "qualified").length,
+      converted: allLeads.filter((l) => l.status === "converted").length,
+      lost: allLeads.filter((l) => l.status === "lost").length,
+      mine: allLeads.filter((l) => String(l.creatorId) === String(currentCreator._id)).length,
+    };
+
+    let filtered = allLeads;
+
+    // Optional: restrict to current creator's own leads ("Only mine" chip)
+    if (args.onlyMine) {
+      filtered = filtered.filter(
+        (l) => String(l.creatorId) === String(currentCreator._id),
+      );
+    }
+
+    // Status filter
+    const statusFilter = args.statusFilter ?? "all";
+    if (statusFilter !== "all") {
+      filtered = filtered.filter((l) => l.status === statusFilter);
+    }
+
+    // Text search across customer fields AND business name (the latter requires
+    // joining submissions, done in the enrichment loop below)
+    const search = args.search?.trim().toLowerCase();
+
+    // Cache submissions/creators to avoid repeated DB hits when the same id
+    // appears across many leads (common in production)
+    const submissionCache = new Map<string, any>();
+    const creatorCache = new Map<string, any>();
+
+    // Pre-load all submissions once for the interviewer-count aggregation
+    const allSubmissions = await ctx.db.query("submissions").collect();
+    for (const sub of allSubmissions) {
+      submissionCache.set(String(sub._id), sub);
+    }
+
+    const enriched = await Promise.all(
+      filtered.map(async (lead) => {
+        const submission = submissionCache.get(String(lead.submissionId)) ?? null;
+
+        // Original submitter (the creator who interviewed this business)
+        let creatorRecord = creatorCache.get(String(lead.creatorId));
+        if (!creatorRecord) {
+          creatorRecord = await ctx.db.get(lead.creatorId);
+          if (creatorRecord) creatorCache.set(String(lead.creatorId), creatorRecord);
+        }
+
+        // Count distinct creators who interviewed the same business by normalized phone
+        let interviewerCount = 0;
+        if (submission) {
+          const targetPhone = normalizePhone(submission.ownerPhone);
+          if (targetPhone) {
+            const matches = allSubmissions.filter(
+              (s) => normalizePhone(s.ownerPhone) === targetPhone,
+            );
+            const creatorIds = new Set(matches.map((s) => String(s.creatorId)));
+            interviewerCount = creatorIds.size;
+          }
+        }
+
+        const isMine = String(lead.creatorId) === String(currentCreator._id);
+
+        return {
+          _id: lead._id,
+          _creationTime: lead._creationTime,
+          name: lead.name,
+          phone: lead.phone,
+          email: lead.email ?? null,
+          source: lead.source,
+          status: lead.status,
+          createdAt: lead.createdAt,
+          businessName: submission?.businessName ?? "(business unavailable)",
+          businessType: submission?.businessType ?? null,
+          businessCity: submission?.city ?? null,
+          businessAddress: submission?.address ?? null,
+          ownerName: submission?.ownerName ?? null,
+          ownerPhone: submission?.ownerPhone ?? null,
+          interviewerCount,
+          websiteUrl: submission?.websiteUrl ?? null,
+          submissionStatus: submission?.status ?? null,
+          isHot: interviewerCount >= 3,
+          // The original submitting creator (prominent display per product spec)
+          submittedBy: creatorRecord
+            ? {
+                creatorId: String(creatorRecord._id),
+                displayName: formatCreatorDisplayName(
+                  creatorRecord.firstName,
+                  creatorRecord.lastName,
+                ),
+                profileImage: creatorRecord.profileImage ?? null,
+              }
+            : null,
+          isMine,
+          // Admin-curated content (Feature B — social card trigger)
+          adminDescription: lead.adminDescription ?? null,
+          previewImageUrl: lead.previewImageUrl ?? null,
+          externalPreviewUrl: lead.externalPreviewUrl ?? null,
+          hasEnrichedContent: !!(
+            lead.adminDescription ||
+            lead.previewImageUrl ||
+            lead.externalPreviewUrl
+          ),
+        };
+      }),
+    );
+
+    // Apply text search AFTER enrichment so we can search business name too
+    let result = enriched;
+    if (search) {
+      result = enriched.filter((row) =>
+        row.name.toLowerCase().includes(search) ||
+        row.phone.toLowerCase().includes(search) ||
+        (row.email?.toLowerCase().includes(search) ?? false) ||
+        row.businessName.toLowerCase().includes(search) ||
+        (row.submittedBy?.displayName.toLowerCase().includes(search) ?? false),
+      );
+    }
+
+    return { leads: result, stats };
+  },
+});
+
+export const getDetailForMobileCRM = query({
+  args: { id: v.id("leads") },
+  handler: async (ctx, args) => {
+    const identity = await requireAuth(ctx);
+
+    const currentCreator = await ctx.db
+      .query("creators")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+    if (!currentCreator) return null;
+
+    const lead = await ctx.db.get(args.id);
+    if (!lead) return null;
+
+    // Per product spec: any signed-in creator can view any lead in detail
+    // (mirrors the social-feed model of the list view)
+    const submitterCreator = await ctx.db.get(lead.creatorId);
+    const submission = await ctx.db.get(lead.submissionId);
+
+    // Find all creators who interviewed this business (matched by phone)
+    let interviewers: Array<{
+      creatorId: string;
+      creatorName: string;
+      creatorProfileImage: string | null;
+      interviewedAt: number;
+      submissionId: string;
+      submissionStatus: string;
+      isMine: boolean;
+    }> = [];
+
+    if (submission) {
+      const targetPhone = normalizePhone(submission.ownerPhone);
+      if (targetPhone) {
+        const allSubs = await ctx.db.query("submissions").collect();
+        const matches = allSubs.filter(
+          (s) => normalizePhone(s.ownerPhone) === targetPhone,
+        );
+        interviewers = await Promise.all(
+          matches.map(async (s) => {
+            const interviewerCreator = await ctx.db.get(s.creatorId);
+            return {
+              creatorId: String(s.creatorId),
+              creatorName: formatCreatorDisplayName(
+                interviewerCreator?.firstName,
+                interviewerCreator?.lastName,
+              ),
+              creatorProfileImage: interviewerCreator?.profileImage ?? null,
+              interviewedAt: s._creationTime,
+              submissionId: String(s._id),
+              submissionStatus: s.status,
+              isMine: String(s.creatorId) === String(currentCreator._id),
+            };
+          }),
+        );
+        // Newest interview first
+        interviewers.sort((a, b) => b.interviewedAt - a.interviewedAt);
+      }
+    }
+
+    // Notes for this lead (latest first)
+    const notes = await ctx.db
+      .query("leadNotes")
+      .withIndex("by_lead", (q) => q.eq("leadId", args.id))
+      .order("desc")
+      .collect();
+
+    return {
+      lead: {
+        _id: lead._id,
+        _creationTime: lead._creationTime,
+        name: lead.name,
+        phone: lead.phone,
+        email: lead.email ?? null,
+        source: lead.source,
+        status: lead.status,
+        createdAt: lead.createdAt,
+      },
+      submittedBy: submitterCreator
+        ? {
+            creatorId: String(submitterCreator._id),
+            displayName: formatCreatorDisplayName(
+              submitterCreator.firstName,
+              submitterCreator.lastName,
+            ),
+            profileImage: submitterCreator.profileImage ?? null,
+          }
+        : null,
+      isMine: String(lead.creatorId) === String(currentCreator._id),
+      business: submission
+        ? {
+            submissionId: String(submission._id),
+            businessName: submission.businessName,
+            businessType: submission.businessType,
+            ownerName: submission.ownerName,
+            ownerPhone: submission.ownerPhone,
+            ownerEmail: submission.ownerEmail ?? null,
+            address: submission.address,
+            city: submission.city,
+            province: submission.province ?? null,
+            barangay: submission.barangay ?? null,
+            websiteUrl: submission.websiteUrl ?? null,
+            businessDescription: submission.businessDescription ?? null,
+            photos: submission.photos ?? [],
+            status: submission.status,
+          }
+        : null,
+      // Admin-curated content (Feature B)
+      adminContent: {
+        description: lead.adminDescription ?? null,
+        previewImageUrl: lead.previewImageUrl ?? null,
+        externalPreviewUrl: lead.externalPreviewUrl ?? null,
+        updatedAt: lead.adminUpdatedAt ?? null,
+        hasEnrichedContent: !!(
+          lead.adminDescription ||
+          lead.previewImageUrl ||
+          lead.externalPreviewUrl
+        ),
+      },
+      interviewers,
+      interviewerCount: interviewers.length,
+      notes: notes.map((n) => ({
+        _id: n._id,
+        content: n.content,
+        createdAt: n.createdAt,
+        creatorId: String(n.creatorId),
+      })),
+    };
+  },
+});
+```
+
+---
+
+## Step 5 — Verify the schema dependencies exist
+
+These queries assume the following fields and indexes are in the deployed schema. If any are missing, **STOP** and ask before proceeding — the queries will fail at runtime.
+
+### `creators` table
+- Index `by_clerk_id` keyed on `clerkId`
+- Field `firstName: optional(string)`
+- Field `lastName: optional(string)`
+- Field `profileImage: optional(string)`
+
+### `leads` table
+- Index `by_creator` keyed on `creatorId`
+- Fields: `name`, `phone`, `email` (optional), `source`, `status`, `createdAt`, `submissionId`, `creatorId`
+
+### `submissions` table
+- Fields: `ownerPhone`, `businessName`, `businessType`, `ownerName`, `ownerEmail` (optional), `address`, `city`, `province` (optional), `barangay` (optional), `websiteUrl` (optional), `businessDescription` (optional), `photos` (optional), `creatorId`, `status`
+
+### `leadNotes` table
+- Index `by_lead` keyed on `leadId`
+- Fields: `content`, `createdAt`, `creatorId`
+
+If you find any of these missing on the web repo's schema, do not "fix" it by modifying the schema — instead, escalate. The schema is shared with mobile and unilateral changes will break the mobile app.
+
+---
+
+## Step 6 — Verify compilation locally before deploying
+
+In the web repo:
+
+```bash
+npx convex dev
+```
+
+Watch the terminal output. Convex's TypeScript checker should report no errors. The dev push will compile the new functions and you should see them listed in the dashboard under `Functions` with names `leads:listForMobileCRM` and `leads:getDetailForMobileCRM`.
+
+If you see errors:
+- **"Cannot find module './lib/phone'"** → Step 2 wasn't completed
+- **"normalizePhone is not defined"** → Step 3 import was missed
+- **"Property 'X' does not exist on submission/lead/creator"** → schema mismatch; see Step 5
+- **"Document with ID X in table 'auditLogs' does not match the schema: Path: .action, Value: 'payout_sent'"** → Step 1a wasn't completed (or was completed incorrectly — verify the `payout_sent` literal was added)
+- **"Object is missing the required field `accountHolderName`"** → Step 1b wasn't completed (verify `accountHolderName` is wrapped in `v.optional(...)`)
+- **Any other "missing required field" or "value does not match validator" error** → likely another schema-drift case that surfaced *after* these fixes. Capture the exact error and contact the mobile team — additional accommodations may be needed.
+
+---
+
+## Step 7 — Deploy to production
+
+Once `npx convex dev` is clean and the functions appear in the dev dashboard:
+
+```bash
+npx convex deploy --prod
+```
+
+After deployment, verify in the **prod** dashboard at https://dashboard.convex.dev:
+1. Switch to the `prod:energetic-panther-693` deployment
+2. Functions tab → confirm `leads:listForMobileCRM` and `leads:getDetailForMobileCRM` are both listed
+3. Optionally, run `listForMobileCRM` with empty args from the dashboard (signed in as a test creator) and verify it returns `{ leads: [], stats: { total: 0, ... } }` or real data
+
+---
+
+## What you MUST NOT do
+
+- ❌ Do not run `npx convex deploy --prod` until Steps 1–4 are complete in your local web repo
+- ❌ Do not modify any existing function in `convex/leads.ts` (`create`, `updateStatus`, `getBySubmission`, `getByCreator`, `getByStatus`, `getCountBySubmission`, `remove`)
+- ❌ Do not modify `convex/schema.ts` beyond the **single additive line** in Step 1. Do not remove any existing literal in `auditLogs.action`. Do not add, remove, retype, or reindex any other field or table.
+- ❌ Do not modify `convex/leadNotes.ts`
+- ❌ Do not rename `listForMobileCRM` or `getDetailForMobileCRM` — the mobile app calls them by name
+- ❌ Do not change the return shapes of the new queries — the mobile app destructures specific fields
+- ❌ Do not "clean up" the `payment_sent` literal even though it's now duplicative with `payout_sent` — at least one prod row uses it, removing it would break schema validation again
+
+## What's safe to do
+
+- ✅ Reformat / lint the new code to match the web repo's style
+- ✅ Add comments (including expanding the TODO note next to `payout_sent` with web-side context)
+- ✅ Move the helper to a different filename if the web repo has a different convention (just update the import path in `leads.ts` to match)
+- ✅ Inline the `normalizePhone` function into `leads.ts` if the web repo prefers fewer files (mobile and web don't have to mirror file structure, only function names + signatures)
+
+---
+
+## Post-deploy verification (with the mobile team)
+
+After deploying, ping the mobile team to confirm the queries are callable. They can verify with:
+
+```bash
+# In the ndm/ repo
+npx convex run leads:listForMobileCRM '{}' --prod
+```
+
+(Requires being signed in via Convex CLI as an account with access to the deployment.)
+
+Or from the mobile app: open the Leads tab on a dev build and confirm leads load without "Server Error" or "function not found" errors.
+
+---
+
+## Step 8 — Add Creator Verification mutations to `convex/creators.ts`
+
+**Why:** The mobile app sends every newly quiz-passing creator to a locked Pending Review screen until an admin approves them. The web admin panel will surface the queue and provide an Approve button.
+
+**Action:** In `convex/creators.ts`:
+
+1. Add `requireAdmin` to the imports if it's not already there:
+   ```typescript
+   import { requireAuth, requireAdmin } from "./lib/auth";
+   ```
+
+2. Append the three new exports at the end of the file. DO NOT modify the existing `certify` mutation:
+
+```typescript
+// ----------------------------------------------------------------------------
+// CREATOR VERIFICATION FLOW (admin-gated)
+//
+// Flow:
+//   1. Creator passes onboarding quiz → markQuizPassed sets quizPassedAt
+//   2. Mobile routes the creator to /pending-review (locked screen)
+//   3. Admin reviews on web admin panel and clicks "Approve"
+//   4. approveCreator sets certifiedAt → mobile gate releases automatically
+// ----------------------------------------------------------------------------
+
+export const markQuizPassed = mutation({
+  args: { id: v.id("creators") },
+  handler: async (ctx, args) => {
+    const identity = await requireAuth(ctx);
+    const creator = await ctx.db.get(args.id);
+    if (!creator || creator.clerkId !== identity.subject) {
+      throw new Error("Forbidden: you can only update your own account");
+    }
+    if (creator.certifiedAt) return;
+    if (creator.quizPassedAt) return;
+    await ctx.db.patch(args.id, {
+      quizPassedAt: Date.now(),
+      lastActiveAt: Date.now(),
+    });
+  },
+});
+
+export const approveCreator = mutation({
+  args: { id: v.id("creators") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const creator = await ctx.db.get(args.id);
+    if (!creator) throw new Error("Creator not found");
+    if (creator.certifiedAt) return;
+    await ctx.db.patch(args.id, {
+      certifiedAt: Date.now(),
+      lastActiveAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+      creatorId: args.id,
+      type: "certification",
+      title: "You're approved!",
+      body: "Welcome aboard. You can now submit businesses and earn from your interviews.",
+      data: { approvedByAdmin: true },
+    });
+  },
+});
+
+export const listPendingApproval = query({
+  args: {},
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+    const all = await ctx.db.query("creators").collect();
+    return all
+      .filter((c) => c.quizPassedAt && !c.certifiedAt && !c.isDeleted)
+      .map((c) => ({
+        _id: c._id,
+        clerkId: c.clerkId,
+        email: c.email,
+        firstName: c.firstName ?? null,
+        middleName: c.middleName ?? null,
+        lastName: c.lastName ?? null,
+        phone: c.phone ?? null,
+        profileImage: c.profileImage ?? null,
+        quizPassedAt: c.quizPassedAt!,
+        createdAt: c.createdAt ?? null,
+        referredByCode: c.referredByCode ?? null,
+        referredByName: c.referredByName ?? null,
+      }))
+      .sort((a, b) => b.quizPassedAt - a.quizPassedAt);
+  },
+});
+```
+
+---
+
+## Step 9 — Add Admin Lead Content functions to `convex/leads.ts`
+
+**Why:** Admin can curate any lead with a description, link, and R2-hosted image. Mobile then renders the lead as a Facebook-style social card. The image upload uses an R2 presigned URL so the file doesn't pass through Convex.
+
+**Action:** In `convex/leads.ts`:
+
+1. Update the import line you added in Step 3 to include the action type and R2 helpers. Replace:
+   ```typescript
+   import { mutation, query, internalMutation } from "./_generated/server";
+   ```
+   with:
+   ```typescript
+   import { mutation, query, internalMutation, action } from "./_generated/server";
+   ```
+   And add (if not already present):
+   ```typescript
+   import { getR2Config, generatePresignedUrl } from "./lib/r2Helpers";
+   ```
+
+2. Add the size/mime constants near the top of the file (after the imports):
+   ```typescript
+   const PREVIEW_IMAGE_MAX_BYTES = 2_000_000; // 2MB cap
+   const ALLOWED_PREVIEW_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+   ```
+
+3. Append the new exports at the end of `convex/leads.ts`. Paste the entire block (also includes the pure-function helpers used by the unit tests):
+
+```typescript
+// ----------------------------------------------------------------------------
+// ADMIN-CURATED LEAD CONTENT (Facebook-style social card data)
+// ----------------------------------------------------------------------------
+
+export const updateAdminContent = mutation({
+  args: {
+    id: v.id("leads"),
+    description: v.optional(v.string()),
+    externalPreviewUrl: v.optional(v.string()),
+    previewImageUrl: v.optional(v.string()),
+    previewImageStorageKey: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await requireAdmin(ctx);
+    const lead = await ctx.db.get(args.id);
+    if (!lead) throw new Error("Lead not found");
+
+    const patch: Record<string, unknown> = {
+      adminUpdatedAt: Date.now(),
+      adminUpdatedBy: identity.subject,
+    };
+
+    if (args.description !== undefined) {
+      const trimmed = args.description.trim();
+      if (trimmed.length > 500) {
+        throw new Error("Description too long (max 500 characters)");
+      }
+      patch.adminDescription = trimmed === "" ? undefined : trimmed;
+    }
+
+    if (args.externalPreviewUrl !== undefined) {
+      const trimmed = args.externalPreviewUrl.trim();
+      if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+        throw new Error("External preview URL must start with http:// or https://");
+      }
+      patch.externalPreviewUrl = trimmed === "" ? undefined : trimmed;
+    }
+
+    if (args.previewImageUrl !== undefined) {
+      patch.previewImageUrl = args.previewImageUrl === "" ? undefined : args.previewImageUrl;
+    }
+
+    if (args.previewImageStorageKey !== undefined) {
+      patch.previewImageStorageKey =
+        args.previewImageStorageKey === "" ? undefined : args.previewImageStorageKey;
+    }
+
+    await ctx.db.patch(args.id, patch);
+  },
+});
+
+export function validatePreviewImageUploadArgs(args: {
+  mimeType: string;
+  sizeBytes: number;
+}): { ok: true } | { ok: false; reason: string } {
+  if (!ALLOWED_PREVIEW_IMAGE_TYPES.includes(args.mimeType)) {
+    return { ok: false, reason: `Unsupported image type ${args.mimeType}. Allowed: ${ALLOWED_PREVIEW_IMAGE_TYPES.join(", ")}` };
+  }
+  if (args.sizeBytes <= 0) return { ok: false, reason: "Image size must be positive" };
+  if (args.sizeBytes > PREVIEW_IMAGE_MAX_BYTES) {
+    return {
+      ok: false,
+      reason: `Image too large (${args.sizeBytes} bytes > ${PREVIEW_IMAGE_MAX_BYTES} byte limit)`,
+    };
+  }
+  return { ok: true };
+}
+
+export function buildPreviewImageStorageKey(leadId: string, mimeType: string, now: number): string {
+  const ext = mimeType.split("/")[1] ?? "bin";
+  return `lead-previews/${leadId}/${now}.${ext}`;
+}
+
+export const generatePreviewImageUploadUrl = action({
+  args: {
+    leadId: v.id("leads"),
+    mimeType: v.string(),
+    sizeBytes: v.number(),
+  },
+  handler: async (ctx, args): Promise<{ uploadUrl: string; publicUrl: string; storageKey: string }> => {
+    await requireAdmin(ctx);
+
+    const validation = validatePreviewImageUploadArgs({
+      mimeType: args.mimeType,
+      sizeBytes: args.sizeBytes,
+    });
+    if (!validation.ok) throw new Error(validation.reason);
+
+    const publicBase = process.env.R2_PUBLIC_URL;
+    if (!publicBase) throw new Error("R2_PUBLIC_URL is not configured on this Convex deployment");
+
+    const storageKey = buildPreviewImageStorageKey(args.leadId, args.mimeType, Date.now());
+    const r2Config = getR2Config();
+    const uploadUrl = await generatePresignedUrl("PUT", storageKey, args.mimeType, r2Config, 3600);
+    const publicUrl = `${publicBase.replace(/\/$/, "")}/${storageKey}`;
+    return { uploadUrl, publicUrl, storageKey };
+  },
+});
+
+export const getDetailForAdmin = query({
+  args: { id: v.id("leads") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const lead = await ctx.db.get(args.id);
+    if (!lead) return null;
+    const submission = await ctx.db.get(lead.submissionId);
+    const creator = await ctx.db.get(lead.creatorId);
+    return {
+      lead,
+      submission,
+      creator: creator
+        ? {
+            _id: creator._id,
+            firstName: creator.firstName ?? null,
+            lastName: creator.lastName ?? null,
+            email: creator.email,
+            profileImage: creator.profileImage ?? null,
+          }
+        : null,
+    };
+  },
+});
+```
+
+---
+
+## Step 10 — Build the web admin UI
+
+Two new admin-side surfaces:
+
+### Surface A — Creator Management → Pending Approval queue
+
+Fetches `listPendingApproval` and renders a table/list of creators awaiting review.
+
+Per-row:
+- Creator name, email, profile image, `quizPassedAt` timestamp (relative time)
+- "View profile" button (existing creator detail view)
+- "Approve" button → calls `api.creators.approveCreator({ id: creator._id })` → row leaves the list optimistically
+
+Reasonable filters: search by name/email, sort by oldest pending first (so the team handles the longest-waiting creators first).
+
+### Surface B — Lead Management → Lead Detail → "Content" section
+
+On the existing lead detail page (or wherever admins click into individual leads), add a new editable "Content" section:
+
+```
+┌────────────────────────────────────────┐
+│  Content (rendered on mobile CRM)      │
+├────────────────────────────────────────┤
+│  Description                           │
+│  ┌──────────────────────────────────┐ │
+│  │ [textarea, optional, max 500 ch] │ │
+│  └──────────────────────────────────┘ │
+│                                        │
+│  External preview link                 │
+│  ┌──────────────────────────────────┐ │
+│  │ https://...                      │ │
+│  └──────────────────────────────────┘ │
+│                                        │
+│  Preview image (max 2MB, jpg/png/webp) │
+│  ┌──────────────────────────────────┐ │
+│  │ [thumbnail or "Choose file..."]   │ │
+│  └──────────────────────────────────┘ │
+│                                        │
+│  [Save changes]      [Clear content]   │
+└────────────────────────────────────────┘
+```
+
+**Image upload flow on the admin web (5 steps):**
+
+1. User selects a file in the browser
+2. Frontend client-side validates size ≤ 2MB and type ∈ {jpeg, png, webp}
+3. Frontend calls `api.leads.generatePreviewImageUploadUrl({ leadId, mimeType, sizeBytes })` → receives `{ uploadUrl, publicUrl, storageKey }`
+4. Frontend does an HTTPS `PUT` to `uploadUrl` with the file bytes and the `Content-Type: <mimeType>` header. The presigned URL already encodes the size limit, but the client check fails faster
+5. On `200` from R2, frontend calls `api.leads.updateAdminContent({ id, previewImageUrl: publicUrl, previewImageStorageKey: storageKey, description, externalPreviewUrl })`
+6. Mobile reactive query picks up the new content immediately — no app reload
+
+**Clearing content:** call `updateAdminContent` with `description: ""`, `externalPreviewUrl: ""`, `previewImageUrl: ""`, `previewImageStorageKey: ""`. The mutation interprets empty string as "clear this field" (sets it to `undefined`).
+
+**Cleaning up old images in R2:** when admin replaces or clears an image, the previous `previewImageStorageKey` is orphaned in R2. We don't have automated cleanup in v1 — leaving the old object is fine. If you want a quick cleanup, web can implement it inside `updateAdminContent` (read existing lead first, capture old storageKey, after patch issue an R2 DELETE). Out of scope for the strict sync.
+
+### Paste-ready upload code (React + Convex hooks)
+
+The admin page component can use this pattern verbatim. Adapt to your existing form library:
+
+```tsx
+import { useState } from 'react';
+import { useMutation, useAction } from 'convex/react';
+import { api } from '../convex/_generated/api';
+import type { Id } from '../convex/_generated/dataModel';
+
+const MAX_UPLOAD_BYTES = 2_000_000;
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+
+export function LeadContentEditor({ leadId, existing }: {
+  leadId: Id<'leads'>;
+  existing: {
+    adminDescription: string | null;
+    externalPreviewUrl: string | null;
+    previewImageUrl: string | null;
+    previewImageStorageKey: string | null;
+  };
+}) {
+  const generateUploadUrl = useAction(api.leads.generatePreviewImageUploadUrl);
+  const updateContent = useMutation(api.leads.updateAdminContent);
+
+  const [description, setDescription] = useState(existing.adminDescription ?? '');
+  const [externalUrl, setExternalUrl] = useState(existing.externalPreviewUrl ?? '');
+  const [imageUrl, setImageUrl] = useState(existing.previewImageUrl ?? '');
+  const [imageStorageKey, setImageStorageKey] = useState(existing.previewImageStorageKey ?? '');
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleImageSelected(file: File) {
+    setError(null);
+
+    // Client-side validation (fast-fail)
+    if (!ALLOWED_MIME_TYPES.includes(file.type as any)) {
+      setError(`Unsupported image type ${file.type}. Use JPEG, PNG, or WebP.`);
+      return;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setError(`Image too large (${(file.size / 1_000_000).toFixed(2)}MB). Max 2MB.`);
+      return;
+    }
+
+    setUploading(true);
+    try {
+      // 1. Get presigned URL from Convex
+      const { uploadUrl, publicUrl, storageKey } = await generateUploadUrl({
+        leadId,
+        mimeType: file.type,
+        sizeBytes: file.size,
+      });
+
+      // 2. PUT the bytes directly to R2 (does not pass through Convex)
+      const putRes = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': file.type },
+        body: file,
+      });
+      if (!putRes.ok) {
+        throw new Error(`R2 upload failed: ${putRes.status} ${putRes.statusText}`);
+      }
+
+      // 3. Stage the new URL/key in local state — admin still needs to click Save
+      setImageUrl(publicUrl);
+      setImageStorageKey(storageKey);
+    } catch (e: any) {
+      setError(e?.message ?? 'Image upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleSave() {
+    setError(null);
+    try {
+      await updateContent({
+        id: leadId,
+        description,
+        externalPreviewUrl: externalUrl,
+        previewImageUrl: imageUrl,
+        previewImageStorageKey: imageStorageKey,
+      });
+    } catch (e: any) {
+      setError(e?.message ?? 'Save failed');
+    }
+  }
+
+  async function handleClear() {
+    setDescription('');
+    setExternalUrl('');
+    setImageUrl('');
+    setImageStorageKey('');
+    await updateContent({
+      id: leadId,
+      description: '',
+      externalPreviewUrl: '',
+      previewImageUrl: '',
+      previewImageStorageKey: '',
+    });
+  }
+
+  return (
+    <div>
+      <label>
+        Description (max 500 characters)
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={500}
+        />
+      </label>
+
+      <label>
+        External preview link
+        <input
+          type="url"
+          value={externalUrl}
+          onChange={(e) => setExternalUrl(e.target.value)}
+          placeholder="https://..."
+        />
+      </label>
+
+      <label>
+        Preview image (max 2MB; JPEG, PNG, or WebP)
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleImageSelected(file);
+          }}
+          disabled={uploading}
+        />
+      </label>
+
+      {imageUrl && (
+        <img src={imageUrl} alt="preview" style={{ maxWidth: 200, marginTop: 8 }} />
+      )}
+      {uploading && <p>Uploading image…</p>}
+      {error && <p style={{ color: 'crimson' }}>{error}</p>}
+
+      <button onClick={handleSave} disabled={uploading}>Save changes</button>
+      <button onClick={handleClear} disabled={uploading}>Clear content</button>
+    </div>
+  );
+}
+```
+
+**Notes for the above:**
+- `useAction` (not `useMutation`) is required for `generatePreviewImageUploadUrl` because it's a Convex action (it makes external R2 calls).
+- The fetch `PUT` must include the `Content-Type` header — R2's presigned URL validates against it. Mismatched content-type causes a 403 from R2.
+- The pattern above stages the image upload separately from the metadata save (admin uploads → image appears in preview → admin clicks Save). If you'd rather auto-save on upload, call `updateContent` inside `handleImageSelected` after the R2 PUT succeeds.
+- The "Clear content" button calls `updateContent` with empty strings, which the backend interprets as "set this field to undefined."
+
+### CORS gotcha (read this before testing the upload)
+
+If you get a CORS error when the browser tries to PUT to the R2 presigned URL, you need to configure the R2 bucket's CORS policy. In Cloudflare R2 dashboard → bucket → Settings → CORS Policy, add:
+
+```json
+[
+  {
+    "AllowedOrigins": ["https://your-web-domain.com", "http://localhost:3000"],
+    "AllowedMethods": ["PUT", "GET", "HEAD"],
+    "AllowedHeaders": ["Content-Type"],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+(Replace `your-web-domain.com` with your production web origin.) The mobile-side video/audio uploads already work because they go through Convex actions, not directly from a browser. Admin image upload is the first direct-from-browser upload, so this is the first time CORS matters.
+
+---
+
+## Step 10.5 — Editorial Paper design system (mobile-inspired, for the admin surfaces)
+
+> **Why this is in this doc:** The mobile team is migrating the mobile UI to an "Editorial Paper" design system (NEO LAB inspired). The two new admin web surfaces in Step 10 (Pending Approval queue, Lead Content editor) should visually match this language so the platform feels coherent. **Apply the tokens below to ALL new admin UI you build in Step 10. Optionally retrofit the rest of the admin web over time.**
+>
+> This section is written from the **mobile-side perspective** — i.e., "this is what the mobile app looks like, replicate it on the web admin surfaces." It also includes mobile-responsive guidance because the admin will sometimes use these pages from a phone or tablet.
+
+### Design language anchor
+
+Direct quote from the NEO LAB landing page that inspired the system:
+
+> "Voice: editorial / cinematic / paper-magazine. **Not SaaS.**"
+> "Display: Instrument Serif — italic-friendly, magazine-y"
+> "Sans: Onest — clean, fresh, not Inter"
+> "Mono: JetBrains Mono — used ONLY for live data + labels"
+
+The mobile app uses this verbatim. The web admin should mirror it as closely as the existing component library allows — at minimum, the typography, color tokens, and the "door" button pattern.
+
+### Typography stack
+
+Three Google Fonts. Already loading via `@expo-google-fonts/*` on mobile; on web load via `<link>` in your HTML head or `next/font` if you're on Next.js:
+
+```html
+<link
+  rel="preconnect"
+  href="https://fonts.googleapis.com"
+/>
+<link
+  rel="preconnect"
+  href="https://fonts.gstatic.com"
+  crossorigin
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Onest:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+  rel="stylesheet"
+/>
+```
+
+| Token | Family | Use |
+|---|---|---|
+| `--font-serif` | `"Instrument Serif", Georgia, serif` | Display headlines, large numbers, hero copy |
+| `--font-serif-italic` | `"Instrument Serif"` (italic variant) | Emphasized phrases in headlines ("Welcome / **back.**") |
+| `--font-sans` | `"Onest", system-ui, sans-serif` | Body text, button labels, form inputs |
+| `--font-mono` | `"JetBrains Mono", Menlo, monospace` | UPPERCASE labels, eyebrows (`STEP 02 / SIGN IN`), timestamps |
+
+**Rule of thumb:** any uppercase letter-spaced text uses mono. Any large headline uses serif (often with one italic word for emphasis). Body and buttons use Onest sans.
+
+### Color palette
+
+Mobile-safe RGB values (no oklch — paste straight into CSS variables or your design tokens):
+
+```css
+:root {
+  /* Paper (surfaces) */
+  --color-paper:  #F8F5EE;  /* warm off-white — default page bg */
+  --color-paper-2: #EFEBE0; /* slightly cooler card bg */
+  --color-paper-3: #FCFAF5; /* near-pure for inputs/popouts */
+
+  /* Ink (text + primary dark surfaces) */
+  --color-ink:   #1B1C24;   /* near-black, cool — headings, primary buttons */
+  --color-ink-2: #3C3F4A;   /* body emphasis */
+  --color-ink-3: #7A7E8A;   /* muted secondary text */
+
+  /* Emerald accent (replaces NEO LAB's terracotta — brand consistency) */
+  --color-accent:        #047857;  /* italic display emphasis, accent links */
+  --color-accent-ink:    #064E3B;  /* accessible text on accent-bg */
+  --color-accent-bg:     #D1FAE5;  /* soft tints, success banners */
+  --color-accent-solid:  #10B981;  /* primary "door" fills */
+
+  /* Business / system accent */
+  --color-business:    #1F3654;
+  --color-business-bg: #E4E9F0;
+  --color-business-ink:#11203A;
+
+  /* Live (real-time markers — distinct from accent so live ≠ brand) */
+  --color-live:      #3FA86A;
+  --color-live-soft: #D4EFDE;
+
+  /* Rules / dividers */
+  --color-rule:        #E0D8C9;
+  --color-rule-strong: #B7AC95;
+
+  /* Status */
+  --color-warn:      #C68A12;
+  --color-warn-bg:   #FBE9C4;
+  --color-danger:    #B43A1F;
+  --color-danger-bg: #F3D7CF;
+}
+```
+
+**Critical:** the existing admin uses emerald (`#10b981`) for primary CTAs and white/zinc surfaces. The new palette swaps this to **ink as primary** (almost black) with emerald as a **secondary accent** (the earning/personal moment, italic display, primary CTA when the action is positive). Don't make every button emerald — reserve emerald for "the win" moments (Approve, Save published content).
+
+### Spacing scale
+
+Multiples of 4, more generous than typical SaaS density:
+
+| Token | Value | Use |
+|---|---|---|
+| `--space-xs` | 4px | Tight icon-text gaps |
+| `--space-sm` | 8px | Small padding |
+| `--space-md` | 16px | Standard card padding |
+| `--space-lg` | 24px | Section gaps |
+| `--space-xl` | 40px | Major section breaks |
+| `--space-2xl` | 64px | Editorial breathing room |
+
+### Border radius scale
+
+No sharp corners anywhere. Minimum 8px on everything that's not a 1px rule.
+
+| Token | Value | Use |
+|---|---|---|
+| `--radius-xs` | 8px | Inputs, small chips |
+| `--radius-sm` | 12px | Form fields |
+| `--radius-md` | 18px | Default cards, doors |
+| `--radius-lg` | 24px | Large cards |
+| `--radius-xl` | 32px | Hero blocks, modals |
+| `--radius-pill` | 999px | Pills, FABs, full-rounded |
+
+### Component patterns (mobile counterparts)
+
+These are the named primitives on the mobile side. Build equivalent web components to match.
+
+#### `<Display>` — serif headline
+
+Mobile:
+```tsx
+<Display size="lg">Welcome</Display>
+<Display size="lg" italic color={colors.accent}>back.</Display>
+```
+
+Web equivalent CSS:
+```css
+.display-lg {
+  font-family: var(--font-serif);
+  font-size: clamp(48px, 5vw, 56px); /* responsive */
+  line-height: 56px;
+  letter-spacing: -0.8px;
+  color: var(--color-ink);
+}
+.display-lg.italic { font-style: italic; color: var(--color-accent); }
+```
+
+Sizes: `sm` (28px) · `md` (40px) · `lg` (56px) · `xl` (72px).
+The italic variant is the editorial signature — usually one word per headline ("Welcome / **back.**").
+
+#### `<Body>` — Onest body text
+
+```css
+.body-md {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 22px;
+  color: var(--color-ink-2);
+}
+```
+
+Sizes: `xs` (11px) · `sm` (13px) · `md` (15px) · `lg` (17px). Weights: 400, 500, 700.
+
+#### `<Label>` — mono uppercase eyebrow
+
+```css
+.label {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 15px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--color-ink-3);
+}
+.label.eyebrow { letter-spacing: 1.8px; }
+```
+
+Use for: section eyebrows, table column headers, timestamps, status indicators. The "magic ingredient" that makes the rest read as editorial — every screen has at least one.
+
+#### `<Door>` — primary button (NEO LAB "door" pattern)
+
+Big tap-target buttons with optional eyebrow caption + arrow:
+
+```html
+<button class="door door-solid">
+  <div class="door-caption">APPROVE</div>
+  <div class="door-label">Approve creator</div>
+  <svg class="door-arrow" /* arrow icon */ />
+</button>
+```
+
+```css
+.door {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 22px;
+  border-radius: var(--radius-md);
+  border: 1px solid currentColor;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 16px;
+  cursor: pointer;
+  transition: transform .15s ease;
+  min-height: 54px;
+}
+.door:hover { transform: translateY(-1px); }
+
+.door-solid { background: var(--color-ink); color: var(--color-paper-3); border-color: var(--color-ink); }
+.door-accent { background: var(--color-accent-solid); color: white; border-color: var(--color-accent-solid); }
+.door-ghost { background: transparent; color: var(--color-ink); border-color: var(--color-ink); }
+
+.door-caption {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 2px;
+}
+.door-ghost .door-caption { color: var(--color-ink-3); }
+.door-arrow { width: 18px; height: 18px; margin-left: 12px; }
+```
+
+Three variants:
+- `door-solid` (ink) — default primary action
+- `door-accent` (emerald) — the win moment ("Approve", "Save and publish")
+- `door-ghost` (bordered) — secondary
+
+#### `<Card>` — paper-bordered surface
+
+```css
+.card {
+  background: var(--color-paper-3);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-md);
+  padding: 16px;
+}
+.card-large { border-radius: var(--radius-lg); }
+```
+
+#### `<Pill>` — mono-labeled chip
+
+```css
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--color-rule-strong);
+  background: var(--color-paper-3);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--color-ink-2);
+  cursor: pointer;
+}
+.pill[aria-pressed="true"] {
+  background: var(--color-ink);
+  color: var(--color-paper-3);
+  border-color: var(--color-ink);
+}
+```
+
+#### `<LiveDot>` — pulsing live-green indicator
+
+```html
+<span class="live-dot" aria-hidden="true"></span>
+```
+
+```css
+.live-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: var(--color-live);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 var(--color-live);
+  animation: live-pulse 2s infinite;
+}
+@keyframes live-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(63, 168, 106, 0.6); }
+  70% { box-shadow: 0 0 0 8px rgba(63, 168, 106, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(63, 168, 106, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .live-dot { animation: none; }
+}
+```
+
+### Applying the system to the two admin surfaces
+
+#### Surface A — Pending Approval queue (editorial treatment)
+
+Page structure mirroring the mobile editorial pattern:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  PENDING APPROVAL · 04 CREATORS                          │  ← mono eyebrow, count
+│                                              ● LIVE       │  ← LiveDot + label
+│                                                            │
+│  Awaiting your                                             │  ← serif display lg
+│  approval.                                                 │     ("approval." italic + accent)
+│                                                            │
+│  These creators passed the onboarding quiz and are         │  ← Onest body lede
+│  waiting on the team. Newest first.                       │
+│                                                            │
+│  ─────────────────────────────────────────────────         │  ← warm rule divider
+│                                                            │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ [Avatar] Maria Santos               2D AGO        │    │  ← serif name, mono timestamp
+│  │          maria@example.com                        │    │     in eyebrow position
+│  │                                                   │    │
+│  │          ╔══════════════╗  ╔══════════════╗      │    │
+│  │          ║ APPROVE      ║  ║ View profile ║      │    │  ← door-accent + door-ghost
+│  │          ╚══════════════╝  ╚══════════════╝      │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                            │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ [Avatar] Juan Dela Cruz             5D AGO        │    │
+│  │          ...                                       │    │
+│  └──────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────┘
+```
+
+CSS pattern:
+
+```html
+<header class="editorial-header">
+  <p class="label eyebrow">Pending Approval · 04 Creators</p>
+  <div class="live-indicator">
+    <span class="live-dot"></span>
+    <span class="label" style="color: var(--color-live);">LIVE</span>
+  </div>
+</header>
+
+<h1 class="display-lg">
+  Awaiting your<br>
+  <em class="display-lg italic">approval.</em>
+</h1>
+
+<p class="body-md" style="color: var(--color-ink-2); max-width: 56ch;">
+  These creators passed the onboarding quiz and are waiting on the team. Newest first.
+</p>
+
+<hr class="rule" />
+
+<ul class="creator-list">
+  {creators.map(creator => (
+    <li class="card creator-card">
+      <div class="creator-card-header">
+        <Avatar name={creator.firstName} />
+        <div class="creator-info">
+          <h3 class="creator-name">{creator.firstName} {creator.lastName}</h3>
+          <p class="body-sm muted">{creator.email}</p>
+        </div>
+        <span class="label">{relativeTime(creator.quizPassedAt)}</span>
+      </div>
+      <div class="creator-card-actions">
+        <button class="door door-accent" onClick={() => approveCreator({ id: creator._id })}>
+          <span class="door-caption">APPROVE</span>
+          <span class="door-label">Approve creator</span>
+        </button>
+        <button class="door door-ghost">View profile</button>
+      </div>
+    </li>
+  ))}
+</ul>
+```
+
+#### Surface B — Lead Content editor (editorial treatment)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  LEAD DETAIL · CONTENT EDITOR                              │  ← mono eyebrow
+│                                                            │
+│  Curate the                                                │  ← serif display
+│  social card.                                              │     ("social card." italic)
+│                                                            │
+│  Anything you write here renders as a Facebook-style       │  ← Onest body
+│  card on mobile. Description, link, and image are          │
+│  all optional.                                              │
+│                                                            │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ DESCRIPTION                                       │    │  ← mono label
+│  │ ┌────────────────────────────────────────────┐  │    │
+│  │ │ Aling Maria's pandesal has been a Quezon   │  │    │  ← paper3 textarea
+│  │ │ City staple since 1987...                   │  │    │
+│  │ └────────────────────────────────────────────┘  │    │
+│  │ MAX 500 CHARACTERS · 142 USED                    │    │  ← mono caption
+│  └──────────────────────────────────────────────────┘    │
+│                                                            │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ EXTERNAL LINK                                     │    │
+│  │ ┌────────────────────────────────────────────┐  │    │
+│  │ │ 🔗  https://maria-bakery.negosyo.digital   │  │    │
+│  │ └────────────────────────────────────────────┘  │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                            │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ PREVIEW IMAGE                                     │    │
+│  │ ┌────────────────────────────────────────────┐  │    │
+│  │ │     [thumb]      Choose file… 2MB max       │  │    │
+│  │ └────────────────────────────────────────────┘  │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                            │
+│  ╔══════════════════════╗  ╔══════════════════════╗      │
+│  ║ SAVE                 ║  ║ Clear content        ║      │  ← door-accent + door-ghost
+│  ╚══════════════════════╝  ╚══════════════════════╝      │
+└──────────────────────────────────────────────────────────┘
+```
+
+Wrap each form section in a `.card` with paper-3 bg, with the `<Label>` above the field (not above the section header) — that's the editorial signature pattern.
+
+### Mobile-responsive guidance for the admin
+
+Admins may use these pages from a tablet or phone. Apply these breakpoints:
+
+| Breakpoint | Approach |
+|---|---|
+| **≥1280px** (desktop) | Two-column where it helps (e.g., editor on left, mobile preview on right) |
+| **768–1279px** (tablet) | Single column, full-width cards, slightly tighter spacing |
+| **<768px** (phone) | Single column, edge-to-edge cards (16px outer gutter), larger tap targets (min 44pt height), display sizes drop one notch (lg → md) |
+
+Concrete responsive overrides:
+
+```css
+@media (max-width: 768px) {
+  .container { padding: 0 16px; }
+  .display-lg { font-size: 40px; line-height: 42px; } /* was 56/56 */
+  .display-md { font-size: 32px; line-height: 34px; }
+  .creator-card-actions {
+    flex-direction: column; /* stack buttons vertically on phone */
+    gap: 8px;
+  }
+  .door { width: 100%; } /* full-width buttons on phone */
+  section { padding: 40px 0; } /* tighter section spacing */
+}
+
+@media (max-width: 480px) {
+  .editorial-header {
+    flex-direction: column; /* stack eyebrow + live indicator */
+    align-items: flex-start;
+    gap: 8px;
+  }
+}
+```
+
+**Tap targets (always):**
+- Buttons / clickable elements: min `44pt × 44pt` (`.door` already at 54pt)
+- Form inputs: min `44pt` tall
+- Icon-only buttons: `40pt × 40pt` minimum with `hitslop: 8`
+
+**Touch-friendly form patterns:**
+- File input: pair with a styled `<label>` that's the full clickable area (the native input is hard to tap)
+- Long textareas: enable `autosize` so editor doesn't fight to scroll
+- Async actions (upload, save): show inline progress + disable the button — don't silently spin
+
+### What NOT to do with this design
+
+- ❌ Don't substitute "Inter" for Onest. The brief explicitly excludes it ("Sans: Onest — clean, fresh, **not Inter**").
+- ❌ Don't use heavy drop shadows. The system uses subtle warm shadows (max `0 12px 24px rgba(0,0,0,0.12)`). Material-style elevation looks wrong against paper bg.
+- ❌ Don't go monochromatic emerald. Three greens (`accent`, `accent-solid`, `live`) play different roles — flat brand-emerald everywhere kills the editorial feel.
+- ❌ Don't make every label uppercase mono. Reserve mono for eyebrows, timestamps, and metadata — body / button labels stay Onest sans.
+- ❌ Don't use the existing zinc gray palette. Use ink / ink-2 / ink-3 instead. Cool zinc gray clashes with warm paper bg.
+
+### Optional: applying to the rest of the admin web
+
+Out of scope for this rollout — but if you have time, the pattern naturally extends to:
+- All existing admin pages (re-skin headers + cards with the tokens above)
+- Login/auth screens (mirror the mobile editorial auth pattern)
+- Reports / dashboards (serif numbers + mono labels in stat cards)
+- Settings (cards with rule dividers, mono labels per row)
+
+Roll out gradually — start with the two admin surfaces in Step 10, then expand as time permits.
+
+---
+
+## Step 11 — Verify locally, test each function, then deploy
+
+### 11.1 — Local compile check
+
+In the web repo:
+
+```bash
+npx convex dev
+```
+
+Watch for `Convex functions ready!` with no schema-validation errors and no TypeScript errors.
+
+### 11.2 — Verify the new functions exist in the dev dashboard
+
+Open https://dashboard.convex.dev → switch to your DEV deployment → **Functions** tab. Confirm these 8 functions are present (in addition to the previously-deployed ones):
+
+**Creators module:**
+- `creators:markQuizPassed` (mutation)
+- `creators:approveCreator` (mutation)
+- `creators:listPendingApproval` (query)
+
+**Leads module:**
+- `leads:listForMobileCRM` (query, args: `search`, `statusFilter`, `onlyMine`)
+- `leads:getDetailForMobileCRM` (query)
+- `leads:updateAdminContent` (mutation)
+- `leads:generatePreviewImageUploadUrl` (action)
+- `leads:getDetailForAdmin` (query)
+
+### 11.3 — Per-function smoke test (dev dashboard "Run function")
+
+The Convex dashboard has a **Run function** button on each function page. Use it to confirm each one works before any deploy.
+
+#### `creators:listPendingApproval`
+- **Args:** `{}`
+- **Auth:** must be signed in as an admin (Clerk ID listed in `ADMIN_CLERK_IDS` env var)
+- **Expected:** array of creators with `quizPassedAt` set but `certifiedAt` null. Empty array `[]` is also valid (means no pending creators exist).
+- **If you get "Forbidden: admin access required":** the dashboard runner uses the env-var-configured admin list. Verify `ADMIN_CLERK_IDS` on the deployment includes your Clerk ID.
+
+#### `creators:markQuizPassed`
+- **Args:** `{ "id": "<a creator _id you control>" }`
+- **Auth:** the creator must match `identity.subject` (i.e., the Clerk session must be the creator themselves). Hard to test from the dashboard — easier to test from the mobile app's quiz pass flow.
+- **Expected:** silent success (no return value). Verify by querying the creator and checking `quizPassedAt` is populated.
+
+#### `creators:approveCreator`
+- **Args:** `{ "id": "<a creator _id with quizPassedAt set>" }`
+- **Auth:** admin
+- **Expected:** silent success. Notification appears in the creator's notifications. The creator's `certifiedAt` field is now populated. Mobile (if running) auto-navigates the user past the Pending Review screen.
+
+#### `leads:listForMobileCRM`
+- **Args:** `{}`
+- **Auth:** any signed-in creator
+- **Expected:** `{ leads: [...], stats: {...} }`. The `leads` array contains ALL leads in the DB (not just yours). Each lead has `submittedBy.displayName` populated. The `stats` object includes a `mine` count.
+- **If `submittedBy` is null on every lead:** the lead's `creatorId` points at a deleted/missing creator. Check the Data tab.
+
+#### `leads:getDetailForMobileCRM`
+- **Args:** `{ "id": "<a lead _id>" }`
+- **Auth:** any signed-in creator
+- **Expected:** the lead detail with `submittedBy`, `interviewers`, `notes`, `business`, `adminContent`. `interviewers` is an array; `interviewerCount` is the length.
+
+#### `leads:updateAdminContent`
+- **Args:** `{ "id": "<a lead _id>", "description": "Test description from dashboard" }`
+- **Auth:** admin
+- **Expected:** silent success. Lead row now has `adminDescription` set and `adminUpdatedAt` populated. Mobile reactive query updates within seconds.
+
+#### `leads:generatePreviewImageUploadUrl`
+- **Args:** `{ "leadId": "<lead _id>", "mimeType": "image/jpeg", "sizeBytes": 102400 }`
+- **Auth:** admin
+- **Expected:** `{ uploadUrl: "https://...amazonaws.com/...", publicUrl: "https://...", storageKey: "lead-previews/..." }`
+- **If you get "R2_PUBLIC_URL is not configured":** that env var is missing on the deployment. Set it via `npx convex env set R2_PUBLIC_URL <value> --prod`.
+- **If you get "Image too large":** size exceeded 2,000,000 bytes — the action validates upfront.
+
+#### `leads:getDetailForAdmin`
+- **Args:** `{ "id": "<a lead _id>" }`
+- **Auth:** admin
+- **Expected:** `{ lead, submission, creator }` with full lead row + linked submission + sanitized creator info.
+
+### 11.4 — Deploy to production
+
+Once all 8 functions test green in the dev dashboard:
+
+```bash
+npx convex deploy --prod
+```
+
+Watch for "Deployed successfully." Then re-do steps 11.2 and 11.3 against the **prod** deployment to confirm everything landed.
+
+---
+
+## Troubleshooting
+
+### Schema validation failures
+
+If `npx convex dev` fails with a schema validation error, it means a row in the deployed DB doesn't match the schema you're trying to push. Common cases for this rollout:
+
+| Error message | Cause | Fix |
+|---|---|---|
+| `Path: .action, Value: "payout_sent"` | Old `auditLogs` row uses `payout_sent` but schema doesn't allow it | Step 1a not applied — add `v.literal("payout_sent")` |
+| `Object is missing the required field "accountHolderName"` | Legacy `withdrawals` row missing the field | Step 1b not applied — wrap `accountHolderName` in `v.optional(...)` |
+| `Object is missing the required field "<other>"` | A different schema drift surfaced after these fixes | Capture exact error and ping mobile team. Apply same additive-optional pattern. |
+| `Path: <field>, Value: <unexpected>` | Data has a value the schema's `v.union(...)` doesn't accept | Either add the literal to the union (additive) OR patch the row in the dashboard. Prefer adding the literal if it's a real value used by code. |
+
+### Function-related errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `"Function not found: leads/listForMobileCRM"` | Step 4 not completed or function wasn't deployed | Re-check Step 4; ensure `npx convex dev` ran cleanly; verify the function appears in the dashboard |
+| `"Forbidden: admin access required"` | `requireAdmin` rejected the caller | Verify `ADMIN_CLERK_IDS` env var on the deployment includes the calling user's Clerk ID. Set via `npx convex env set ADMIN_CLERK_IDS "user_abc,user_xyz" --prod` |
+| `"Forbidden: you can only update your own account"` | `markQuizPassed` was called by an admin on behalf of a creator | Don't — `markQuizPassed` is creator-self-only. Admin uses `approveCreator` instead. |
+| `"R2_PUBLIC_URL is not configured"` | Env var missing | `npx convex env set R2_PUBLIC_URL "https://your-r2-domain" --prod` |
+| `"Cannot find module './lib/phone'"` | Step 2 not completed | Create the file per Step 2 |
+| `"normalizePhone is not defined"` | Step 3 import line missing | Add the import |
+| `"Image too large (max 2MB)"` | Upload payload over the cap | Client must validate first; cap is intentional |
+| `"Unsupported image type"` | MIME outside `image/jpeg,png,webp` | Same — enforce in browser file picker `accept=` attribute |
+| `403 from R2 PUT request` | Either: (a) Content-Type header mismatch with presigned URL's encoded type, (b) presigned URL expired (1h TTL), or (c) CORS not configured on the bucket | (a) Match `Content-Type` to the `mimeType` you sent in the action call. (b) Re-call `generatePreviewImageUploadUrl` to get a fresh URL. (c) Apply the CORS policy snippet above. |
+| `CORS error in browser console on PUT` | R2 bucket missing CORS rules for browser-direct uploads | Apply the JSON CORS policy from the "CORS gotcha" subsection above |
+| Notification not sent after `approveCreator` | `internal.notifications.createAndSend` import / module mismatch | Verify the existing notification system handles `type: "certification"` — this rollout reuses it. If the type literal is missing from the notification schema, it'll throw. |
+
+### Index-related warnings during `npx convex dev`
+
+If you see `Deleted table indexes:` mentioning indexes you didn't add, that's the **schema-drift between mobile and web** showing up. Mobile and web's `schema.ts` declare slightly different index names (`by_submission_id` vs `by_submissionId`, etc.). Each side's `dev` push removes the other's indexes. Out of scope for this rollout — flag for a future cleanup but don't fix here.
+
+### Mobile sees stale data after admin saves
+
+Reactive Convex queries refresh within ~1s of a mutation. If mobile doesn't update:
+1. Confirm the mutation actually ran (Functions tab → recent invocations)
+2. Confirm the mobile app is signed in (a logged-out app obviously won't reactively refresh)
+3. Mobile's `useQuery` will refetch on every focus by default — if it's stuck, navigating away and back fixes the immediate view
+
+### Convex `useAction` returns a function that errors with "actions don't return values"
+
+Convex requires you to `await` the action and use the return value directly. If you wrap it weirdly, the await semantics break. The paste-ready code above uses the correct pattern.
+
+---
+
+## Post-deploy verification (with the mobile team)
+
+After deploying, ping the mobile team to confirm everything works. They should:
+
+1. Run a quiz pass on a test creator → confirm they land on `/pending-review`
+2. Call `creators.approveCreator` from the Convex dashboard for that creator → confirm the mobile app auto-navigates to the home screen
+3. Use the new admin UI to enrich a test lead with description + link + image → confirm the mobile lead card renders as a social card
+4. Browse the CRM list as a different creator → confirm all leads are visible with original-creator attribution
+
+---
+
+## Summary checklist
+
+Tick each one off as you go. Don't skip any. The order matters because later steps depend on earlier ones.
+
+### Schema additions to `convex/schema.ts` (Step 1)
+
+- [ ] **1a:** `v.literal("payout_sent")` added to `auditLogs.action` union (additive)
+- [ ] **1b:** `accountHolderName` made optional + `reference: v.optional(v.string())` added on `withdrawals`
+- [ ] **1c:** `quizPassedAt: v.optional(v.number())` added to `creators` table
+- [ ] **1d:** 6 new optional admin-content fields added to `leads` table
+
+### Files created (Step 2)
+
+- [ ] `convex/lib/phone.ts` created with `normalizePhone` export
+
+### `convex/leads.ts` additions (Steps 3 + 4 + 9)
+
+- [ ] **Step 3:** `import { normalizePhone } from "./lib/phone";` added to imports
+- [ ] **Step 4:** Three new exports added at end of file:
+  - [ ] `formatCreatorDisplayName` (pure helper)
+  - [ ] `listForMobileCRM` (query, with `onlyMine` arg, returns ALL leads, includes `submittedBy` + admin content)
+  - [ ] `getDetailForMobileCRM` (query, returns `submittedBy`, `interviewers`, `notes`, `business`, `adminContent`)
+- [ ] **Step 9:** Imports updated to include `action` + R2 helpers
+- [ ] **Step 9:** Constants `PREVIEW_IMAGE_MAX_BYTES = 2_000_000` and `ALLOWED_PREVIEW_IMAGE_TYPES = [...]` added
+- [ ] **Step 9:** Five new exports added at end of file:
+  - [ ] `updateAdminContent` (mutation, admin-only, validates URL prefix + 500-char description)
+  - [ ] `validatePreviewImageUploadArgs` (pure helper, exported for tests)
+  - [ ] `buildPreviewImageStorageKey` (pure helper, exported for tests)
+  - [ ] `generatePreviewImageUploadUrl` (action, admin-only, returns presigned PUT URL)
+  - [ ] `getDetailForAdmin` (query, admin-only, returns full lead + submission + creator)
+
+### `convex/creators.ts` additions (Step 8)
+
+- [ ] `requireAdmin` added to the existing import from `./lib/auth`
+- [ ] Three new exports added at end of file (existing `certify` mutation UNTOUCHED):
+  - [ ] `markQuizPassed` (mutation, creator-self-only, idempotent)
+  - [ ] `approveCreator` (mutation, admin-only, sends notification)
+  - [ ] `listPendingApproval` (query, admin-only)
+
+### Verification (Steps 5 + 11)
+
+- [ ] **Step 5:** Schema fields verified to exist on `creators`, `submissions`, `leads`, `leadNotes` tables
+- [ ] **Step 11.1:** `npx convex dev` compiles cleanly (no TS errors, no schema validation errors)
+- [ ] **Step 11.2:** All 8 new functions appear in the **dev** Convex dashboard's Functions tab
+- [ ] **Step 11.3:** Each function smoke-tested via dashboard "Run function" — at minimum `listPendingApproval`, `listForMobileCRM`, `generatePreviewImageUploadUrl`
+- [ ] **Step 11.4:** `npx convex deploy --prod` succeeds
+- [ ] All 8 functions reappear in the **prod** Convex dashboard's Functions tab
+
+### Env vars (one-time setup on prod, if not already)
+
+- [ ] `ADMIN_CLERK_IDS` set on prod (comma-separated Clerk user IDs of admins). Without this, all admin-gated functions reject all callers.
+- [ ] `R2_PUBLIC_URL` set on prod (e.g., `https://pub-xxxxxx.r2.dev` or your custom domain). Without this, `generatePreviewImageUploadUrl` throws.
+- [ ] R2 bucket CORS policy includes `PUT` and `Content-Type` for the web origin (see "CORS gotcha" in Step 10)
+
+### Admin UI (web frontend) (Step 10)
+
+- [ ] **Surface A:** Pending Approval queue page wired to `listPendingApproval` + `approveCreator`
+- [ ] **Surface B:** Lead Content editor section on the lead detail page wired to `updateAdminContent` + `generatePreviewImageUploadUrl`
+- [ ] Image upload validates size (≤2MB) and MIME type (JPEG/PNG/WebP) on the client BEFORE calling the action
+- [ ] Clear-content button (calls `updateAdminContent` with empty strings) works
+
+### Editorial Paper design system applied to both surfaces (Step 10.5)
+
+- [ ] Google Fonts loaded (Instrument Serif, Onest, JetBrains Mono) via `<link>` or `next/font`
+- [ ] CSS variables / design tokens defined (`--color-paper`, `--color-ink`, `--color-accent`, etc.)
+- [ ] Display / Body / Label / Door / Card / Pill / LiveDot components built (or equivalent classes)
+- [ ] Pending Approval queue uses serif display headline + mono eyebrow + accent door for Approve
+- [ ] Lead Content editor uses serif headline + mono labels per field + accent door for Save
+- [ ] **Mobile responsive:** breakpoints at 1280 / 768 / 480px applied; tap targets ≥44pt; doors stack full-width on phone
+- [ ] No system-default fonts visible (i.e., font load completed before render)
+- [ ] No Inter or zinc grays used (replaced by Onest + ink-2/ink-3)
+
+### Coordination
+
+- [ ] Mobile team notified that prod deploy is complete
+- [ ] Mobile team confirmed all mobile flows work end-to-end:
+  - [ ] Quiz pass routes to Pending Review screen
+  - [ ] Admin approving from web auto-releases the gate
+  - [ ] CRM lead list shows ALL leads with `submittedBy` attribution
+  - [ ] Admin-curated content renders as a social card on mobile


### PR DESCRIPTION
## Summary

- **Mobile-coupled backend (additive)**: CRM team-wide feed queries, creator
  approval flow (`markQuizPassed` → admin `approveCreator`), admin-curated
  lead content with R2 direct-from-browser image upload
- **Two new admin surfaces**: `/admin/pending-approvals` queue and a
  `LeadContentModal` on `/admin/leads` (description + external link + image)
- **Editorial Paper design system** ported from mobile (§10.5 of the spec)
  applied to every admin page + every creator-facing page (dashboard, wallet,
  referrals, profile got full editorial passes; secondary pages got
  outer-wrapper paper + Onest)
- **Schema is additive only** — no removed fields, no removed literals, no
  validator made stricter. The 1a/1b "accommodations" in the spec were
  already permissive in this repo (auditLogs.action is already `v.string()`,
  withdrawals.accountHolderName is already optional, `reference` is already
  there), so only Step 1c + 1d needed schema edits.

## Source spec

Implementation follows `docs/changes/WEB-SYNC-CRM-CREATOR-APPROVAL-UI-REDESIGNED.md`.

## What changed

### Convex (`convex/`)
- `schema.ts`: `quizPassedAt` on `creators`; 6 admin-content fields on `leads`
- `lib/phone.ts` (new): `normalizePhone` helper
- `leads.ts`: 8 new exports (Mobile CRM queries + admin content + image upload)
- `creators.ts`: 3 new exports (`markQuizPassed`, `approveCreator`,
  `listPendingApproval`)

### Admin UI
- `app/admin/pending-approvals/page.tsx` (new) — searchable queue + Approve
- `app/admin/leads/LeadContentModal.tsx` (new) + wired into `/admin/leads`
  row actions menu
- `app/admin/components/AdminLayout.tsx` — full editorial rebrand
- `app/admin/page.tsx` — editorial dashboard header

### Editorial design system
- `app/globals.css`: new `--ed-*` token namespace + utility classes; legacy
  `--khaki`/`--ink`/`--rust` remapped to editorial RGB values
- `app/layout.tsx`: Onest font added via `next/font/google`

### Creator-facing pages (UI-only, no logic changes)
Full editorial pass:
- `app/dashboard/page.tsx`, `app/wallet/page.tsx`,
  `app/referrals/page.tsx`, `app/profile/page.tsx`

Outer wrapper paper + Onest:
- `app/edit-profile`, `app/notifications`, `app/training`,
  `app/training-lessons`, `app/certification-quiz`, `app/submissions`,
  `app/submit/{info,interview,photos,review,success}`

Skipped intentionally:
- `app/onboarding/page.tsx` — cyberpunk dark theme preserved by design
- Landing tree (`/`, `/for-business`, `/for-creators`, `/knowledge`,
  `/contact`, `/help-faq`) — already has its own `.neo` scope

### Auth UI
- `app/signup/page.tsx` — Google OAuth button now full-width

## Deploy plan (in this order)

1. **`npx convex deploy`** — pushes 8 new functions + schema additions
   (note: in current Convex CLI, `--prod` is implicit; the old `--prod` flag
   was removed). The schema additions are all `v.optional` so they validate
   against existing prod data.

2. **Verify functions appear** in Convex dashboard → Functions:
   - `creators:markQuizPassed`, `creators:approveCreator`,
     `creators:listPendingApproval`
   - `leads:listForMobileCRM`, `leads:getDetailForMobileCRM`,
     `leads:updateAdminContent`, `leads:generatePreviewImageUploadUrl`,
     `leads:getDetailForAdmin`, `leads:getCreatorRoleByClerkIdInternal`

3. **R2 env vars on prod Convex** (likely already set, but confirm):
   `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`,
   `R2_BUCKET_NAME`, `R2_PUBLIC_URL`

4. **R2 bucket CORS** for direct-from-browser uploads — Cloudflare R2
   dashboard → bucket → Settings → CORS Policy:
   ```json
   [{
     "AllowedOrigins": ["https://your-web-domain.com", "http://localhost:3000"],
     "AllowedMethods": ["PUT", "GET", "HEAD"],
     "AllowedHeaders": ["Content-Type"],
     "MaxAgeSeconds": 3600
   }]
