### PR TITLE
feat(creators): add /leads CRM page, detail view, and Business Near M…

### DIFF
--- a/app/api/download-apk/route.ts
+++ b/app/api/download-apk/route.ts
@@ -10,73 +10,100 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
  * Stable, friendly-named download endpoint for the Negosyo Digital APK.
  *
  * The APK upload pipeline (convex/r2.ts:generateApkUploadUrl + the admin
- * App Release page) intentionally stores each release at a collision-safe
- * R2 key like `releases/1704812345678-a8b2c1d4.apk`. That keeps re-uploads
- * safe but makes the user-facing filename ugly when the browser downloads
- * directly from the public R2 URL.
+ * App Release page) stores each release at a collision-safe R2 key like
+ * `releases/1704812345678-a8b2c1d4.apk` and persists FOUR Convex settings:
  *
- * This route fixes only the user-facing filename. It:
- *  1. Looks up the current `apk_r2_key` from Convex settings.
- *  2. Mints a fresh presigned GET URL with
- *     `ResponseContentDisposition: attachment; filename="negosyo-digital.apk"`.
- *     R2 honors that header on the response, so the browser saves the file
- *     with the friendly name regardless of the cryptic R2 key.
- *  3. 302-redirects to it. The R2 download stream then handles the bytes
- *     directly — Next.js never proxies the 200 MB payload.
+ *   apk_r2_key       — R2 storage key, used to mint presigned URLs
+ *   apk_download_url — public R2 URL, used as a fallback
+ *   apk_file_name    — original filename
+ *   apk_uploaded_at  — upload timestamp
  *
- * NO changes to the upload side. NO migration of existing R2 keys.
+ * The Navbar/Footer link decision is based on `apk_download_url`. This route
+ * MUST be at least as available as that decision — otherwise a setting drift
+ * (where apk_download_url is present but apk_r2_key isn't, e.g. legacy
+ * uploads or a manual edit in the Convex dashboard) makes the download
+ * appear available in the UI but 404 on click.
+ *
+ * Resolution strategy (most-friendly first, last-resort last):
+ *   1. apk_r2_key present                    → presigned URL + friendly name
+ *   2. apk_download_url + R2_PUBLIC_URL set  → derive key from URL → same
+ *   3. apk_download_url present              → 302 to public URL (cryptic name, but works)
+ *   4. neither present                       → real 404
  */
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
     try {
-        // Resolve the current release's R2 key from Convex settings. The
-        // admin App Release page persists this on every upload.
-        const apkR2Key = (await fetchQuery(api.settings.get, {
-            key: 'apk_r2_key',
-        })) as string | null | undefined
+        // Read both settings up front — cheap, single round trip.
+        const [apkR2Key, apkDownloadUrl] = (await Promise.all([
+            fetchQuery(api.settings.get, { key: 'apk_r2_key' }),
+            fetchQuery(api.settings.get, { key: 'apk_download_url' }),
+        ])) as Array<string | null | undefined>
 
-        if (!apkR2Key) {
+        // Fail fast on the genuine "nothing uploaded" case.
+        if (!apkR2Key && !apkDownloadUrl) {
             return NextResponse.json(
                 { error: 'No APK release available right now.' },
                 { status: 404 },
             )
         }
 
-        const r2AccountId = process.env.R2_ACCOUNT_ID
-        const r2AccessKeyId = process.env.R2_ACCESS_KEY_ID
-        const r2SecretAccessKey = process.env.R2_SECRET_ACCESS_KEY
-        const r2BucketName = process.env.R2_BUCKET_NAME
-
-        if (!r2AccountId || !r2AccessKeyId || !r2SecretAccessKey || !r2BucketName) {
-            console.error('download-apk: R2 env vars are not configured')
-            return NextResponse.json(
-                { error: 'APK storage is not configured.' },
-                { status: 500 },
-            )
+        // Strategy 2: derive the R2 key from the public URL when apk_r2_key
+        // is missing. R2 public URLs are built as `${R2_PUBLIC_URL}/${key}`
+        // (see convex/r2.ts:generateApkUploadUrl), so stripping the prefix
+        // gives us the key back. This recovers gracefully from settings
+        // drift without forcing the admin to re-upload.
+        const r2PublicUrlRaw = process.env.R2_PUBLIC_URL
+        const r2PublicUrl = r2PublicUrlRaw ? r2PublicUrlRaw.replace(/\/$/, '') : null
+        let resolvedKey: string | null = apkR2Key ?? null
+        if (!resolvedKey && apkDownloadUrl && r2PublicUrl && apkDownloadUrl.startsWith(r2PublicUrl + '/')) {
+            resolvedKey = apkDownloadUrl.slice(r2PublicUrl.length + 1)
         }
 
-        const client = new S3Client({
-            region: 'auto',
-            endpoint: `https://${r2AccountId}.r2.cloudflarestorage.com`,
-            credentials: {
-                accessKeyId: r2AccessKeyId,
-                secretAccessKey: r2SecretAccessKey,
-            },
-        })
+        // Strategies 1 + 2: mint a presigned URL so the browser gets the
+        // friendly `negosyo-digital.apk` filename via response headers.
+        if (resolvedKey) {
+            const r2AccountId = process.env.R2_ACCOUNT_ID
+            const r2AccessKeyId = process.env.R2_ACCESS_KEY_ID
+            const r2SecretAccessKey = process.env.R2_SECRET_ACCESS_KEY
+            const r2BucketName = process.env.R2_BUCKET_NAME
 
-        // Generate a short-lived presigned URL whose `Content-Disposition`
-        // response header overrides whatever R2 would have served. The
-        // browser uses this header to name the saved file.
-        const command = new GetObjectCommand({
-            Bucket: r2BucketName,
-            Key: apkR2Key,
-            ResponseContentDisposition: 'attachment; filename="negosyo-digital.apk"',
-            ResponseContentType: 'application/vnd.android.package-archive',
-        })
-        const signedUrl = await getSignedUrl(client, command, {
-            expiresIn: 60 * 60, // 1 hour — plenty for the redirect to land
-        })
+            if (r2AccountId && r2AccessKeyId && r2SecretAccessKey && r2BucketName) {
+                try {
+                    const client = new S3Client({
+                        region: 'auto',
+                        endpoint: `https://${r2AccountId}.r2.cloudflarestorage.com`,
+                        credentials: { accessKeyId: r2AccessKeyId, secretAccessKey: r2SecretAccessKey },
+                    })
+                    const command = new GetObjectCommand({
+                        Bucket: r2BucketName,
+                        Key: resolvedKey,
+                        ResponseContentDisposition: 'attachment; filename="negosyo-digital.apk"',
+                        ResponseContentType: 'application/vnd.android.package-archive',
+                    })
+                    const signedUrl = await getSignedUrl(client, command, { expiresIn: 60 * 60 })
+                    return NextResponse.redirect(signedUrl, { status: 302 })
+                } catch (signErr) {
+                    // Fall through to strategy 3 — never block the download
+                    // because the signing step itself failed.
+                    console.error('download-apk: presign failed, falling back to public URL', signErr)
+                }
+            } else {
+                console.warn('download-apk: R2 env vars missing, falling back to public URL')
+            }
+        }
 
-        return NextResponse.redirect(signedUrl, { status: 302 })
+        // Strategy 3: last-resort direct redirect to the public R2 URL. The
+        // user gets the cryptic R2 key as the filename but at least the
+        // download succeeds — strictly better than a 404.
+        if (apkDownloadUrl) {
+            return NextResponse.redirect(apkDownloadUrl, { status: 302 })
+        }
+
+        // Should be unreachable given the early return above, but kept for
+        // exhaustiveness.
+        return NextResponse.json(
+            { error: 'No APK release available right now.' },
+            { status: 404 },
+        )
     } catch (err: any) {
         console.error('download-apk error:', err)
         return NextResponse.json(

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { api } from "@/convex/_generated/api"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
 import Link from "next/link"
-import { Wallet, Store, Clock, Loader2, Bell, User } from "lucide-react"
+import { Wallet, Store, Clock, Loader2, Bell, User, Users, ChevronRight } from "lucide-react"
 import { BottomNav } from "@/components/BottomNav"
 
 export default function DashboardPage() {
@@ -29,6 +29,14 @@ export default function DashboardPage() {
     const unreadCount = useQuery(
         api.notifications.getUnreadCount,
         creator?._id ? { creatorId: creator._id } : "skip"
+    )
+
+    // Team leads feed (for the "STEP 02 / TEAM LEADS" card). Subscribes the
+    // dashboard to the same listForMobileCRM query the /leads page uses so the
+    // count stays in sync as new leads land.
+    const leadsFeed = useQuery(
+        api.leads.listForMobileCRM,
+        creator?._id && creator.role !== 'admin' ? {} : "skip"
     )
 
     // Redirect to login if not authenticated
@@ -275,6 +283,98 @@ export default function DashboardPage() {
                         </div>
                     ))}
                 </div>
+
+                {/* STEP 02 / TEAM LEADS — feed entry card */}
+                {(() => {
+                    const total = leadsFeed?.stats.total ?? 0
+                    const mine = leadsFeed?.stats.mine ?? 0
+                    const converted = leadsFeed?.stats.converted ?? 0
+                    const hot = leadsFeed?.leads.filter((l: any) => l.isHot).length ?? 0
+                    return (
+                        <Link
+                            href="/leads"
+                            className="block rounded-2xl overflow-hidden transition-transform hover:translate-y-[-1px]"
+                            style={{
+                                background: "var(--ed-paper-3)",
+                                border: "1px solid var(--ed-rule)",
+                            }}
+                        >
+                            <div className="p-4 sm:p-5">
+                                <div className="flex items-center justify-between mb-2">
+                                    <div className="flex items-center gap-2 text-[10px]" style={{
+                                        fontFamily: "var(--ed-mono)",
+                                        letterSpacing: "0.14em",
+                                        textTransform: "uppercase",
+                                        color: "var(--ed-ink-3)",
+                                    }}>
+                                        <span>Step 02 / Team Leads</span>
+                                        <span className="ed-live-dot" />
+                                    </div>
+                                    <ChevronRight className="w-4 h-4" style={{ color: "var(--ed-ink-3)" }} />
+                                </div>
+                                <h2
+                                    style={{
+                                        fontFamily: "var(--ed-serif)",
+                                        fontSize: 26,
+                                        lineHeight: 1.1,
+                                        letterSpacing: "-0.015em",
+                                        color: "var(--ed-ink)",
+                                        margin: 0,
+                                    }}
+                                >
+                                    {total} {total === 1 ? "lead" : "leads"},{" "}
+                                    <em style={{ color: "var(--ed-accent)" }}>browse the feed.</em>
+                                </h2>
+                                <p className="text-[13px] mt-2" style={{ color: "var(--ed-ink-2)" }}>
+                                    See every business the team has interviewed — including yours.
+                                </p>
+                            </div>
+                            <div
+                                className="grid grid-cols-4 divide-x"
+                                style={{
+                                    borderTop: "1px solid var(--ed-rule)",
+                                    background: "var(--ed-paper-2)",
+                                }}
+                            >
+                                {[
+                                    { label: "Total", value: total, tone: "ink" as const },
+                                    { label: "Hot", value: hot, tone: "danger" as const },
+                                    { label: "Yours", value: mine, tone: "ink" as const },
+                                    { label: "Converted", value: converted, tone: "accent" as const },
+                                ].map((stat) => (
+                                    <div key={stat.label} className="px-2 py-3 text-center" style={{ borderColor: "var(--ed-rule)" }}>
+                                        <div
+                                            style={{
+                                                fontFamily: "var(--ed-serif)",
+                                                fontSize: 22,
+                                                lineHeight: 1.05,
+                                                fontVariantNumeric: "tabular-nums",
+                                                color:
+                                                    stat.tone === "accent" ? "var(--ed-accent)" :
+                                                    stat.tone === "danger" ? "var(--ed-danger)" :
+                                                    "var(--ed-ink)",
+                                            }}
+                                        >
+                                            {stat.value}
+                                        </div>
+                                        <div
+                                            className="mt-0.5"
+                                            style={{
+                                                fontFamily: "var(--ed-mono)",
+                                                fontSize: 9,
+                                                letterSpacing: "0.14em",
+                                                textTransform: "uppercase",
+                                                color: "var(--ed-ink-3)",
+                                            }}
+                                        >
+                                            {stat.label}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </Link>
+                    )
+                })()}
 
                 {/* Submission Status — eyebrow + serif heading */}
                 <div>

--- a/app/leads/[leadId]/page.tsx
+++ b/app/leads/[leadId]/page.tsx
@@ -1,0 +1,637 @@
+"use client";
+
+/**
+ * /leads/[leadId] — Creator-side lead detail view.
+ *
+ * Mirrors mobile's `app/(app)/leads/[leadId].tsx`. Reads
+ * `api.leads.getDetailForMobileCRM` for the full lead bundle (lead + business
+ * + interviewers + notes + admin-curated content). Lets the creator post a
+ * note via `api.leadNotes.create`, and — if the lead is theirs — change the
+ * status via `api.leads.updateStatus`. Admin elevation also unlocks status.
+ */
+import { Suspense, use, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+    ArrowLeft, Phone, Mail, MapPin, Loader2, Send, Building2, ExternalLink, Globe,
+} from "lucide-react";
+
+type LeadStatus = "new" | "contacted" | "qualified" | "converted" | "lost";
+const STATUS_OPTIONS: LeadStatus[] = ["new", "contacted", "qualified", "converted", "lost"];
+
+const STATUS_PILL_STYLES: Record<string, { bg: string; ink: string }> = {
+    new:       { bg: "var(--ed-status-new-bg, #E4E9F0)",       ink: "var(--ed-status-new-ink, #1F3654)" },
+    contacted: { bg: "var(--ed-status-contacted-bg, #FBE9C4)", ink: "var(--ed-status-contacted-ink, #C68A12)" },
+    qualified: { bg: "var(--ed-status-qualified-bg, #EDE9FE)", ink: "var(--ed-status-qualified-ink, #6D28D9)" },
+    converted: { bg: "var(--ed-status-converted-bg, #D1FAE5)", ink: "var(--ed-status-converted-ink, #064E3B)" },
+    lost:      { bg: "var(--ed-status-lost-bg, #F3D7CF)",      ink: "var(--ed-status-lost-ink, #B43A1F)" },
+};
+
+function timeAgo(ts: number | null | undefined): string {
+    if (!ts) return "—";
+    const diff = Date.now() - ts;
+    const min = Math.floor(diff / 60_000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    return `${Math.floor(hr / 24)}d ago`;
+}
+
+export default function CreatorLeadDetailPage({
+    params,
+}: {
+    params: Promise<{ leadId: string }>;
+}) {
+    const router = useRouter();
+    const { user, isLoaded, isSignedIn } = useUser();
+    const { leadId } = use(params);
+
+    const creator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip",
+    );
+
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) router.push("/login");
+    }, [isLoaded, isSignedIn, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
+    }, [isLoaded, isSignedIn, creator, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
+            router.replace("/training");
+        }
+    }, [isLoaded, isSignedIn, creator, router]);
+
+    const ready =
+        isLoaded && isSignedIn && creator !== undefined && !!creator && (creator.role === "admin" || !!creator.certifiedAt);
+
+    if (!ready) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+            </div>
+        );
+    }
+
+    return (
+        <Suspense
+            fallback={
+                <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                    <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+                </div>
+            }
+        >
+            <DetailContent leadId={leadId as Id<"leads">} creator={creator} />
+        </Suspense>
+    );
+}
+
+function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any }) {
+    const data = useQuery(api.leads.getDetailForMobileCRM, { id: leadId });
+    const updateStatus = useMutation(api.leads.updateStatus);
+    const addNote = useMutation(api.leadNotes.create);
+
+    const [noteDraft, setNoteDraft] = useState("");
+    const [posting, setPosting] = useState(false);
+
+    if (data === undefined) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+            </div>
+        );
+    }
+    if (data === null) {
+        return (
+            <div
+                className="min-h-screen pb-20"
+                style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+            >
+                <div className="max-w-2xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6">
+                    <Link
+                        href="/leads"
+                        className="inline-flex items-center gap-1.5 text-[12px] mb-6"
+                        style={{ color: "var(--ed-ink-3)" }}
+                    >
+                        <ArrowLeft className="w-3.5 h-3.5" /> Back to Leads
+                    </Link>
+                    <div
+                        className="rounded-2xl py-10 px-6 text-center"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <h2 style={{ fontFamily: "var(--ed-serif)", fontSize: 28, color: "var(--ed-ink)" }}>
+                            Lead not found.
+                        </h2>
+                        <p className="text-[14px] mt-2" style={{ color: "var(--ed-ink-2)" }}>
+                            It may have been deleted or you don&apos;t have access.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    const { lead, submittedBy, isMine, business, adminContent, interviewers, notes } = data as any;
+    const isAdmin = creator?.role === "admin";
+    const canChangeStatus = isMine || isAdmin;
+
+    const handlePostNote = async () => {
+        const trimmed = noteDraft.trim();
+        if (!trimmed || !creator?._id) return;
+        setPosting(true);
+        try {
+            await addNote({
+                leadId,
+                creatorId: creator._id as Id<"creators">,
+                content: trimmed,
+            });
+            setNoteDraft("");
+        } catch (e: any) {
+            alert(e?.message ?? "Failed to post note");
+        } finally {
+            setPosting(false);
+        }
+    };
+
+    return (
+        <div
+            className="min-h-screen pb-24"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
+            <div className="max-w-2xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6 space-y-5">
+                {/* Header */}
+                <div className="flex items-center gap-3">
+                    <Link
+                        href="/leads"
+                        className="w-9 h-9 rounded-full inline-flex items-center justify-center transition-colors"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <ArrowLeft className="w-4 h-4" style={{ color: "var(--ed-ink-2)" }} />
+                    </Link>
+                    <div className="flex items-center gap-2 text-[11px]" style={{
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}>
+                        <span>03 / Lead Detail</span>
+                        {isMine && (
+                            <>
+                                <span>·</span>
+                                <span style={{ color: "var(--ed-accent)" }}>Mine</span>
+                            </>
+                        )}
+                    </div>
+                </div>
+
+                {/* Title row */}
+                <div>
+                    <h1
+                        style={{
+                            fontFamily: "var(--ed-serif)",
+                            fontSize: 36,
+                            lineHeight: 1.05,
+                            letterSpacing: "-0.02em",
+                            color: "var(--ed-ink)",
+                            margin: 0,
+                        }}
+                    >
+                        {business?.businessName ?? lead.name ?? "(unnamed)"}
+                    </h1>
+                    {business && (
+                        <p className="text-[14px] mt-2" style={{ color: "var(--ed-ink-2)" }}>
+                            {[business.businessType, business.city].filter(Boolean).join(" · ")}
+                        </p>
+                    )}
+                </div>
+
+                {/* Submitter strip */}
+                {submittedBy && (
+                    <div
+                        className="flex items-center gap-3 px-4 py-3 rounded-2xl"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        {submittedBy.profileImage ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                                src={submittedBy.profileImage}
+                                alt=""
+                                className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                            />
+                        ) : (
+                            <div
+                                className="w-10 h-10 rounded-full flex items-center justify-center text-[14px] flex-shrink-0"
+                                style={{
+                                    background: "var(--ed-paper-2)",
+                                    color: "var(--ed-ink)",
+                                    fontFamily: "var(--ed-serif)",
+                                    fontWeight: 500,
+                                }}
+                            >
+                                {(submittedBy.displayName ?? "?").slice(0, 1).toUpperCase()}
+                            </div>
+                        )}
+                        <div className="min-w-0 flex-1">
+                            <div className="text-[14px]" style={{ color: "var(--ed-ink)" }}>
+                                Submitted by{" "}
+                                <span className="font-semibold">{submittedBy.displayName}</span>
+                            </div>
+                            <div
+                                className="text-[11px]"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    color: "var(--ed-ink-3)",
+                                    letterSpacing: "0.04em",
+                                }}
+                            >
+                                {timeAgo(lead._creationTime)}
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* Status — pill if read-only, dropdown if can change */}
+                <div className="flex items-center gap-3">
+                    <div
+                        className="text-[11px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        Status
+                    </div>
+                    {canChangeStatus ? (
+                        <select
+                            value={lead.status}
+                            onChange={async (e) => {
+                                try {
+                                    await updateStatus({ id: leadId, status: e.target.value as LeadStatus });
+                                } catch (err: any) {
+                                    alert(err?.message ?? "Failed to update status");
+                                }
+                            }}
+                            className="text-[12px] px-3 py-1.5 rounded-full"
+                            style={{
+                                background: STATUS_PILL_STYLES[lead.status]?.bg ?? "var(--ed-paper-2)",
+                                color: STATUS_PILL_STYLES[lead.status]?.ink ?? "var(--ed-ink)",
+                                border: "none",
+                                fontFamily: "var(--ed-mono)",
+                                letterSpacing: "0.08em",
+                                textTransform: "uppercase",
+                                fontWeight: 700,
+                            }}
+                        >
+                            {STATUS_OPTIONS.map((s) => (
+                                <option key={s} value={s}>{s}</option>
+                            ))}
+                        </select>
+                    ) : (
+                        <span
+                            className="text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded-full"
+                            style={{
+                                background: STATUS_PILL_STYLES[lead.status]?.bg ?? "var(--ed-paper-2)",
+                                color: STATUS_PILL_STYLES[lead.status]?.ink ?? "var(--ed-ink)",
+                            }}
+                        >
+                            {lead.status}
+                        </span>
+                    )}
+                </div>
+
+                {/* Admin social card (when curated content present) */}
+                {adminContent?.hasEnrichedContent && (
+                    <div
+                        className="rounded-2xl overflow-hidden"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        {adminContent.previewImageUrl && (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                                src={adminContent.previewImageUrl}
+                                alt=""
+                                className="w-full object-cover"
+                                style={{ maxHeight: 280 }}
+                            />
+                        )}
+                        <div className="p-4 space-y-3">
+                            {adminContent.description && (
+                                <p className="text-[14px]" style={{ color: "var(--ed-ink)", lineHeight: 1.5 }}>
+                                    {adminContent.description}
+                                </p>
+                            )}
+                            {adminContent.externalPreviewUrl && (
+                                <a
+                                    href={adminContent.externalPreviewUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-1.5 text-[13px]"
+                                    style={{ color: "var(--ed-accent)" }}
+                                >
+                                    <ExternalLink className="w-3.5 h-3.5" />
+                                    {adminContent.externalPreviewUrl}
+                                </a>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Lead contact (the customer who inquired) */}
+                {(lead.name || lead.phone || lead.email) && (
+                    <div
+                        className="rounded-2xl p-4 space-y-3"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <div
+                            className="text-[10px]"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: "var(--ed-ink-3)",
+                            }}
+                        >
+                            Customer Inquiry
+                        </div>
+                        {lead.name && (
+                            <div className="text-[15px] font-semibold" style={{ color: "var(--ed-ink)" }}>
+                                {lead.name}
+                            </div>
+                        )}
+                        <div className="flex flex-wrap gap-2">
+                            {lead.phone && (
+                                <a
+                                    href={`tel:${lead.phone.replace(/[^0-9+]/g, "")}`}
+                                    className="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-full"
+                                    style={{
+                                        background: "var(--ed-paper-2)",
+                                        color: "var(--ed-ink)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                >
+                                    <Phone className="w-3.5 h-3.5" /> {lead.phone}
+                                </a>
+                            )}
+                            {lead.email && (
+                                <a
+                                    href={`mailto:${lead.email}`}
+                                    className="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-full"
+                                    style={{
+                                        background: "var(--ed-paper-2)",
+                                        color: "var(--ed-ink)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                >
+                                    <Mail className="w-3.5 h-3.5" /> {lead.email}
+                                </a>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Business details */}
+                {business && (
+                    <div
+                        className="rounded-2xl p-4 space-y-3"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <div className="flex items-center gap-2 mb-1">
+                            <Building2 className="w-4 h-4" style={{ color: "var(--ed-accent)" }} />
+                            <div
+                                className="text-[10px]"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                Business Profile
+                            </div>
+                        </div>
+                        <h2
+                            style={{
+                                fontFamily: "var(--ed-serif)",
+                                fontSize: 22,
+                                color: "var(--ed-ink)",
+                                margin: 0,
+                                lineHeight: 1.15,
+                            }}
+                        >
+                            {business.businessName}
+                        </h2>
+                        {business.businessDescription && (
+                            <p className="text-[14px]" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                                {business.businessDescription}
+                            </p>
+                        )}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-[13px]">
+                            {business.ownerName && (
+                                <Field label="Owner" value={business.ownerName} />
+                            )}
+                            {business.ownerPhone && (
+                                <Field label="Phone" value={business.ownerPhone} link={`tel:${business.ownerPhone.replace(/[^0-9+]/g, "")}`} />
+                            )}
+                            {business.address && (
+                                <Field label="Address" value={business.address} full />
+                            )}
+                            {(business.barangay || business.city || business.province) && (
+                                <Field
+                                    label="Location"
+                                    value={[business.barangay, business.city, business.province].filter(Boolean).join(", ")}
+                                />
+                            )}
+                        </div>
+                        {business.websiteUrl && (
+                            <a
+                                href={business.websiteUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1.5 text-[13px]"
+                                style={{ color: "var(--ed-accent)" }}
+                            >
+                                <Globe className="w-3.5 h-3.5" /> {business.websiteUrl}
+                            </a>
+                        )}
+                    </div>
+                )}
+
+                {/* Other interviewers */}
+                {interviewers && interviewers.length > 1 && (
+                    <div
+                        className="rounded-2xl p-4 space-y-3"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <div
+                            className="text-[10px]"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: "var(--ed-ink-3)",
+                            }}
+                        >
+                            Other Interviewers · {interviewers.length}
+                        </div>
+                        <ul className="space-y-2.5">
+                            {interviewers.map((i: any) => (
+                                <li key={i.submissionId} className="flex items-center justify-between gap-3 text-[13px]">
+                                    <div className="flex items-center gap-2.5 min-w-0">
+                                        {i.creatorProfileImage ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img src={i.creatorProfileImage} alt="" className="w-7 h-7 rounded-full object-cover flex-shrink-0" />
+                                        ) : (
+                                            <div
+                                                className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] flex-shrink-0"
+                                                style={{
+                                                    background: "var(--ed-paper-2)",
+                                                    color: "var(--ed-ink)",
+                                                    fontFamily: "var(--ed-serif)",
+                                                    fontWeight: 500,
+                                                }}
+                                            >
+                                                {(i.creatorName ?? "?").slice(0, 1).toUpperCase()}
+                                            </div>
+                                        )}
+                                        <span className="truncate" style={{ color: "var(--ed-ink)" }}>
+                                            {i.creatorName}
+                                            {i.isMine && <span style={{ color: "var(--ed-accent)" }}> · mine</span>}
+                                        </span>
+                                    </div>
+                                    <span className="ed-label flex-shrink-0" style={{ color: "var(--ed-ink-3)" }}>
+                                        {timeAgo(i.interviewedAt)}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+
+                {/* Notes */}
+                <div
+                    className="rounded-2xl p-4 space-y-3"
+                    style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                >
+                    <div
+                        className="text-[10px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        Notes · {notes?.length ?? 0}
+                    </div>
+
+                    {/* Composer */}
+                    <div className="space-y-2">
+                        <textarea
+                            value={noteDraft}
+                            onChange={(e) => setNoteDraft(e.target.value)}
+                            placeholder="Add a follow-up note…"
+                            rows={3}
+                            className="w-full px-3 py-2.5 text-[14px] focus:outline-none resize-y"
+                            style={{
+                                background: "var(--ed-paper)",
+                                border: "1px solid var(--ed-rule)",
+                                borderRadius: 12,
+                                color: "var(--ed-ink)",
+                                fontFamily: "var(--ed-sans)",
+                            }}
+                        />
+                        <div className="flex justify-end">
+                            <button
+                                type="button"
+                                onClick={handlePostNote}
+                                disabled={posting || !noteDraft.trim()}
+                                className="inline-flex items-center gap-1.5 text-[11px] px-3.5 py-2 rounded-full disabled:opacity-50"
+                                style={{
+                                    background: "var(--ed-ink)",
+                                    color: "var(--ed-paper-3)",
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.08em",
+                                    textTransform: "uppercase",
+                                }}
+                            >
+                                {posting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Send className="w-3 h-3" />}
+                                Post note
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Notes list */}
+                    {notes && notes.length > 0 ? (
+                        <ul className="space-y-3 pt-2" style={{ borderTop: "1px solid var(--ed-rule)" }}>
+                            {notes.map((n: any) => (
+                                <li key={n._id} className="text-[14px]">
+                                    <div
+                                        className="text-[10px] mb-1"
+                                        style={{
+                                            fontFamily: "var(--ed-mono)",
+                                            color: "var(--ed-ink-3)",
+                                            letterSpacing: "0.04em",
+                                        }}
+                                    >
+                                        {timeAgo(n.createdAt)}
+                                    </div>
+                                    <p style={{ color: "var(--ed-ink)", whiteSpace: "pre-wrap" }}>{n.content}</p>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-[12px] italic" style={{ color: "var(--ed-ink-3)" }}>
+                            No notes yet. Be the first to add one.
+                        </p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Field({
+    label, value, full, link,
+}: {
+    label: string;
+    value: string | null | undefined;
+    full?: boolean;
+    link?: string;
+}) {
+    if (!value) return null;
+    const inner = (
+        <>
+            <div
+                className="text-[10px] mb-0.5"
+                style={{
+                    fontFamily: "var(--ed-mono)",
+                    color: "var(--ed-ink-3)",
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                }}
+            >
+                {label}
+            </div>
+            <div style={{ color: link ? "var(--ed-accent)" : "var(--ed-ink)" }}>{value}</div>
+        </>
+    );
+    return (
+        <div className={full ? "sm:col-span-2" : ""}>
+            {link ? (
+                <a href={link} style={{ textDecoration: "none" }}>
+                    {inner}
+                </a>
+            ) : (
+                inner
+            )}
+        </div>
+    );
+}

--- a/app/leads/near/page.tsx
+++ b/app/leads/near/page.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+/**
+ * /leads/near — "Businesses near you" view.
+ *
+ * Reads `api.leads.listForMap` for every lead with resolvable lat/lng, then
+ * computes haversine distance from the user's browser geolocation and renders
+ * a "nearest first" list. The map is a single iframe centered on the user's
+ * location (or Philippines fallback) using the same Google Maps embed pattern
+ * the Astro site uses — no API key required.
+ */
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { ArrowLeft, Loader2, MapPin, Building2, ExternalLink } from "lucide-react";
+
+const PH_CENTER = { lat: 14.5995, lng: 120.9842 }; // Manila — used when geolocation unavailable
+
+function haversineKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+    const R = 6371; // Earth radius in km
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const dLat = toRad(b.lat - a.lat);
+    const dLng = toRad(b.lng - a.lng);
+    const sin1 = Math.sin(dLat / 2);
+    const sin2 = Math.sin(dLng / 2);
+    const h = sin1 * sin1 + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sin2 * sin2;
+    return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+function formatDistance(km: number): string {
+    if (km < 1) return `${Math.round(km * 1000)} m`;
+    if (km < 10) return `${km.toFixed(1)} km`;
+    return `${Math.round(km)} km`;
+}
+
+export default function BusinessesNearYouPage() {
+    const router = useRouter();
+    const { user, isLoaded, isSignedIn } = useUser();
+
+    const creator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip",
+    );
+
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) router.push("/login");
+    }, [isLoaded, isSignedIn, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
+    }, [isLoaded, isSignedIn, creator, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
+            router.replace("/training");
+        }
+    }, [isLoaded, isSignedIn, creator, router]);
+
+    const ready =
+        isLoaded && isSignedIn && creator !== undefined && !!creator && (creator.role === "admin" || !!creator.certifiedAt);
+
+    const [userLoc, setUserLoc] = useState<{ lat: number; lng: number } | null>(null);
+    const [locError, setLocError] = useState<string | null>(null);
+    const [locRequesting, setLocRequesting] = useState(false);
+
+    // Ask for browser geolocation once on mount. We don't block rendering — if
+    // the user denies, we fall back to PH center and show all leads unsorted.
+    useEffect(() => {
+        if (!ready) return;
+        if (typeof window === "undefined" || !navigator.geolocation) {
+            setLocError("Geolocation not available in this browser.");
+            return;
+        }
+        setLocRequesting(true);
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                setUserLoc({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+                setLocRequesting(false);
+            },
+            (err) => {
+                setLocError(err?.message ?? "Couldn't get your location.");
+                setLocRequesting(false);
+            },
+            { enableHighAccuracy: false, timeout: 8000, maximumAge: 5 * 60_000 },
+        );
+    }, [ready]);
+
+    const mappable = useQuery(api.leads.listForMap, ready ? {} : "skip");
+
+    const sorted = useMemo(() => {
+        if (!mappable) return undefined;
+        const origin = userLoc ?? PH_CENTER;
+        return mappable
+            .map((m: any) => ({
+                ...m,
+                distanceKm: haversineKm(origin, { lat: m.lat, lng: m.lng }),
+            }))
+            .sort((a: any, b: any) => a.distanceKm - b.distanceKm);
+    }, [mappable, userLoc]);
+
+    if (!ready) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+            </div>
+        );
+    }
+
+    const mapCenter = userLoc ?? PH_CENTER;
+    const mapQuery = userLoc
+        ? `${mapCenter.lat},${mapCenter.lng}`
+        : "Philippines";
+    const mapEmbedSrc = `https://maps.google.com/maps?q=${encodeURIComponent(mapQuery)}&z=${userLoc ? 13 : 6}&hl=en&output=embed`;
+
+    return (
+        <div
+            className="min-h-screen pb-24"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
+            <div className="max-w-2xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6">
+                {/* Header */}
+                <div className="flex items-center gap-3 mb-6">
+                    <Link
+                        href="/leads"
+                        className="w-9 h-9 rounded-full inline-flex items-center justify-center transition-colors"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <ArrowLeft className="w-4 h-4" style={{ color: "var(--ed-ink-2)" }} />
+                    </Link>
+                    <div className="flex items-center gap-2 text-[11px]" style={{
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}>
+                        <span>03 / Near You</span>
+                        <span>·</span>
+                        <span className="inline-flex items-center gap-1.5" style={{ color: "var(--ed-accent)" }}>
+                            <span className="ed-live-dot" /> Live
+                        </span>
+                    </div>
+                </div>
+
+                <h1
+                    className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
+                    style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
+                >
+                    Businesses{" "}
+                    <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>near you.</em>
+                </h1>
+                <p className="text-[14px] mb-5" style={{ color: "var(--ed-ink-2)" }}>
+                    {mappable === undefined
+                        ? "Loading mappable leads…"
+                        : `${mappable.length} mappable lead${mappable.length === 1 ? "" : "s"}.`}
+                </p>
+
+                {/* Permission / fallback banner */}
+                {locError && (
+                    <div
+                        className="rounded-2xl px-4 py-3 mb-4 text-[13px]"
+                        style={{
+                            background: "var(--ed-status-contacted-bg, #FBE9C4)",
+                            color: "var(--ed-status-contacted-ink, #C68A12)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        Showing distances from Manila (default) — enable location access in your browser for accurate &quot;nearest&quot; sorting.
+                    </div>
+                )}
+                {locRequesting && !userLoc && (
+                    <div
+                        className="rounded-2xl px-4 py-3 mb-4 text-[13px] flex items-center gap-2"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        Requesting your location…
+                    </div>
+                )}
+
+                {/* Map */}
+                <div
+                    className="rounded-2xl overflow-hidden mb-5"
+                    style={{ border: "1px solid var(--ed-rule)" }}
+                >
+                    <iframe
+                        title="Map"
+                        src={mapEmbedSrc}
+                        loading="lazy"
+                        referrerPolicy="no-referrer-when-downgrade"
+                        style={{ width: "100%", height: 320, border: 0 }}
+                    />
+                </div>
+
+                {/* Nearest-first label */}
+                <div className="flex items-center justify-between mb-3">
+                    <div
+                        className="text-[10px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        Nearest first
+                    </div>
+                    <div
+                        className="text-[10px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        {sorted ? `${sorted.length} pinned` : "—"}
+                    </div>
+                </div>
+
+                {/* List */}
+                {sorted === undefined ? (
+                    <div className="space-y-3">
+                        {Array.from({ length: 4 }).map((_, i) => (
+                            <div
+                                key={i}
+                                className="animate-pulse rounded-2xl"
+                                style={{ background: "var(--ed-paper-2)", height: 90 }}
+                            />
+                        ))}
+                    </div>
+                ) : sorted.length === 0 ? (
+                    <div
+                        className="rounded-2xl py-10 px-6 text-center"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <MapPin className="w-9 h-9 mx-auto mb-3" style={{ color: "var(--ed-accent)" }} />
+                        <h3 style={{ fontFamily: "var(--ed-serif)", fontSize: 24, color: "var(--ed-ink)" }}>
+                            Nothing to pin yet.
+                        </h3>
+                        <p className="text-[14px] mt-2" style={{ color: "var(--ed-ink-2)" }}>
+                            Leads with location data will appear here once the team submits them with coordinates.
+                        </p>
+                    </div>
+                ) : (
+                    <ul className="space-y-3">
+                        {sorted.map((row: any) => (
+                            <li key={String(row._id)}>
+                                <Link
+                                    href={`/leads/${row._id}`}
+                                    className="block rounded-2xl p-3.5 transition-colors hover:bg-white"
+                                    style={{
+                                        background: "var(--ed-paper-3)",
+                                        border: "1px solid var(--ed-rule)",
+                                        textDecoration: "none",
+                                        color: "inherit",
+                                    }}
+                                >
+                                    <div className="flex items-start gap-3">
+                                        <div
+                                            className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                                            style={{ background: "var(--ed-paper-2)" }}
+                                        >
+                                            <Building2 className="w-5 h-5" style={{ color: "var(--ed-ink-2)" }} />
+                                        </div>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="text-[15px] font-semibold truncate" style={{ color: "var(--ed-ink)" }}>
+                                                {row.businessName}
+                                            </div>
+                                            {(row.businessAddress || row.businessCity) && (
+                                                <div className="text-[12px] mt-0.5" style={{ color: "var(--ed-ink-3)", lineHeight: 1.4 }}>
+                                                    {row.businessAddress ?? row.businessCity}
+                                                </div>
+                                            )}
+                                            {row.submittedBy && (
+                                                <div
+                                                    className="flex items-center gap-1.5 mt-2 text-[10px]"
+                                                    style={{
+                                                        fontFamily: "var(--ed-mono)",
+                                                        color: "var(--ed-ink-3)",
+                                                        letterSpacing: "0.08em",
+                                                        textTransform: "uppercase",
+                                                    }}
+                                                >
+                                                    {row.submittedBy.profileImage ? (
+                                                        // eslint-disable-next-line @next/next/no-img-element
+                                                        <img
+                                                            src={row.submittedBy.profileImage}
+                                                            alt=""
+                                                            className="w-4 h-4 rounded-full object-cover"
+                                                        />
+                                                    ) : (
+                                                        <span
+                                                            className="w-4 h-4 rounded-full inline-flex items-center justify-center text-[8px]"
+                                                            style={{ background: "var(--ed-paper-2)", color: "var(--ed-ink)" }}
+                                                        >
+                                                            {(row.submittedBy.displayName ?? "?").slice(0, 1).toUpperCase()}
+                                                        </span>
+                                                    )}
+                                                    Submitted by {row.submittedBy.displayName}
+                                                </div>
+                                            )}
+                                        </div>
+                                        <div className="text-right flex-shrink-0">
+                                            <div
+                                                style={{
+                                                    fontFamily: "var(--ed-serif)",
+                                                    fontSize: 18,
+                                                    color: "var(--ed-ink)",
+                                                    lineHeight: 1.1,
+                                                    fontVariantNumeric: "tabular-nums",
+                                                }}
+                                            >
+                                                {formatDistance(row.distanceKm)}
+                                            </div>
+                                            <a
+                                                href={`https://www.google.com/maps/search/?api=1&query=${row.lat},${row.lng}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                onClick={(e) => e.stopPropagation()}
+                                                className="inline-flex items-center gap-1 mt-1 text-[10px]"
+                                                style={{ color: "var(--ed-accent)" }}
+                                            >
+                                                <ExternalLink className="w-2.5 h-2.5" /> Map
+                                            </a>
+                                        </div>
+                                    </div>
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -1,0 +1,567 @@
+"use client";
+
+/**
+ * /leads — Creator-side Lead CRM feed.
+ *
+ * Mirrors the mobile app's leads index (`ndm/app/(app)/leads/index.tsx`).
+ * Reads the team-wide social feed via `api.leads.listForMobileCRM` and
+ * renders it as scrollable cards with submitter attribution + status pill.
+ * Linked to the dashboard's "STEP 02 / TEAM LEADS" card.
+ *
+ * Spec: docs/changes/WEB-BUILD-CRM.md (Creators platform integration).
+ */
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { BottomNav } from "@/components/BottomNav";
+import {
+    ArrowLeft, Search, Map as MapIcon, Building2, Loader2, ChevronRight, Star,
+} from "lucide-react";
+
+// ── Types + constants ─────────────────────────────────────────────────────
+type LeadStatus = "new" | "contacted" | "qualified" | "converted" | "lost";
+const STATUS_OPTIONS: LeadStatus[] = ["new", "contacted", "qualified", "converted", "lost"];
+type StatusFilter = "all" | LeadStatus;
+
+const STATUS_PILL_STYLES: Record<string, { bg: string; ink: string }> = {
+    new:       { bg: "var(--ed-status-new-bg, #E4E9F0)",       ink: "var(--ed-status-new-ink, #1F3654)" },
+    contacted: { bg: "var(--ed-status-contacted-bg, #FBE9C4)", ink: "var(--ed-status-contacted-ink, #C68A12)" },
+    qualified: { bg: "var(--ed-status-qualified-bg, #EDE9FE)", ink: "var(--ed-status-qualified-ink, #6D28D9)" },
+    converted: { bg: "var(--ed-status-converted-bg, #D1FAE5)", ink: "var(--ed-status-converted-ink, #064E3B)" },
+    lost:      { bg: "var(--ed-status-lost-bg, #F3D7CF)",      ink: "var(--ed-status-lost-ink, #B43A1F)" },
+};
+
+function timeAgo(ts: number | null | undefined): string {
+    if (!ts) return "—";
+    const diff = Date.now() - ts;
+    const min = Math.floor(diff / 60_000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    return `${Math.floor(hr / 24)}d ago`;
+}
+
+function formatDateShort(ts: number | null | undefined): string {
+    if (!ts) return "—";
+    const d = new Date(ts);
+    return d.toLocaleDateString("en-US", { month: "numeric", day: "numeric", year: "numeric" });
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────
+export default function CreatorLeadsPage() {
+    const router = useRouter();
+    const { user, isLoaded, isSignedIn } = useUser();
+
+    const creator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip",
+    );
+
+    // Same redirect guards as /dashboard so users land in the right place.
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) router.push("/login");
+    }, [isLoaded, isSignedIn, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
+    }, [isLoaded, isSignedIn, creator, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator && creator.role === "admin") router.push("/admin");
+    }, [isLoaded, isSignedIn, creator, router]);
+    useEffect(() => {
+        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
+            router.replace("/training");
+        }
+    }, [isLoaded, isSignedIn, creator, router]);
+
+    // UI state
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+    const [onlyMine, setOnlyMine] = useState(false);
+    const [searchInput, setSearchInput] = useState("");
+    const [debouncedSearch, setDebouncedSearch] = useState("");
+
+    // 300ms debounce — matches the spec.
+    useEffect(() => {
+        const t = setTimeout(() => setDebouncedSearch(searchInput.trim()), 300);
+        return () => clearTimeout(t);
+    }, [searchInput]);
+
+    const feed = useQuery(
+        api.leads.listForMobileCRM,
+        isSignedIn && creator
+            ? {
+                  search: debouncedSearch || undefined,
+                  statusFilter,
+                  onlyMine,
+              }
+            : "skip",
+    );
+
+    const ready =
+        isLoaded &&
+        isSignedIn &&
+        creator !== undefined &&
+        !!creator &&
+        creator.role !== "admin" &&
+        !!creator.certifiedAt;
+
+    if (!ready) {
+        return (
+            <div
+                className="min-h-screen flex items-center justify-center"
+                style={{ background: "var(--ed-paper)" }}
+            >
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+            </div>
+        );
+    }
+
+    const stats = feed?.stats;
+    const leads = feed?.leads ?? [];
+    const hotCount = useMemo(() => leads.filter((l: any) => l.isHot).length, [leads]);
+
+    return (
+        <div
+            className="editorial min-h-screen pb-28 overflow-x-hidden"
+            style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+        >
+            <div className="max-w-2xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6">
+                {/* Header */}
+                <div className="flex items-center gap-3 mb-6">
+                    <Link
+                        href="/dashboard"
+                        className="w-9 h-9 rounded-full inline-flex items-center justify-center transition-colors"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <ArrowLeft className="w-4 h-4" style={{ color: "var(--ed-ink-2)" }} />
+                    </Link>
+                    <div className="flex items-center gap-2 text-[11px]" style={{
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}>
+                        <span>03 / Team Leads</span>
+                        <span>·</span>
+                        <span className="inline-flex items-center gap-1.5" style={{ color: "var(--ed-accent)" }}>
+                            <span className="ed-live-dot" /> Live
+                        </span>
+                    </div>
+                </div>
+
+                {/* Editorial display */}
+                <h1
+                    className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
+                    style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
+                >
+                    All leads,{" "}
+                    <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>every interview.</em>
+                </h1>
+                <p className="text-[15px] mb-6" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                    The whole team&apos;s hunt — including yours. {stats?.total ?? 0} lead{(stats?.total ?? 0) === 1 ? "" : "s"} · {hotCount} hot.
+                </p>
+
+                {/* Stats cards (TOTAL · YOURS · HOT LEADS) */}
+                <div className="grid grid-cols-3 gap-2 sm:gap-3 mb-5">
+                    <StatCard
+                        label="Total"
+                        value={stats?.total ?? 0}
+                        dotColor="var(--ed-ink)"
+                    />
+                    <StatCard
+                        label="Yours"
+                        value={stats?.mine ?? 0}
+                        dotColor="var(--ed-ink)"
+                    />
+                    <StatCard
+                        label="Hot Leads"
+                        sublabel="3+ interviews"
+                        value={hotCount}
+                        dotColor="var(--ed-danger)"
+                    />
+                </div>
+
+                {/* Search */}
+                <div className="relative mb-4">
+                    <Search
+                        className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4"
+                        style={{ color: "var(--ed-ink-3)" }}
+                    />
+                    <input
+                        type="text"
+                        value={searchInput}
+                        onChange={(e) => setSearchInput(e.target.value)}
+                        placeholder="Search lead, business, or creator…"
+                        className="w-full pl-11 pr-4 py-3.5 text-[15px] focus:outline-none transition-colors"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            border: "1px solid var(--ed-rule)",
+                            borderRadius: 16,
+                            fontFamily: "var(--ed-sans)",
+                            color: "var(--ed-ink)",
+                        }}
+                    />
+                </div>
+
+                {/* Primary CTA — Businesses near me (map view) */}
+                <Link
+                    href="/leads/near"
+                    className="block mb-3 rounded-2xl px-5 py-4 flex items-center justify-between transition-opacity hover:opacity-95"
+                    style={{ background: "var(--ed-accent-solid, #10B981)", color: "#fff" }}
+                >
+                    <div>
+                        <div
+                            className="text-[10px] mb-1"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                opacity: 0.75,
+                            }}
+                        >
+                            On the map
+                        </div>
+                        <div className="text-[18px] font-semibold">Businesses near me</div>
+                    </div>
+                    <MapIcon className="w-6 h-6" />
+                </Link>
+
+                {/* Filter pills row */}
+                <div className="-mx-4 sm:mx-0 mb-5">
+                    <div className="flex items-center gap-2 overflow-x-auto px-4 sm:px-0 pb-1 no-scrollbar">
+                        <FilterPill
+                            label="Only mine"
+                            active={onlyMine}
+                            onClick={() => setOnlyMine((v) => !v)}
+                        />
+                        {(["all", ...STATUS_OPTIONS] as const).map((s) => {
+                            const active = !onlyMine && statusFilter === s;
+                            return (
+                                <FilterPill
+                                    key={s}
+                                    label={s}
+                                    active={active}
+                                    onClick={() => {
+                                        setStatusFilter(s);
+                                    }}
+                                />
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Feed */}
+                {feed === undefined ? (
+                    <div className="space-y-3">
+                        {Array.from({ length: 3 }).map((_, i) => (
+                            <div
+                                key={i}
+                                className="animate-pulse rounded-2xl"
+                                style={{ background: "var(--ed-paper-2)", height: 160 }}
+                            />
+                        ))}
+                    </div>
+                ) : leads.length === 0 ? (
+                    <EmptyState
+                        title={debouncedSearch || statusFilter !== "all" || onlyMine ? "No matches." : "Nothing yet."}
+                        body={
+                            debouncedSearch || statusFilter !== "all" || onlyMine
+                                ? "Try a different filter or clear the search."
+                                : "The team's leads will appear here as soon as someone submits a business."
+                        }
+                        cta={
+                            debouncedSearch || statusFilter !== "all" || onlyMine
+                                ? null
+                                : { label: "Submit a business", href: "/submit/info" }
+                        }
+                    />
+                ) : (
+                    <div className="space-y-3">
+                        {leads.map((lead: any) => (
+                            <LeadCard key={String(lead._id)} lead={lead} />
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <BottomNav active="home" />
+        </div>
+    );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+function StatCard({
+    label, sublabel, value, dotColor,
+}: {
+    label: string;
+    sublabel?: string;
+    value: number;
+    dotColor: string;
+}) {
+    return (
+        <div
+            className="rounded-2xl px-3 py-3"
+            style={{
+                background: "var(--ed-paper-3)",
+                border: "1px solid var(--ed-rule)",
+            }}
+        >
+            <div className="flex items-center gap-1.5 mb-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: dotColor }} />
+                <span
+                    className="text-[10px]"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.12em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}
+                >
+                    {label}
+                </span>
+            </div>
+            <div
+                style={{
+                    fontFamily: "var(--ed-serif)",
+                    fontSize: 28,
+                    lineHeight: 1.05,
+                    color: "var(--ed-ink)",
+                    fontVariantNumeric: "tabular-nums",
+                }}
+            >
+                {value}
+            </div>
+            {sublabel && (
+                <div
+                    className="text-[10px] mt-0.5"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        color: "var(--ed-ink-3)",
+                        letterSpacing: "0.08em",
+                    }}
+                >
+                    {sublabel}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function FilterPill({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[11px] flex-shrink-0 transition-colors"
+            style={{
+                background: active ? "var(--ed-ink)" : "transparent",
+                color: active ? "var(--ed-paper-3)" : "var(--ed-ink-2)",
+                border: `1px solid ${active ? "var(--ed-ink)" : "var(--ed-rule)"}`,
+                fontFamily: "var(--ed-mono)",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                fontWeight: 600,
+            }}
+        >
+            {label}
+        </button>
+    );
+}
+
+function LeadCard({ lead }: { lead: any }) {
+    return (
+        <Link
+            href={`/leads/${lead._id}`}
+            className="block rounded-2xl p-4 transition-colors hover:bg-white"
+            style={{
+                background: "var(--ed-paper-3)",
+                border: "1px solid var(--ed-rule)",
+                textDecoration: "none",
+                color: "inherit",
+            }}
+        >
+            {/* Submitter strip */}
+            {lead.submittedBy && (
+                <div className="flex items-center gap-2.5 mb-3">
+                    {lead.submittedBy.profileImage ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            src={lead.submittedBy.profileImage}
+                            alt=""
+                            className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                        />
+                    ) : (
+                        <div
+                            className="w-8 h-8 rounded-full flex items-center justify-center text-[11px] flex-shrink-0"
+                            style={{
+                                background: "var(--ed-paper-2)",
+                                color: "var(--ed-ink)",
+                                fontFamily: "var(--ed-serif)",
+                                fontWeight: 500,
+                            }}
+                        >
+                            {(lead.submittedBy.displayName ?? "?").slice(0, 1).toUpperCase()}
+                        </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                        <div className="text-[14px] font-semibold truncate" style={{ color: "var(--ed-ink)" }}>
+                            {lead.submittedBy.displayName}
+                        </div>
+                        <div
+                            className="text-[11px]"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                color: "var(--ed-ink-3)",
+                                letterSpacing: "0.04em",
+                            }}
+                        >
+                            submitted this · {formatDateShort(lead._creationTime)}
+                        </div>
+                    </div>
+                    {lead.isHot && (
+                        <span
+                            className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full flex-shrink-0"
+                            style={{
+                                background: "var(--ed-status-lost-bg, #F3D7CF)",
+                                color: "var(--ed-danger)",
+                            }}
+                        >
+                            <Star className="w-2.5 h-2.5 fill-current" /> Hot
+                        </span>
+                    )}
+                </div>
+            )}
+
+            {/* Lead inquired-by row */}
+            {(lead.name || lead.phone || lead.email) && (
+                <div className="flex items-start gap-2.5 mb-3">
+                    <div
+                        className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0"
+                        style={{
+                            background: "var(--ed-paper-2)",
+                            color: "var(--ed-ink)",
+                            fontFamily: "var(--ed-serif)",
+                            fontWeight: 500,
+                            fontSize: 13,
+                        }}
+                    >
+                        {(lead.name ?? "?").slice(0, 1).toUpperCase()}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        {lead.name && (
+                            <div className="text-[14px]" style={{ color: "var(--ed-ink)" }}>
+                                <span className="font-semibold">{lead.name}</span>
+                                <span style={{ color: "var(--ed-ink-3)" }}> · inquired</span>
+                            </div>
+                        )}
+                        <div
+                            className="text-[11px] flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5"
+                            style={{
+                                fontFamily: "var(--ed-mono)",
+                                color: "var(--ed-ink-3)",
+                            }}
+                        >
+                            {lead.phone && <span>{lead.phone}</span>}
+                            {lead.phone && lead.email && <span>·</span>}
+                            {lead.email && <span className="truncate max-w-[200px]">{lead.email}</span>}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Divider */}
+            <hr className="border-t" style={{ borderColor: "var(--ed-rule)" }} />
+
+            {/* Business + status */}
+            <div className="flex items-center justify-between gap-3 mt-3">
+                <div className="flex items-center gap-2 min-w-0">
+                    <Building2 className="w-4 h-4 flex-shrink-0" style={{ color: "var(--ed-ink-3)" }} />
+                    <div className="text-[14px] truncate" style={{ color: "var(--ed-ink)" }}>
+                        {lead.businessName}
+                        {lead.businessCity && (
+                            <span style={{ color: "var(--ed-ink-3)" }}> · {lead.businessCity}</span>
+                        )}
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                    <StatusPill status={lead.status} />
+                    <ChevronRight className="w-4 h-4" style={{ color: "var(--ed-ink-3)" }} />
+                </div>
+            </div>
+
+            {/* Interviewer count + admin-curated indicator */}
+            {(lead.interviewerCount > 1 || lead.hasEnrichedContent) && (
+                <div
+                    className="mt-2 flex items-center gap-2 text-[11px]"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        color: "var(--ed-ink-3)",
+                        letterSpacing: "0.04em",
+                    }}
+                >
+                    {lead.interviewerCount > 1 && (
+                        <span>{lead.interviewerCount} interviewers</span>
+                    )}
+                    {lead.hasEnrichedContent && lead.interviewerCount > 1 && <span>·</span>}
+                    {lead.hasEnrichedContent && <span style={{ color: "var(--ed-accent)" }}>Curated</span>}
+                </div>
+            )}
+        </Link>
+    );
+}
+
+function StatusPill({ status }: { status: string }) {
+    const colors = STATUS_PILL_STYLES[status] ?? { bg: "var(--ed-paper-2)", ink: "var(--ed-ink-2)" };
+    return (
+        <span
+            className="inline-flex items-center text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full"
+            style={{ background: colors.bg, color: colors.ink }}
+        >
+            {status}
+        </span>
+    );
+}
+
+function EmptyState({
+    title, body, cta,
+}: {
+    title: string;
+    body: string;
+    cta: { label: string; href: string } | null;
+}) {
+    return (
+        <div
+            className="rounded-2xl py-10 px-6 text-center"
+            style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+        >
+            <Building2 className="w-9 h-9 mx-auto mb-3" style={{ color: "var(--ed-accent)" }} />
+            <h3
+                style={{ fontFamily: "var(--ed-serif)", fontSize: 24, color: "var(--ed-ink)", lineHeight: 1.1 }}
+            >
+                {title}
+            </h3>
+            <p className="text-[14px] mt-2" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                {body}
+            </p>
+            {cta && (
+                <Link
+                    href={cta.href}
+                    className="inline-flex items-center gap-1.5 mt-4 text-[12px] px-4 py-2.5 rounded-full"
+                    style={{
+                        background: "var(--ed-ink)",
+                        color: "var(--ed-paper-3)",
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    {cta.label}
+                </Link>
+            )}
+        </div>
+    );
+}

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -448,6 +448,107 @@ export const listForMobileCRM = query({
     },
 });
 
+/**
+ * Minimal coordinates feed used by the creator-side "Businesses near me" map
+ * view. Returns every lead that has resolvable lat/lng — either from a linked
+ * submission (`submission.coordinates`) or from an Outscraper prospect
+ * (`businessLatitude`/`businessLongitude`). Auth is the same as
+ * listForMobileCRM (any signed-in identity).
+ *
+ * Kept additive and read-only on purpose — mobile callers don't see this
+ * query and the existing CRM queries aren't touched.
+ */
+export const listForMap = query({
+    args: {},
+    handler: async (ctx) => {
+        await requireIdentity(ctx);
+
+        const allLeads = await ctx.db.query('leads').order('desc').collect();
+
+        // Cache submissions/creators so we don't re-fetch per row.
+        const allSubmissions = await ctx.db.query('submissions').collect();
+        const submissionCache = new Map<string, any>();
+        for (const sub of allSubmissions) submissionCache.set(String(sub._id), sub);
+        const creatorCache = new Map<string, any>();
+
+        const result: Array<{
+            _id: any;
+            businessName: string;
+            businessAddress: string | null;
+            businessCity: string | null;
+            lat: number;
+            lng: number;
+            status: string;
+            source: string;
+            hasSubmission: boolean;
+            submittedBy: {
+                creatorId: string;
+                displayName: string;
+                profileImage: string | null;
+            } | null;
+        }> = [];
+
+        for (const lead of allLeads) {
+            const sub = lead.submissionId
+                ? submissionCache.get(String(lead.submissionId))
+                : null;
+
+            // Resolve coords from submission first, then Outscraper fields.
+            let lat: number | null = null;
+            let lng: number | null = null;
+            if (sub?.coordinates?.lat != null && sub?.coordinates?.lng != null) {
+                lat = sub.coordinates.lat;
+                lng = sub.coordinates.lng;
+            } else if (lead.businessLatitude != null && lead.businessLongitude != null) {
+                lat = lead.businessLatitude;
+                lng = lead.businessLongitude;
+            }
+            if (lat == null || lng == null) continue;
+
+            // Pick a display name; fall back through known fields.
+            const businessName =
+                sub?.businessName ?? lead.businessName ?? '(unnamed business)';
+            const businessAddress = sub?.address ?? lead.businessAddress ?? null;
+            const businessCity = sub?.city ?? lead.businessCity ?? null;
+
+            let submittedBy: {
+                creatorId: string;
+                displayName: string;
+                profileImage: string | null;
+            } | null = null;
+            if (lead.creatorId) {
+                let c = creatorCache.get(String(lead.creatorId));
+                if (!c) {
+                    c = await ctx.db.get(lead.creatorId);
+                    if (c) creatorCache.set(String(lead.creatorId), c);
+                }
+                if (c) {
+                    submittedBy = {
+                        creatorId: String(c._id),
+                        displayName: formatCreatorDisplayName(c.firstName, c.lastName),
+                        profileImage: c.profileImage ?? null,
+                    };
+                }
+            }
+
+            result.push({
+                _id: lead._id,
+                businessName,
+                businessAddress,
+                businessCity,
+                lat,
+                lng,
+                status: lead.status,
+                source: lead.source,
+                hasSubmission: !!sub,
+                submittedBy,
+            });
+        }
+
+        return result;
+    },
+});
+
 export const getDetailForMobileCRM = query({
     args: { id: v.id('leads') },
     handler: async (ctx, args) => {

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -1,0 +1,386 @@
+# Web-side Lead CRM — Creators platform integration
+
+> **Sister doc to [WEB-SYNC-MOBILE-FEATURES.md](./WEB-SYNC-MOBILE-FEATURES.md).** That doc covers the *admin* surfaces (Pending Approval queue, Lead Content editor). This doc covers the **public-facing web Creators platform** — the page that signed-in creators visit on the web (not admin) to view, search, and manage leads alongside the mobile app.
+>
+> Single source of truth for the web Creators platform's "Leads" page (URL: `/creators/leads` or `/dashboard/leads`, exact slug owned by web team). Mirrors mobile's `app/(app)/leads/*` 1:1 in behavior, and adopts the Editorial Paper design system (greens + khaki — NOT orange/terracotta) so the web and mobile apps feel like one product.
+
+---
+
+## Why this needs to exist
+
+Today, mobile creators can:
+- See the team-wide social feed of leads at `app/(app)/leads/index.tsx`
+- Drill into a single lead at `app/(app)/leads/[leadId].tsx`
+- See admin-curated social-card content when present
+- Filter, search, and "Only mine" the list
+
+Web creators can do **none** of this. The web Creators platform's existing screens (Home, Referrals, Wallet, Profile) have no Leads tab, even though the Convex queries `listForMobileCRM` and `getDetailForMobileCRM` are deployed in prod and would work the same way from the web client.
+
+Goal: ship a `/creators/leads` route on the web that's feature-equivalent to mobile's leads tab, using the same Convex queries (no new backend), styled in the Editorial Paper system to match mobile's redesign.
+
+---
+
+## Out of scope (explicit)
+
+- Admin surfaces — those are covered in [WEB-SYNC-MOBILE-FEATURES.md Step 10](./WEB-SYNC-MOBILE-FEATURES.md). The admin uses `getDetailForAdmin` + `updateAdminContent`. The Creators page uses `listForMobileCRM` + `getDetailForMobileCRM`. Different consumers, different routes.
+- Schema changes — none. Everything is already deployed.
+- New Convex functions — none. The queries the mobile app already calls are the contract.
+- Submissions, Wallet, Referrals web pages — separate redesign work. This doc is leads-only.
+- Native push notifications on web — out of scope for v1.
+
+---
+
+## Convex contract (frozen — do not modify)
+
+All four functions below are already deployed to `prod:energetic-panther-693`. The web Creators page must call them with the **exact** argument shapes shown.
+
+### Read: list view
+
+```typescript
+api.leads.listForMobileCRM({
+  search?: string,
+  statusFilter?: "all" | "new" | "contacted" | "qualified" | "converted" | "lost",
+  onlyMine?: boolean,
+})
+```
+
+**Returns** `{ leads: EnrichedLead[], stats: { total, new, contacted, qualified, converted, lost, mine } }`.
+
+Each `EnrichedLead` carries: `_id`, `name`, `phone`, `email`, `source`, `status`, `createdAt`, `businessName`, `businessType`, `businessCity`, `interviewerCount`, `submittedBy: { creatorId, displayName, profileImage }`, `isMine`, `isHot` (interviewerCount ≥ 3), and the admin content fields (`adminDescription`, `previewImageUrl`, `externalPreviewUrl`, `hasEnrichedContent`).
+
+Auth: requires a signed-in Convex identity. Anonymous users get `{ leads: [], stats: { total: 0, ... } }`.
+
+### Read: detail view
+
+```typescript
+api.leads.getDetailForMobileCRM({ id: Id<"leads"> })
+```
+
+**Returns** `{ lead, submittedBy, isMine, business, adminContent, interviewers, interviewerCount, notes }` or `null` if not found.
+
+### Write: add note
+
+```typescript
+api.leadNotes.add({ leadId: Id<"leads">, content: string })
+```
+
+Web should mirror mobile's behavior — any signed-in creator can post a note on any lead.
+
+### Write: update status
+
+```typescript
+api.leads.updateStatus({ id: Id<"leads">, status: "new" | "contacted" | "qualified" | "converted" | "lost" })
+```
+
+Mobile gates this to "only the original submitter or admin can change status" — replicate that gate client-side too (use `isMine` from the detail payload; admin elevation is via Clerk roles, same as everywhere else).
+
+---
+
+## Page architecture (web)
+
+Two routes under the existing authenticated Creators platform shell:
+
+| Route | Purpose | Convex calls |
+|---|---|---|
+| `/creators/leads` | List view — filters, search, social-card cards | `listForMobileCRM` |
+| `/creators/leads/[leadId]` | Detail view — full lead, interviewers, notes | `getDetailForMobileCRM`, `leadNotes.add`, `leads.updateStatus` |
+
+Both routes should be **server-rendered shell + client-rendered data** (Next.js App Router pattern) so the page paints fast and Convex hydrates the live data.
+
+---
+
+## List page UX spec (`/creators/leads`)
+
+Visual reference: mobile's `app/(app)/leads/index.tsx`. The web should be the desktop expansion of that pattern, NOT a separate design language.
+
+### Above-the-fold
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  STEP 03 / TEAM LEADS                          ● LIVE             │
+│                                                                    │
+│  All leads,                                                        │
+│  every interview.                ← Display: Instrument Serif       │
+│                                                                    │
+│  The whole team's hunt — including yours.                         │
+│  Last sync: 12s ago · 38 leads · 6 hot                            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- Eyebrow: mono `STEP 03 / TEAM LEADS` (matches the auth page eyebrow pattern)
+- Live dot pulses next to "LIVE" if Convex socket connected
+- Display headline: Instrument Serif, two-line. The italic word (here: "every") is `colors.accent` emerald
+- Sub-copy: Onest 15px, ink-2
+
+### Filters row (sticky on scroll)
+
+| Filter | Token | Notes |
+|---|---|---|
+| Search input | `EditorialInputFrame` | Search across business name, owner name, phone, lead name, submitter display name. Debounce 300ms. |
+| Status pill row | `Pill` × 6 | `All / New / Contacted / Qualified / Converted / Lost`. Stat counts in parens (`New · 12`). |
+| "Only mine" toggle | `Pill` (active state) | When active, sets `onlyMine: true`. Counts in pill labels update to filtered counts. |
+
+### Lead cards (grid)
+
+- Desktop: 2–3 column grid (CSS `repeat(auto-fill, minmax(360px, 1fr))`)
+- Tablet: 2 cards per row
+- Mobile (web responsive): 1 card per row — should match mobile native screen closely
+
+Each card has **two render modes** depending on `hasEnrichedContent`:
+
+**Standard mode** (no admin content):
+```
+┌────────────────────────────────────────┐
+│  ●  BUSINESS NAME              ★ HOT   │  ← header: avatar of submittedBy, mono label, optional hot star (red-orange, NOT brand orange)
+│     City, Type                          │
+│  ┌──────────────────────────────────┐  │
+│  │ Owner: Maria Cruz                 │  │
+│  │ Phone: 0917 234 1234              │  │
+│  │ NEW · Submitted by Maria S. · 2d │  │  ← status pill + submitter chip + time
+│  └──────────────────────────────────┘  │
+│  [View detail →]                       │
+└────────────────────────────────────────┘
+```
+
+**Social-card mode** (when `hasEnrichedContent === true` — FB-style):
+```
+┌────────────────────────────────────────┐
+│  Maria S. · 2d ago               ⋯     │  ← submitter strip (avatar + display name)
+│                                          │
+│  Lorenzo's Sari-Sari Store              │  ← serif headline
+│  in italics for accent word              │
+│                                          │
+│  [hero image — previewImageUrl]         │  ← 16:9 max-h-280 cover
+│                                          │
+│  Admin description text (max 500 ch)... │  ← Body, ink-2
+│                                          │
+│  ┌──────────────────────────────────┐  │
+│  │ EXTERNAL LINK ↗                   │  │  ← externalPreviewUrl as link card
+│  └──────────────────────────────────┘  │
+│                                          │
+│  NEW · 3 interviewers                  │
+└────────────────────────────────────────┘
+```
+
+Both card modes are clickable (full card → detail route). Use semantic `<article>` and an inner `<Link>` for keyboard nav.
+
+### Empty + loading + error
+
+- Loading: skeleton cards (paper-2 background, animated shimmer using `colors.rule` → `colors.ruleStrong`)
+- Empty (no leads at all): editorial empty state — large serif "Nothing yet." + Onest sub-copy "The team's leads will appear here as soon as someone submits a business." + Door button "Submit a business" linking to `/creators/submit`
+- Empty (filters applied): "No leads match these filters." + ghost Door "Clear filters"
+- Error: `colors.danger` banner, no retry button (Convex auto-retries)
+
+---
+
+## Detail page UX spec (`/creators/leads/[leadId]`)
+
+Two-column on desktop, single-column on tablet/mobile.
+
+### Left column (60% width)
+
+1. **Breadcrumb** — `STEP 03 / TEAM LEADS / Lorenzo's Sari-Sari Store`. Last segment serif italic if admin-curated.
+2. **Submitter strip** — Avatar + display name + relative time ("Submitted by Maria S. · 2d ago"). If `isMine`, append a small `MINE` mono pill.
+3. **Status row** — current status as a large pill. If `isMine` or admin, click to open status update dropdown. Status changes write via `leads.updateStatus`.
+4. **Admin social card** (if `hasEnrichedContent`) — exact same FB-style render as the list card, full-width.
+5. **Business details** — paper-3 Card with `business.businessName`, `businessType`, address, city, owner name + phone, etc. Click-to-call on the phone.
+6. **Other interviewers** — paper-3 Card. List of interviewers from `detail.interviewers`. Each row: avatar + display name + time + submission status pill. Used to surface "this business has been interviewed 3 times — it's hot."
+7. **Notes feed** — paper-3 Card. List of notes (latest first). Below the list, an `EditorialField` for posting a new note. POST goes to `leadNotes.add`. Optimistic update; show toast on failure.
+
+### Right column (40% width — sticky on desktop)
+
+1. **Quick contact card** — phone (click-to-call), email (click-to-mailto), copy buttons next to each.
+2. **Lead metadata** — created date, source, lead ID (small mono).
+3. **Submission link** — link to the underlying submission detail in the admin / public submission page, if visible to creators.
+
+### Mobile (web responsive)
+
+Collapse to single column. Sticky right column becomes a "Quick actions" bottom sheet triggered by a Door button.
+
+---
+
+## Design system — Editorial Paper (web port)
+
+> **Quoted from the mobile theme** (`ndm/theme/tokens.ts`). Use these tokens verbatim — no custom palette extensions, no terracotta/orange anywhere.
+
+### Typography stack
+
+Load all three Google Fonts in the layout:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Onest:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+  rel="stylesheet"
+/>
+```
+
+| Token | Family | Used for |
+|---|---|---|
+| `--font-serif` | `"Instrument Serif", Georgia, serif` | Display headlines, large numbers |
+| `--font-serif-italic` | `"Instrument Serif"` italic | Accent word in headline (set `font-style: italic` + `color: var(--color-accent)`) |
+| `--font-sans` | `"Onest", system-ui, sans-serif` | Body, buttons, form labels |
+| `--font-mono` | `"JetBrains Mono", Menlo, monospace` | Eyebrows, mono labels, timestamps |
+
+### Color palette (greens + khaki — final, no orange)
+
+```css
+:root {
+  /* Paper — warm khaki off-whites (page bg, card bg) */
+  --color-paper:    #F8F5EE;
+  --color-paper-2:  #EFEBE0;
+  --color-paper-3:  #FCFAF5;
+
+  /* Ink — near-black, cool (text + primary surfaces) */
+  --color-ink:   #1B1C24;
+  --color-ink-2: #3C3F4A;
+  --color-ink-3: #7A7E8A;
+
+  /* Emerald accent (replaces NEO LAB's terracotta — brand consistency) */
+  --color-accent:        #047857;  /* italic display emphasis */
+  --color-accent-ink:    #064E3B;
+  --color-accent-bg:     #D1FAE5;
+  --color-accent-solid:  #10B981;  /* primary "door" fills */
+
+  /* Live (real-time markers) */
+  --color-live:      #3FA86A;
+  --color-live-soft: #D4EFDE;
+
+  /* Rules / dividers (warm khaki) */
+  --color-rule:        #E0D8C9;
+  --color-rule-strong: #B7AC95;
+
+  /* Status (CRM lead pipeline) */
+  --color-status-new-bg:        #E4E9F0;  --color-status-new-ink:        #1F3654;
+  --color-status-contacted-bg:  #FBE9C4;  --color-status-contacted-ink:  #C68A12;
+  --color-status-qualified-bg:  #EDE9FE;  --color-status-qualified-ink:  #6D28D9;  /* muted purple, not bright */
+  --color-status-converted-bg:  #D1FAE5;  --color-status-converted-ink:  #064E3B;
+  --color-status-lost-bg:       #F3D7CF;  --color-status-lost-ink:       #B43A1F;
+
+  /* Critical */
+  --color-warn:   #C68A12;
+  --color-danger: #B43A1F;
+}
+```
+
+**The "Hot" badge** (interviewerCount ≥ 3): use `--color-danger-bg` + `--color-danger` text, NOT brand orange. Reads as urgency, not as a brand color.
+
+### Component patterns (mirror mobile primitives)
+
+| Mobile primitive | Web equivalent |
+|---|---|
+| `<Display size="lg">` | `<h1 className="serif text-6xl tracking-tight">` |
+| `<Body size="md">` | `<p className="sans text-base text-ink-2">` |
+| `<Label tracking={1.4}>` | `<span className="mono text-[11px] tracking-[0.12em] uppercase text-ink-3">` |
+| `<Door variant="solid">` | Black-ink button with mono caption above sans label, right arrow icon |
+| `<Pill active>` | Ink-filled chip with paper text |
+| `<Card>` | `bg-paper-3 border border-rule rounded-[18px] p-4` |
+| `<LiveDot>` | Pulsing 7px green dot (CSS keyframe animation) |
+| `<Avatar name="Maria">` | Round; if no image, render Instrument Serif initial centered on ink-3 bg |
+| `<Rule>` | `h-px bg-rule` |
+| `<EditorialField>` | Paper-3 input frame, mono label under, focused border ink |
+
+Build these as web React components and reuse across the redesign — same pattern as mobile's `components/ui/primitives.tsx`.
+
+### Spacing scale
+
+```css
+--space-xs: 4px;   --space-sm: 8px;   --space-md: 16px;
+--space-lg: 24px;  --space-xl: 40px;  --space-2xl: 64px;
+```
+
+### Radius scale
+
+```css
+--r-xs: 8px;   --r-sm: 12px;   --r-md: 18px;
+--r-lg: 24px;  --r-xl: 32px;   --r-pill: 999px;
+```
+
+### Shadows (subtle, warm — not material)
+
+```css
+--shadow-soft:   0 2px 8px rgba(0,0,0,0.06);
+--shadow-lifted: 0 12px 24px rgba(0,0,0,0.12);
+```
+
+### Critical "do not" rules
+
+- ❌ No orange. No terracotta. No `#f59e0b`. No `#ea580c`. If you see those, replace with `--color-warn` or `--color-accent` depending on context.
+- ❌ No SaaS-y purple gradients on cards.
+- ❌ No Inter, no Roboto, no Geist. Onest is the only sans. Instrument Serif is the only display.
+- ❌ No `border-radius: 4px` — too sharp. Minimum radius is 8px (`--r-xs`).
+- ❌ Don't put emerald on every button. Reserve `--color-accent-solid` for "the win" — Approve a status change, Submit a note successfully. Default primary button is ink-solid.
+
+---
+
+## State management
+
+- **Convex hooks**: `useQuery(api.leads.listForMobileCRM, args)` and `useQuery(api.leads.getDetailForMobileCRM, { id })`. Reactive — no manual refresh.
+- **Mutations**: `useMutation(api.leadNotes.add)` and `useMutation(api.leads.updateStatus)`. Optimistic UI for note posting (append immediately, roll back on error).
+- **URL state**: filters (`status`, `search`, `onlyMine`) live in the URL search params so creators can share/bookmark filtered views.
+- **Auth gate**: route protected by the existing Clerk session middleware. Unauthenticated users redirect to `/sign-in?next=/creators/leads`.
+
+---
+
+## Performance budget
+
+| Metric | Budget |
+|---|---|
+| LCP | ≤ 1.8s on Fast 4G |
+| Card grid render with 200 leads | < 16ms paint |
+| Search debounce | 300ms |
+| Lead detail server response | < 250ms p95 (Convex hosted) |
+
+**Pagination:** the existing `listForMobileCRM` loads ALL leads in one shot (mobile expects this for the social feed). If the prod lead count grows past ~500, the web should add cursor pagination — propose a backend change in a follow-up PR, do not patch around it client-side.
+
+---
+
+## Accessibility
+
+- Color contrast: ink on paper = 14.8:1 (AAA). Accent-ink on accent-bg = 7.1:1 (AAA).
+- All interactive elements keyboard focusable; visible focus ring (2px ink, 2px offset).
+- Lead cards: full card is the link target; nested buttons (status change, copy phone) use `event.stopPropagation()` and have their own `aria-label`.
+- "Live" badge announces "live data" to screen readers via `aria-live="polite"` on the stats strip.
+- Hot badge: don't rely on color alone — include the word "HOT" in the visual + an `aria-label` of "Hot lead — 3 or more interviewers".
+
+---
+
+## Implementation order (suggested)
+
+1. **Day 1** — Create the web design-system primitives (Display, Body, Label, Door, Pill, Card, LiveDot, Avatar, EditorialField, Rule). Drop them in a new `components/editorial/` folder. Add Google Fonts to the root layout. Write a Storybook (or equivalent) page that renders every primitive in both light and dark theme (web supports a dark mode toggle by swapping the `--color-*` vars on `[data-theme="ink"]`).
+2. **Day 2** — Build the list page route. Hook `listForMobileCRM`. Render the filter row + standard-mode card. Skip social-card mode and detail page.
+3. **Day 3** — Add social-card render mode. Add empty/loading/error states. Add URL state syncing.
+4. **Day 4** — Build the detail page. Hook `getDetailForMobileCRM`. Render submitter strip, business card, interviewers, notes feed.
+5. **Day 5** — Wire `leadNotes.add` (optimistic) and `leads.updateStatus` (with the `isMine`/admin gate). QA pass.
+6. **Day 6** — Mobile-responsive pass. Sticky filter bar, single-column collapse, mobile-optimized note input.
+7. **Day 7** — Performance pass, a11y audit, ship behind a feature flag for internal review before rolling out.
+
+---
+
+## Open questions for the web team
+
+- [ ] **Route slug**: `/creators/leads` or `/dashboard/leads`? Mobile uses `/(app)/leads/` — propose matching the structure.
+- [ ] **Dark mode**: mobile is paper-only today. Should the web do paper-only too, or ship `[data-theme="ink"]` from day one? (Mobile follows web's lead here — if web ships dark, mobile will too.)
+- [ ] **Feature flag**: which flag system are we using? Should this hide behind a `FF_WEB_LEADS_CRM` or roll out to all signed-in creators at once?
+- [ ] **Empty state CTA**: the "Submit a business" Door — does the web Creators platform already have a `/creators/submit` route, or does this need to be a deep-link into the mobile app?
+
+---
+
+## What MUST NOT change
+
+- ❌ Do not modify the Convex queries listed above. They are deployed in prod and consumed by mobile — any breaking change reverses the mobile launch.
+- ❌ Do not add new Convex fields without a sister PR to mobile. All shared schema changes go through [WEB-SYNC-MOBILE-FEATURES.md](./WEB-SYNC-MOBILE-FEATURES.md).
+- ❌ Do not introduce a second design system. If a primitive is missing, extend `components/editorial/` — don't fall back to the existing zinc/emerald admin styles. The user has been explicit: greens + khaki, no orange, no SaaS look.
+- ❌ Do not call admin-only queries (`getDetailForAdmin`, `updateAdminContent`, `generatePreviewImageUploadUrl`, `listPendingApproval`, `approveCreator`) from this page. They are admin-gated and will throw for regular creators.
+
+---
+
+## Related docs
+
+- [WEB-SYNC-MOBILE-FEATURES.md](./WEB-SYNC-MOBILE-FEATURES.md) — admin web surfaces, Convex schema sync, Editorial Paper tokens (Step 10.5)
+- [MOBILE-CRM-LEADS.md](./MOBILE-CRM-LEADS.md) — mobile-side leads implementation that this web page mirrors
+- [UI-REDESIGN-EDITORIAL-PAPER.md](./UI-REDESIGN-EDITORIAL-PAPER.md) — design system origin doc
+- `ndm/theme/tokens.ts` — canonical token source
+- `ndm/components/ui/primitives.tsx` — mobile primitive reference (mirror these on web)
+- `NEO LAB/For Creators.html` — original design inspiration (note: this uses terracotta — we replace it with emerald)


### PR DESCRIPTION
## Summary

Two changes, bundled because they shipped in the same session and are both small:

1. **`/leads` — creator-side Lead CRM** (main feature). Closes the gap where mobile creators had a team-wide leads feed and web creators had nothing. Spec: [docs/changes/WEB-BUILD-CRM.md](./docs/changes/WEB-BUILD-CRM.md).
2. **APK download route fix** (regression bug fix). Restores landing-page APK downloads after a settings-drift issue I introduced in an earlier PR.

## 1. Creator Lead CRM

Three new routes under the existing creator shell:

| Route | What it shows |
|---|---|
| `/leads` | Team-wide feed — stats (Total / Yours / Hot), search, filter pills (Only mine / All / status), green "Businesses near me" CTA, mobile-style lead cards with submitter strip + customer inquiry + business + status. |
| `/leads/[leadId]` | Single-lead detail — submitter strip, status dropdown (gated to `isMine` or admin), admin social card when curated, customer inquiry, business profile, other interviewers, notes feed with post-note composer. |
| `/leads/near` | "Businesses near you" — Google Maps embed iframe centered on browser geolocation, nearest-first list with haversine distances, per-lead deep-link to Google Maps. |

Plus a "STEP 02 / TEAM LEADS" entry card on the dashboard between the quick stats and Recent submissions, with live counts pulled from the same Convex subscription as the leads feed.

**Backend**: one new additive read-only query, `leads.listForMap`. The spec doesn't ship a data path for the map view (existing `listForMobileCRM` doesn't return coordinates), so this fills the gap. Read-only, signed-in only, returns lat/lng + business + submitter for any lead with resolvable coords (from `submission.coordinates` or Outscraper's `businessLatitude`/`Longitude`). No existing query is touched.

**Outscraper**: creators can **see** Outscraper-discovered prospects in the feed + map (since both list queries include all sources). The **scrape action** stays admin-only — no "Pull nearby" button on the creator page, matching the spec's "admin-internal until assigned" rule.

## 2. APK download fix

The previous APK rename change introduced an asymmetry: the Navbar/Footer decided to show the download button based on `apk_download_url`, but `/api/download-apk` decided whether to serve based on `apk_r2_key`. When those drifted apart on prod, the button appeared but every click 404'd.

The route is now strictly more available than the button-visibility check, with a 4-strategy fallback. Strategy 2 (deriving the R2 key from the public URL) is the load-bearing new bit — it recovers existing prod state without forcing an admin re-upload.

## Explicitly NOT touched

- Mobile-shared Convex queries (`listForMobileCRM`, `getDetailForMobileCRM`, `leadNotes.create`, `leads.updateStatus`, `outscraper.scrapeNearby`)
- Convex schema — no new fields
- `components/BottomNav.tsx` — kept as-is to match the user-provided screenshot; leads page is reached via the dashboard card
- Existing `/admin/leads`, `/admin/lead-prospects`, `/admin/app-release` pages
- APK upload pipeline — no upload-side changes, no setting writes

