### PR TITLE
Devpatch6

### DIFF
--- a/app/api/download-apk/route.ts
+++ b/app/api/download-apk/route.ts
@@ -1,109 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchQuery } from 'convex/nextjs'
 import { api } from '@/convex/_generated/api'
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
 /**
  * GET /api/download-apk
  *
- * Stable, friendly-named download endpoint for the Negosyo Digital APK.
+ * Thin backward-compat passthrough. The landing-page Navbar and Footer now
+ * link DIRECTLY to `apk_download_url` (the R2 public URL) — that's the
+ * canonical download path. This route exists only so any external link or
+ * bookmark to `/api/download-apk` keeps working.
  *
- * The APK upload pipeline (convex/r2.ts:generateApkUploadUrl + the admin
- * App Release page) stores each release at a collision-safe R2 key like
- * `releases/1704812345678-a8b2c1d4.apk` and persists FOUR Convex settings:
- *
- *   apk_r2_key       — R2 storage key, used to mint presigned URLs
- *   apk_download_url — public R2 URL, used as a fallback
- *   apk_file_name    — original filename
- *   apk_uploaded_at  — upload timestamp
- *
- * The Navbar/Footer link decision is based on `apk_download_url`. This route
- * MUST be at least as available as that decision — otherwise a setting drift
- * (where apk_download_url is present but apk_r2_key isn't, e.g. legacy
- * uploads or a manual edit in the Convex dashboard) makes the download
- * appear available in the UI but 404 on click.
- *
- * Resolution strategy (most-friendly first, last-resort last):
- *   1. apk_r2_key present                    → presigned URL + friendly name
- *   2. apk_download_url + R2_PUBLIC_URL set  → derive key from URL → same
- *   3. apk_download_url present              → 302 to public URL (cryptic name, but works)
- *   4. neither present                       → real 404
+ * The filename problem ("downloaded as 1704812345678-a8b2c1d4.apk instead
+ * of negosyo-digital.apk") is now solved at the upload layer in
+ * convex/r2.ts: the APK is stored at a stable key `releases/negosyo-digital.apk`,
+ * so R2 derives the friendly filename from the storage key. No
+ * Content-Disposition rewrites, no presigned URLs, no settings drift.
  */
 export async function GET(_request: NextRequest) {
     try {
-        // Read both settings up front — cheap, single round trip.
-        const [apkR2Key, apkDownloadUrl] = (await Promise.all([
-            fetchQuery(api.settings.get, { key: 'apk_r2_key' }),
-            fetchQuery(api.settings.get, { key: 'apk_download_url' }),
-        ])) as Array<string | null | undefined>
+        const apkDownloadUrl = (await fetchQuery(api.settings.get, {
+            key: 'apk_download_url',
+        })) as string | null | undefined
 
-        // Fail fast on the genuine "nothing uploaded" case.
-        if (!apkR2Key && !apkDownloadUrl) {
+        if (!apkDownloadUrl) {
             return NextResponse.json(
                 { error: 'No APK release available right now.' },
                 { status: 404 },
             )
         }
 
-        // Strategy 2: derive the R2 key from the public URL when apk_r2_key
-        // is missing. R2 public URLs are built as `${R2_PUBLIC_URL}/${key}`
-        // (see convex/r2.ts:generateApkUploadUrl), so stripping the prefix
-        // gives us the key back. This recovers gracefully from settings
-        // drift without forcing the admin to re-upload.
-        const r2PublicUrlRaw = process.env.R2_PUBLIC_URL
-        const r2PublicUrl = r2PublicUrlRaw ? r2PublicUrlRaw.replace(/\/$/, '') : null
-        let resolvedKey: string | null = apkR2Key ?? null
-        if (!resolvedKey && apkDownloadUrl && r2PublicUrl && apkDownloadUrl.startsWith(r2PublicUrl + '/')) {
-            resolvedKey = apkDownloadUrl.slice(r2PublicUrl.length + 1)
-        }
-
-        // Strategies 1 + 2: mint a presigned URL so the browser gets the
-        // friendly `negosyo-digital.apk` filename via response headers.
-        if (resolvedKey) {
-            const r2AccountId = process.env.R2_ACCOUNT_ID
-            const r2AccessKeyId = process.env.R2_ACCESS_KEY_ID
-            const r2SecretAccessKey = process.env.R2_SECRET_ACCESS_KEY
-            const r2BucketName = process.env.R2_BUCKET_NAME
-
-            if (r2AccountId && r2AccessKeyId && r2SecretAccessKey && r2BucketName) {
-                try {
-                    const client = new S3Client({
-                        region: 'auto',
-                        endpoint: `https://${r2AccountId}.r2.cloudflarestorage.com`,
-                        credentials: { accessKeyId: r2AccessKeyId, secretAccessKey: r2SecretAccessKey },
-                    })
-                    const command = new GetObjectCommand({
-                        Bucket: r2BucketName,
-                        Key: resolvedKey,
-                        ResponseContentDisposition: 'attachment; filename="negosyo-digital.apk"',
-                        ResponseContentType: 'application/vnd.android.package-archive',
-                    })
-                    const signedUrl = await getSignedUrl(client, command, { expiresIn: 60 * 60 })
-                    return NextResponse.redirect(signedUrl, { status: 302 })
-                } catch (signErr) {
-                    // Fall through to strategy 3 — never block the download
-                    // because the signing step itself failed.
-                    console.error('download-apk: presign failed, falling back to public URL', signErr)
-                }
-            } else {
-                console.warn('download-apk: R2 env vars missing, falling back to public URL')
-            }
-        }
-
-        // Strategy 3: last-resort direct redirect to the public R2 URL. The
-        // user gets the cryptic R2 key as the filename but at least the
-        // download succeeds — strictly better than a 404.
-        if (apkDownloadUrl) {
-            return NextResponse.redirect(apkDownloadUrl, { status: 302 })
-        }
-
-        // Should be unreachable given the early return above, but kept for
-        // exhaustiveness.
-        return NextResponse.json(
-            { error: 'No APK release available right now.' },
-            { status: 404 },
-        )
+        return NextResponse.redirect(apkDownloadUrl, { status: 302 })
     } catch (err: any) {
         console.error('download-apk error:', err)
         return NextResponse.json(

--- a/app/leads/[leadId]/page.tsx
+++ b/app/leads/[leadId]/page.tsx
@@ -18,6 +18,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import {
     ArrowLeft, Phone, Mail, MapPin, Loader2, Send, Building2, ExternalLink, Globe,
+    Copy, Check,
 } from "lucide-react";
 
 type LeadStatus = "new" | "contacted" | "qualified" | "converted" | "lost";
@@ -164,7 +165,7 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
             className="min-h-screen pb-24"
             style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
         >
-            <div className="max-w-2xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6 space-y-5">
+            <div className="max-w-5xl mx-auto px-4 pt-6 sm:pt-8 sm:px-6 space-y-5">
                 {/* Header */}
                 <div className="flex items-center gap-3">
                     <Link
@@ -210,6 +211,11 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
                         </p>
                     )}
                 </div>
+
+                {/* Two-column layout below the title — left content rail
+                    + sticky right rail. Single-column on mobile/tablet. */}
+                <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px] gap-6">
+                    <div className="space-y-5 min-w-0">
 
                 {/* Submitter strip */}
                 {submittedBy && (
@@ -344,7 +350,8 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
                     </div>
                 )}
 
-                {/* Lead contact (the customer who inquired) */}
+                {/* Lead contact (the customer who inquired) — with primary
+                    Call + Email action buttons per spec. */}
                 {(lead.name || lead.phone || lead.email) && (
                     <div
                         className="rounded-2xl p-4 space-y-3"
@@ -366,33 +373,48 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
                                 {lead.name}
                             </div>
                         )}
-                        <div className="flex flex-wrap gap-2">
-                            {lead.phone && (
+                        {(lead.phone || lead.email) && (
+                            <div className="text-[12px] space-y-1" style={{ color: "var(--ed-ink-2)" }}>
+                                {lead.phone && (
+                                    <div className="flex items-center gap-2">
+                                        <Phone className="w-3.5 h-3.5" style={{ color: "var(--ed-ink-3)" }} />
+                                        <span>{lead.phone}</span>
+                                    </div>
+                                )}
+                                {lead.email && (
+                                    <div className="flex items-center gap-2">
+                                        <Mail className="w-3.5 h-3.5" style={{ color: "var(--ed-ink-3)" }} />
+                                        <span className="truncate">{lead.email}</span>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                        {/* Primary action buttons — Call (emerald) + Email (ink-blue) */}
+                        <div className="grid grid-cols-2 gap-2 pt-1">
+                            {lead.phone ? (
                                 <a
                                     href={`tel:${lead.phone.replace(/[^0-9+]/g, "")}`}
-                                    className="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-full"
+                                    className="inline-flex items-center justify-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl transition-opacity hover:opacity-95"
                                     style={{
-                                        background: "var(--ed-paper-2)",
-                                        color: "var(--ed-ink)",
-                                        border: "1px solid var(--ed-rule)",
+                                        background: "var(--ed-accent-solid, #10B981)",
+                                        color: "#fff",
                                     }}
                                 >
-                                    <Phone className="w-3.5 h-3.5" /> {lead.phone}
+                                    <Phone className="w-4 h-4" /> Call
                                 </a>
-                            )}
-                            {lead.email && (
+                            ) : <span />}
+                            {lead.email ? (
                                 <a
                                     href={`mailto:${lead.email}`}
-                                    className="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-full"
+                                    className="inline-flex items-center justify-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl transition-opacity hover:opacity-95"
                                     style={{
-                                        background: "var(--ed-paper-2)",
-                                        color: "var(--ed-ink)",
-                                        border: "1px solid var(--ed-rule)",
+                                        background: "var(--ed-ink)",
+                                        color: "var(--ed-paper-3)",
                                     }}
                                 >
-                                    <Mail className="w-3.5 h-3.5" /> {lead.email}
+                                    <Mail className="w-4 h-4" /> Email
                                 </a>
-                            )}
+                            ) : <span />}
                         </div>
                     </div>
                 )}
@@ -455,63 +477,194 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
                                 href={business.websiteUrl}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1.5 text-[13px]"
+                                className="inline-flex items-center gap-1.5 text-[12px] truncate max-w-full"
                                 style={{ color: "var(--ed-accent)" }}
                             >
-                                <Globe className="w-3.5 h-3.5" /> {business.websiteUrl}
+                                <Globe className="w-3.5 h-3.5 flex-shrink-0" />
+                                <span className="truncate">{business.websiteUrl}</span>
                             </a>
                         )}
+
+                        {/* Primary action buttons — Directions (always when address) +
+                            View Website (active when live, ghost "not live yet" otherwise) */}
+                        <div className="grid grid-cols-2 gap-2 pt-2">
+                            {business.address ? (
+                                <a
+                                    href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                                        [business.address, business.city, business.province]
+                                            .filter(Boolean)
+                                            .join(", "),
+                                    )}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center justify-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl transition-colors hover:bg-white"
+                                    style={{
+                                        background: "var(--ed-paper-2)",
+                                        color: "var(--ed-ink)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                >
+                                    <MapPin className="w-4 h-4" /> Directions
+                                </a>
+                            ) : <span />}
+                            {business.websiteUrl ? (
+                                <a
+                                    href={business.websiteUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center justify-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl transition-colors"
+                                    style={{
+                                        background: "transparent",
+                                        color: "var(--ed-accent)",
+                                        border: "1px solid var(--ed-accent)",
+                                    }}
+                                >
+                                    <Globe className="w-4 h-4" /> View website
+                                </a>
+                            ) : (
+                                <span
+                                    className="inline-flex items-center justify-center gap-2 text-[12px] font-medium px-3 py-2.5 rounded-xl"
+                                    style={{
+                                        background: "transparent",
+                                        color: "var(--ed-ink-3)",
+                                        border: "1px dashed var(--ed-rule-strong, #B7AC95)",
+                                    }}
+                                    title="The submission hasn't been deployed yet."
+                                >
+                                    <Globe className="w-4 h-4" /> Website not live yet
+                                </span>
+                            )}
+                        </div>
                     </div>
                 )}
 
-                {/* Other interviewers */}
-                {interviewers && interviewers.length > 1 && (
+                {/* Interviewed by — full roster of every creator who's
+                    interviewed this business. Spec calls this out explicitly:
+                    "this is what surfaces the 'this business has been
+                    interviewed 3 times — it's hot' pattern. Don't omit it." */}
+                {interviewers && (
                     <div
                         className="rounded-2xl p-4 space-y-3"
                         style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
                     >
-                        <div
-                            className="text-[10px]"
-                            style={{
-                                fontFamily: "var(--ed-mono)",
-                                letterSpacing: "0.14em",
-                                textTransform: "uppercase",
-                                color: "var(--ed-ink-3)",
-                            }}
-                        >
-                            Other Interviewers · {interviewers.length}
+                        <div className="flex items-center justify-between">
+                            <div
+                                className="text-[10px]"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                Interviewed by
+                            </div>
+                            {interviewers.length > 0 && (
+                                <span
+                                    className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full"
+                                    style={{
+                                        background: "var(--ed-paper-2)",
+                                        color: "var(--ed-ink-2)",
+                                        fontFamily: "var(--ed-mono)",
+                                    }}
+                                >
+                                    {interviewers.length} {interviewers.length === 1 ? "creator" : "creators"}
+                                </span>
+                            )}
                         </div>
-                        <ul className="space-y-2.5">
-                            {interviewers.map((i: any) => (
-                                <li key={i.submissionId} className="flex items-center justify-between gap-3 text-[13px]">
-                                    <div className="flex items-center gap-2.5 min-w-0">
-                                        {i.creatorProfileImage ? (
-                                            // eslint-disable-next-line @next/next/no-img-element
-                                            <img src={i.creatorProfileImage} alt="" className="w-7 h-7 rounded-full object-cover flex-shrink-0" />
-                                        ) : (
+                        {interviewers.length === 0 ? (
+                            <p
+                                className="text-[13px] italic py-2"
+                                style={{
+                                    fontFamily: "var(--ed-serif)",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                No interview history found for this business.
+                            </p>
+                        ) : (
+                            <ul className="space-y-2">
+                                {interviewers.map((i: any) => {
+                                    const rejected = i.submissionStatus === "rejected";
+                                    const rowBg = i.isMine
+                                        ? "var(--ed-accent-bg, #D1FAE5)"
+                                        : "var(--ed-paper-2)";
+                                    const opacity = rejected && !i.isMine ? 0.6 : 1;
+                                    return (
+                                        <li
+                                            key={i.submissionId}
+                                            className="flex items-center justify-between gap-3 text-[13px] px-3 py-2.5 rounded-xl"
+                                            style={{
+                                                background: rowBg,
+                                                borderLeft: i.isMine ? "3px solid var(--ed-accent)" : "3px solid transparent",
+                                                opacity,
+                                            }}
+                                        >
+                                            <div className="flex items-center gap-2.5 min-w-0">
+                                                {i.creatorProfileImage ? (
+                                                    // eslint-disable-next-line @next/next/no-img-element
+                                                    <img
+                                                        src={i.creatorProfileImage}
+                                                        alt=""
+                                                        className="w-7 h-7 rounded-full object-cover flex-shrink-0"
+                                                    />
+                                                ) : (
+                                                    <div
+                                                        className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] flex-shrink-0"
+                                                        style={{
+                                                            background: i.isMine
+                                                                ? "var(--ed-accent-solid, #10B981)"
+                                                                : "var(--ed-ink-3)",
+                                                            color: "#fff",
+                                                            fontFamily: "var(--ed-serif)",
+                                                            fontWeight: 500,
+                                                        }}
+                                                    >
+                                                        {(i.creatorName ?? "?").slice(0, 1).toUpperCase()}
+                                                    </div>
+                                                )}
+                                                <span className="truncate" style={{ color: "var(--ed-ink)" }}>
+                                                    {i.creatorName}
+                                                </span>
+                                                {i.isMine && (
+                                                    <span
+                                                        className="text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded flex-shrink-0"
+                                                        style={{
+                                                            background: "var(--ed-accent-solid, #10B981)",
+                                                            color: "#fff",
+                                                            fontFamily: "var(--ed-mono)",
+                                                            letterSpacing: "0.1em",
+                                                            textTransform: "uppercase",
+                                                        }}
+                                                    >
+                                                        You
+                                                    </span>
+                                                )}
+                                            </div>
                                             <div
-                                                className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] flex-shrink-0"
+                                                className="text-right flex-shrink-0 text-[10px]"
                                                 style={{
-                                                    background: "var(--ed-paper-2)",
-                                                    color: "var(--ed-ink)",
-                                                    fontFamily: "var(--ed-serif)",
-                                                    fontWeight: 500,
+                                                    fontFamily: "var(--ed-mono)",
+                                                    letterSpacing: "0.04em",
                                                 }}
                                             >
-                                                {(i.creatorName ?? "?").slice(0, 1).toUpperCase()}
+                                                <div style={{ color: "var(--ed-ink-3)" }}>
+                                                    {timeAgo(i.interviewedAt)}
+                                                </div>
+                                                <div
+                                                    style={{
+                                                        color: rejected ? "var(--ed-danger)" : "var(--ed-ink-2)",
+                                                        textTransform: "uppercase",
+                                                    }}
+                                                >
+                                                    {i.submissionStatus}
+                                                </div>
                                             </div>
-                                        )}
-                                        <span className="truncate" style={{ color: "var(--ed-ink)" }}>
-                                            {i.creatorName}
-                                            {i.isMine && <span style={{ color: "var(--ed-accent)" }}> · mine</span>}
-                                        </span>
-                                    </div>
-                                    <span className="ed-label flex-shrink-0" style={{ color: "var(--ed-ink-3)" }}>
-                                        {timeAgo(i.interviewedAt)}
-                                    </span>
-                                </li>
-                            ))}
-                        </ul>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        )}
                     </div>
                 )}
 
@@ -593,6 +746,241 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
                         </p>
                     )}
                 </div>
+
+                    </div>
+                    {/* Right rail — sticky on desktop, stacked under main column on mobile/tablet */}
+                    <RightRail lead={lead} business={business} leadId={leadId} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function RightRail({
+    lead, business, leadId,
+}: {
+    lead: any;
+    business: any;
+    leadId: Id<"leads">;
+}) {
+    const [copiedId, setCopiedId] = useState(false);
+    const directionsHref = business?.address
+        ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+              [business.address, business.city, business.province].filter(Boolean).join(", "),
+          )}`
+        : null;
+
+    const handleCopyId = async () => {
+        try {
+            await navigator.clipboard.writeText(String(lead._id));
+            setCopiedId(true);
+            setTimeout(() => setCopiedId(false), 1500);
+        } catch {
+            // Older browsers — silently ignore.
+        }
+    };
+
+    return (
+        <aside className="lg:sticky lg:top-6 lg:self-start space-y-4">
+            {/* Quick contact */}
+            {(lead.phone || lead.email) && (
+                <div
+                    className="rounded-2xl p-4 space-y-2.5"
+                    style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                >
+                    <div
+                        className="text-[10px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        Quick contact
+                    </div>
+                    {lead.phone && (
+                        <a
+                            href={`tel:${lead.phone.replace(/[^0-9+]/g, "")}`}
+                            className="flex items-center gap-2 text-[13px] px-3 py-2 rounded-lg transition-colors hover:bg-white"
+                            style={{
+                                background: "var(--ed-paper-2)",
+                                color: "var(--ed-ink)",
+                                border: "1px solid var(--ed-rule)",
+                            }}
+                        >
+                            <Phone className="w-3.5 h-3.5" style={{ color: "var(--ed-accent)" }} />
+                            <span className="truncate">{lead.phone}</span>
+                        </a>
+                    )}
+                    {lead.email && (
+                        <a
+                            href={`mailto:${lead.email}`}
+                            className="flex items-center gap-2 text-[13px] px-3 py-2 rounded-lg transition-colors hover:bg-white"
+                            style={{
+                                background: "var(--ed-paper-2)",
+                                color: "var(--ed-ink)",
+                                border: "1px solid var(--ed-rule)",
+                            }}
+                        >
+                            <Mail className="w-3.5 h-3.5" style={{ color: "var(--ed-accent)" }} />
+                            <span className="truncate">{lead.email}</span>
+                        </a>
+                    )}
+                </div>
+            )}
+
+            {/* Quick actions — sticky duplicate of Directions + Website */}
+            {(directionsHref || business) && (
+                <div
+                    className="rounded-2xl p-4 space-y-2.5"
+                    style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                >
+                    <div
+                        className="text-[10px]"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "var(--ed-ink-3)",
+                        }}
+                    >
+                        Quick actions
+                    </div>
+                    {directionsHref && (
+                        <a
+                            href={directionsHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl transition-colors hover:bg-white"
+                            style={{
+                                background: "var(--ed-paper-2)",
+                                color: "var(--ed-ink)",
+                                border: "1px solid var(--ed-rule)",
+                            }}
+                        >
+                            <MapPin className="w-4 h-4" /> Directions
+                        </a>
+                    )}
+                    {business?.websiteUrl ? (
+                        <a
+                            href={business.websiteUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 text-[13px] font-semibold px-3 py-2.5 rounded-xl"
+                            style={{
+                                background: "transparent",
+                                color: "var(--ed-accent)",
+                                border: "1px solid var(--ed-accent)",
+                            }}
+                        >
+                            <Globe className="w-4 h-4" /> View website
+                        </a>
+                    ) : (
+                        <span
+                            className="flex items-center gap-2 text-[12px] font-medium px-3 py-2.5 rounded-xl"
+                            style={{
+                                background: "transparent",
+                                color: "var(--ed-ink-3)",
+                                border: "1px dashed var(--ed-rule-strong, #B7AC95)",
+                            }}
+                            title="The submission hasn't been deployed yet."
+                        >
+                            <Globe className="w-4 h-4" /> Website not live yet
+                        </span>
+                    )}
+                </div>
+            )}
+
+            {/* Lead metadata */}
+            <div
+                className="rounded-2xl p-4 space-y-3"
+                style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+            >
+                <div
+                    className="text-[10px]"
+                    style={{
+                        fontFamily: "var(--ed-mono)",
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "var(--ed-ink-3)",
+                    }}
+                >
+                    Metadata
+                </div>
+                <MetaRow label="Created" value={new Date(lead.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })} />
+                <MetaRow label="Source" value={lead.source} mono />
+                <div>
+                    <div
+                        className="text-[10px] mb-1"
+                        style={{
+                            fontFamily: "var(--ed-mono)",
+                            color: "var(--ed-ink-3)",
+                            letterSpacing: "0.08em",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        Lead ID
+                    </div>
+                    <button
+                        type="button"
+                        onClick={handleCopyId}
+                        className="flex items-center gap-1.5 text-[11px] font-mono px-2 py-1 rounded-md w-full text-left transition-colors hover:bg-white"
+                        style={{
+                            background: "var(--ed-paper-2)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                            fontFamily: "var(--ed-mono)",
+                        }}
+                        title="Copy lead ID"
+                    >
+                        {copiedId ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                        <span className="truncate">{String(lead._id)}</span>
+                    </button>
+                </div>
+            </div>
+
+            {/* Submission link */}
+            {business?.submissionId && (
+                <Link
+                    href={`/submissions/${business.submissionId}`}
+                    className="flex items-center justify-between gap-2 rounded-2xl p-4 text-[13px] transition-colors hover:bg-white"
+                    style={{
+                        background: "var(--ed-paper-3)",
+                        color: "var(--ed-ink)",
+                        border: "1px solid var(--ed-rule)",
+                    }}
+                >
+                    <span>View submission</span>
+                    <ExternalLink className="w-4 h-4" style={{ color: "var(--ed-ink-3)" }} />
+                </Link>
+            )}
+        </aside>
+    );
+}
+
+function MetaRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+    return (
+        <div>
+            <div
+                className="text-[10px] mb-0.5"
+                style={{
+                    fontFamily: "var(--ed-mono)",
+                    color: "var(--ed-ink-3)",
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                }}
+            >
+                {label}
+            </div>
+            <div
+                className="text-[13px]"
+                style={{
+                    color: "var(--ed-ink)",
+                    fontFamily: mono ? "var(--ed-mono)" : "var(--ed-sans)",
+                }}
+            >
+                {value}
             </div>
         </div>
     );

--- a/app/leads/near/page.tsx
+++ b/app/leads/near/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 /**
- * /leads/near — "Businesses near you" view.
+ * /leads/near — map view of mappable leads.
+ *
+ * Two modes via URL state:
+ *   (default)      — every lead with resolvable lat/lng
+ *   ?live=true     — "See Live Business" — filter to leads with a live
+ *                    deployed website (lead.hasLiveWebsite). This is the
+ *                    "what's already working — and earning" view from the
+ *                    spec's two action doors.
  *
  * Reads `api.leads.listForMap` for every lead with resolvable lat/lng, then
  * computes haversine distance from the user's browser geolocation and renders
@@ -9,13 +16,13 @@
  * location (or Philippines fallback) using the same Google Maps embed pattern
  * the Astro site uses — no API key required.
  */
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { ArrowLeft, Loader2, MapPin, Building2, ExternalLink } from "lucide-react";
+import { ArrowLeft, Loader2, MapPin, Building2, ExternalLink, Globe } from "lucide-react";
 
 const PH_CENTER = { lat: 14.5995, lng: 120.9842 }; // Manila — used when geolocation unavailable
 
@@ -37,7 +44,23 @@ function formatDistance(km: number): string {
 }
 
 export default function BusinessesNearYouPage() {
+    return (
+        <Suspense
+            fallback={
+                <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+                    <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+                </div>
+            }
+        >
+            <NearInner />
+        </Suspense>
+    );
+}
+
+function NearInner() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const liveOnly = searchParams.get("live") === "true";
     const { user, isLoaded, isSignedIn } = useUser();
 
     const creator = useQuery(
@@ -91,13 +114,19 @@ export default function BusinessesNearYouPage() {
     const sorted = useMemo(() => {
         if (!mappable) return undefined;
         const origin = userLoc ?? PH_CENTER;
-        return mappable
+        const filtered = liveOnly
+            ? mappable.filter((m: any) => m.hasLiveWebsite)
+            : mappable;
+        return filtered
             .map((m: any) => ({
                 ...m,
                 distanceKm: haversineKm(origin, { lat: m.lat, lng: m.lng }),
             }))
             .sort((a: any, b: any) => a.distanceKm - b.distanceKm);
-    }, [mappable, userLoc]);
+    }, [mappable, userLoc, liveOnly]);
+
+    const visibleCount = sorted?.length ?? 0;
+    const totalMappable = mappable?.length ?? 0;
 
     if (!ready) {
         return (
@@ -146,14 +175,61 @@ export default function BusinessesNearYouPage() {
                     className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
                     style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
                 >
-                    Businesses{" "}
-                    <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>near you.</em>
+                    {liveOnly ? (
+                        <>
+                            Live businesses,{" "}
+                            <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>near you.</em>
+                        </>
+                    ) : (
+                        <>
+                            Businesses{" "}
+                            <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>near you.</em>
+                        </>
+                    )}
                 </h1>
                 <p className="text-[14px] mb-5" style={{ color: "var(--ed-ink-2)" }}>
                     {mappable === undefined
                         ? "Loading mappable leads…"
-                        : `${mappable.length} mappable lead${mappable.length === 1 ? "" : "s"}.`}
+                        : liveOnly
+                            ? `${visibleCount} of ${totalMappable} mappable leads have a live website.`
+                            : `${totalMappable} mappable lead${totalMappable === 1 ? "" : "s"}.`}
                 </p>
+
+                {/* Mode toggle — switch between "all mappable" and "live only" */}
+                <div className="flex gap-2 mb-4">
+                    <Link
+                        href="/leads/near"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px]"
+                        style={{
+                            background: liveOnly ? "transparent" : "var(--ed-ink)",
+                            color: liveOnly ? "var(--ed-ink-2)" : "var(--ed-paper-3)",
+                            border: `1px solid ${liveOnly ? "var(--ed-rule)" : "var(--ed-ink)"}`,
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.1em",
+                            textTransform: "uppercase",
+                            fontWeight: 600,
+                            textDecoration: "none",
+                        }}
+                    >
+                        <MapPin className="w-3 h-3" /> All mappable
+                    </Link>
+                    <Link
+                        href="/leads/near?live=true"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px]"
+                        style={{
+                            background: liveOnly ? "var(--ed-accent-solid, #10B981)" : "transparent",
+                            color: liveOnly ? "#fff" : "var(--ed-ink-2)",
+                            border: `1px solid ${liveOnly ? "var(--ed-accent-solid, #10B981)" : "var(--ed-rule)"}`,
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.1em",
+                            textTransform: "uppercase",
+                            fontWeight: 600,
+                            textDecoration: "none",
+                        }}
+                    >
+                        <Globe className="w-3 h-3" /> Live websites only
+                    </Link>
+                </div>
 
                 {/* Permission / fallback banner */}
                 {locError && (

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -6,20 +6,24 @@
  * Mirrors the mobile app's leads index (`ndm/app/(app)/leads/index.tsx`).
  * Reads the team-wide social feed via `api.leads.listForMobileCRM` and
  * renders it as scrollable cards with submitter attribution + status pill.
- * Linked to the dashboard's "STEP 02 / TEAM LEADS" card.
+ *
+ * URL state (per spec):
+ *   ?tab=prospects   — Outscraper-discovered businesses not yet interviewed
+ *   (default)        — All interviewed leads ("See Live Business" map is
+ *                      its own route at /leads/near?live=true)
  *
  * Spec: docs/changes/WEB-BUILD-CRM.md (Creators platform integration).
  */
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { BottomNav } from "@/components/BottomNav";
 import {
-    ArrowLeft, Search, Map as MapIcon, Building2, Loader2, ChevronRight, Star,
+    ArrowLeft, Search, Map as MapIcon, Compass, Building2, Loader2, ChevronRight, Star,
 } from "lucide-react";
 
 // ── Types + constants ─────────────────────────────────────────────────────
@@ -52,9 +56,28 @@ function formatDateShort(ts: number | null | undefined): string {
     return d.toLocaleDateString("en-US", { month: "numeric", day: "numeric", year: "numeric" });
 }
 
-// ── Page ──────────────────────────────────────────────────────────────────
+// ── Page entry — wraps inner content in Suspense for useSearchParams ──────
 export default function CreatorLeadsPage() {
+    return (
+        <Suspense
+            fallback={
+                <div
+                    className="min-h-screen flex items-center justify-center"
+                    style={{ background: "var(--ed-paper)" }}
+                >
+                    <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+                </div>
+            }
+        >
+            <CreatorLeadsInner />
+        </Suspense>
+    );
+}
+
+function CreatorLeadsInner() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const tab: "all" | "prospects" = searchParams.get("tab") === "prospects" ? "prospects" : "all";
     const { user, isLoaded, isSignedIn } = useUser();
 
     const creator = useQuery(
@@ -121,8 +144,28 @@ export default function CreatorLeadsPage() {
     }
 
     const stats = feed?.stats;
-    const leads = feed?.leads ?? [];
+    const allLeads = feed?.leads ?? [];
+
+    // Tab filter — Prospects = Outscraper-source leads only. Applied AFTER
+    // the Convex query so the stats stay accurate to the full team feed.
+    const leads = useMemo(() => {
+        if (tab === "prospects") {
+            return allLeads.filter((l: any) => l.source === "outscraper");
+        }
+        // "All" excludes Outscraper prospects from the main feed so the two
+        // tabs don't double-count — prospects belong on the Prospects tab.
+        return allLeads.filter((l: any) => l.source !== "outscraper");
+    }, [allLeads, tab]);
+
     const hotCount = useMemo(() => leads.filter((l: any) => l.isHot).length, [leads]);
+    const prospectCount = useMemo(
+        () => allLeads.filter((l: any) => l.source === "outscraper").length,
+        [allLeads],
+    );
+    const interviewedCount = useMemo(
+        () => allLeads.filter((l: any) => l.source !== "outscraper").length,
+        [allLeads],
+    );
 
     return (
         <div
@@ -153,17 +196,37 @@ export default function CreatorLeadsPage() {
                     </div>
                 </div>
 
-                {/* Editorial display */}
-                <h1
-                    className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
-                    style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
-                >
-                    All leads,{" "}
-                    <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>every interview.</em>
-                </h1>
-                <p className="text-[15px] mb-6" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
-                    The whole team&apos;s hunt — including yours. {stats?.total ?? 0} lead{(stats?.total ?? 0) === 1 ? "" : "s"} · {hotCount} hot.
-                </p>
+                {/* Editorial display — copy swaps per active tab */}
+                {tab === "prospects" ? (
+                    <>
+                        <h1
+                            className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
+                            style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
+                        >
+                            Find your{" "}
+                            <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>
+                                next interview.
+                            </em>
+                        </h1>
+                        <p className="text-[15px] mb-6" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                            {prospectCount} prospect{prospectCount === 1 ? "" : "s"} pulled in from
+                            Outscraper — businesses nobody on the team has interviewed yet.
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <h1
+                            className="text-[40px] sm:text-[52px] leading-[1.05] tracking-[-0.02em] mb-3"
+                            style={{ fontFamily: "var(--ed-serif)", color: "var(--ed-ink)" }}
+                        >
+                            All leads,{" "}
+                            <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>every interview.</em>
+                        </h1>
+                        <p className="text-[15px] mb-6" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                            The whole team&apos;s hunt — including yours. {interviewedCount} lead{interviewedCount === 1 ? "" : "s"} · {hotCount} hot.
+                        </p>
+                    </>
+                )}
 
                 {/* Stats cards (TOTAL · YOURS · HOT LEADS) */}
                 <div className="grid grid-cols-3 gap-2 sm:gap-3 mb-5">
@@ -207,28 +270,73 @@ export default function CreatorLeadsPage() {
                     />
                 </div>
 
-                {/* Primary CTA — Businesses near me (map view) */}
-                <Link
-                    href="/leads/near"
-                    className="block mb-3 rounded-2xl px-5 py-4 flex items-center justify-between transition-opacity hover:opacity-95"
-                    style={{ background: "var(--ed-accent-solid, #10B981)", color: "#fff" }}
-                >
-                    <div>
-                        <div
-                            className="text-[10px] mb-1"
-                            style={{
-                                fontFamily: "var(--ed-mono)",
-                                letterSpacing: "0.14em",
-                                textTransform: "uppercase",
-                                opacity: 0.75,
-                            }}
-                        >
-                            On the map
+                {/* Two action doors — See Live Business + Find Local Business.
+                    Per spec: "Don't merge these into one button. Don't swap their
+                    semantics. The labels are exact." */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mb-5">
+                    <Link
+                        href="/leads/near?live=true"
+                        className="rounded-2xl px-5 py-4 flex items-center justify-between transition-opacity hover:opacity-95"
+                        style={{ background: "var(--ed-accent-solid, #10B981)", color: "#fff" }}
+                    >
+                        <div>
+                            <div
+                                className="text-[10px] mb-1"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    opacity: 0.75,
+                                }}
+                            >
+                                On the map
+                            </div>
+                            <div className="text-[16px] font-semibold">See Live Business</div>
                         </div>
-                        <div className="text-[18px] font-semibold">Businesses near me</div>
-                    </div>
-                    <MapIcon className="w-6 h-6" />
-                </Link>
+                        <MapIcon className="w-5 h-5" />
+                    </Link>
+                    <Link
+                        href="/leads?tab=prospects"
+                        className="rounded-2xl px-5 py-4 flex items-center justify-between transition-colors hover:bg-white"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            color: "var(--ed-ink)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <div>
+                            <div
+                                className="text-[10px] mb-1"
+                                style={{
+                                    fontFamily: "var(--ed-mono)",
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "var(--ed-ink-3)",
+                                }}
+                            >
+                                Discover
+                            </div>
+                            <div className="text-[16px] font-semibold">Find Local Business</div>
+                        </div>
+                        <Compass className="w-5 h-5" style={{ color: "var(--ed-ink-2)" }} />
+                    </Link>
+                </div>
+
+                {/* All / Prospects tab switcher */}
+                <div className="grid grid-cols-2 mb-5" style={{ borderBottom: "1px solid var(--ed-rule)" }}>
+                    <TabButton
+                        label="All Leads"
+                        count={interviewedCount}
+                        active={tab === "all"}
+                        onClick={() => router.replace("/leads", { scroll: false })}
+                    />
+                    <TabButton
+                        label="Prospects"
+                        count={prospectCount}
+                        active={tab === "prospects"}
+                        onClick={() => router.replace("/leads?tab=prospects", { scroll: false })}
+                    />
+                </div>
 
                 {/* Filter pills row */}
                 <div className="-mx-4 sm:mx-0 mb-5">
@@ -348,6 +456,39 @@ function StatCard({
                 </div>
             )}
         </div>
+    );
+}
+
+function TabButton({
+    label, count, active, onClick,
+}: { label: string; count: number; active: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex items-center justify-center gap-2 py-3 transition-colors text-[11px]"
+            style={{
+                fontFamily: "var(--ed-mono)",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: active ? "var(--ed-ink)" : "var(--ed-ink-3)",
+                borderBottom: active ? "2px solid var(--ed-ink)" : "2px solid transparent",
+                marginBottom: -1,
+                fontWeight: active ? 600 : 500,
+            }}
+        >
+            {label}
+            <span
+                className="inline-flex items-center justify-center min-w-[22px] h-5 px-1.5 rounded-full text-[10px]"
+                style={{
+                    background: active ? "var(--ed-ink)" : "var(--ed-paper-2)",
+                    color: active ? "var(--ed-paper-3)" : "var(--ed-ink-2)",
+                    fontFamily: "var(--ed-mono)",
+                }}
+            >
+                {count}
+            </span>
+        </button>
     );
 }
 

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -88,10 +88,10 @@ export default function Footer({
                     </div>
                     <FootCol title="Get the app">
                         {apkUrl ? (
-                            // Routed through /api/download-apk so the browser
-                            // saves the file as "negosyo-digital.apk" instead
-                            // of the cryptic R2 key. Upload pipeline untouched.
-                            <a href="/api/download-apk">
+                            // Direct R2 public URL. The download filename
+                            // comes from the R2 storage key, which the
+                            // upload pipeline pins to "negosyo-digital.apk".
+                            <a href={apkUrl} download="negosyo-digital.apk">
                                 Android · Direct APK
                             </a>
                         ) : (

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -31,11 +31,12 @@ export default function Navbar({
     onCountryChange?: (v: string) => void;
 } = {}) {
     // Direct APK download URL (admin uploads via /admin/app-release).
-    // Falls back to /signup if no APK is currently uploaded. Routed through
-    // /api/download-apk so the browser saves the file as "negosyo-digital.apk"
-    // instead of the cryptic R2 key. Upload pipeline unchanged.
+    // Falls back to /signup if no APK is currently uploaded. The URL points
+    // straight at the R2 public URL — R2 derives the download filename from
+    // the storage key (which the upload code pins to releases/negosyo-digital.apk),
+    // so no proxy route or Content-Disposition rewrite is needed.
     const apkUrl = useQuery(api.settings.get, { key: "apk_download_url" }) as string | null | undefined;
-    const downloadHref = apkUrl ? "/api/download-apk" : "/signup";
+    const downloadHref = apkUrl ?? "/signup";
     const isApk = !!apkUrl;
     return (
         <div className="topbar">

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -481,6 +481,9 @@ export const listForMap = query({
             status: string;
             source: string;
             hasSubmission: boolean;
+            websiteUrl: string | null;
+            hasLiveWebsite: boolean;
+            submissionId: string | null;
             submittedBy: {
                 creatorId: string;
                 displayName: string;
@@ -531,6 +534,7 @@ export const listForMap = query({
                 }
             }
 
+            const websiteUrl = (sub as any)?.websiteUrl ?? null;
             result.push({
                 _id: lead._id,
                 businessName,
@@ -541,6 +545,9 @@ export const listForMap = query({
                 status: lead.status,
                 source: lead.source,
                 hasSubmission: !!sub,
+                websiteUrl,
+                hasLiveWebsite: !!websiteUrl,
+                submissionId: sub ? String(sub._id) : null,
                 submittedBy,
             });
         }

--- a/convex/r2.ts
+++ b/convex/r2.ts
@@ -224,33 +224,40 @@ export const deleteFile = action({
 });
 
 /**
- * Generate a presigned URL for uploading an APK to R2
+ * Generate a presigned URL for uploading an APK to R2.
+ *
+ * Uses a STABLE storage key — `releases/negosyo-digital.apk` — so the
+ * downloaded file is always named "negosyo-digital.apk" without any
+ * Content-Disposition rewrites or route-level indirection. R2 derives
+ * the download filename from the storage key, and re-uploads simply
+ * overwrite the previous file at the same key.
+ *
+ * Trade-off accepted on purpose: no per-release version history in R2.
+ * If we ever need historical releases, snapshot apk_uploaded_at +
+ * archive the bytes elsewhere; don't pollute the storage key.
  */
+const APK_STABLE_KEY = 'releases/negosyo-digital.apk';
+
 export const generateApkUploadUrl = action({
     args: {
         fileName: v.string(),
         fileType: v.string(),
     },
-    handler: async (ctx, args) => {
+    handler: async (_ctx, args) => {
         const client = getR2Client();
         const bucketName = getBucketName();
         const publicUrlPrefix = getPublicUrlPrefix();
 
-        const timestamp = Date.now();
-        const randomStr = Math.random().toString(36).substring(2, 10);
-        const extension = args.fileName.split('.').pop() || 'apk';
-        const key = `releases/${timestamp}-${randomStr}.${extension}`;
-
         const command = new PutObjectCommand({
             Bucket: bucketName,
-            Key: key,
+            Key: APK_STABLE_KEY,
             ContentType: args.fileType || 'application/vnd.android.package-archive',
         });
 
         const uploadUrl = await getSignedUrl(client, command, { expiresIn: 3600 });
-        const publicUrl = `${publicUrlPrefix}/${key}`;
+        const publicUrl = `${publicUrlPrefix}/${APK_STABLE_KEY}`;
 
-        return { uploadUrl, publicUrl, key };
+        return { uploadUrl, publicUrl, key: APK_STABLE_KEY };
     },
 });
 

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -89,6 +89,76 @@ Both routes should be **server-rendered shell + client-rendered data** (Next.js 
 
 ---
 
+## Entry points — where creators discover this page from the dashboard
+
+Three places. **All three must exist** so the page is reachable from anywhere in the platform.
+
+### Entry A — Top-level nav (sidebar or top-bar)
+
+Add a new "Leads" item to the existing creator-side nav. Place it between **Submissions** and **Wallet**:
+
+```
+Dashboard
+Submissions
+Leads          ← NEW. Routes to /creators/leads
+Wallet
+Referrals
+Profile
+```
+
+Match the existing nav-item styling. Optionally show a small count badge next to "Leads" pulling from `stats.total` from `listForMobileCRM` — skip if it'd require extra subscription plumbing.
+
+### Entry B — Dashboard hero card
+
+On the existing `/creators/dashboard`, add a Team Leads card between the balance/earnings area and the recent-submissions list. Mirrors what mobile has on its home tab.
+
+```
+┌────────────────────────────────────────────────────────┐
+│  STEP 02 / TEAM LEADS                          ● LIVE  │
+│                                                        │
+│  12 leads, browse the feed.                            │
+│                                                        │
+│  See every business the team has interviewed —         │
+│  the whole hunt, including the ones with live sites.   │
+│                                                        │
+│  ┌──────┬──────┬──────┬──────────┐                    │
+│  │  12  │   3  │   2  │     4     │                    │
+│  │Total │ Hot  │Yours │ Converted │                    │
+│  └──────┴──────┴──────┴──────────┘                    │
+│                                                        │
+│  [Browse leads →]                                      │
+└────────────────────────────────────────────────────────┘
+```
+
+The whole card is clickable → routes to `/creators/leads`. Stats come from the same `listForMobileCRM` query the page itself uses (free reactive subscription, Convex caches the result).
+
+- **Total** — `stats.total`
+- **Hot** — count of leads with `interviewerCount >= 3` (or use `isHot === true` if exposed)
+- **Yours** — `stats.mine`
+- **Converted** — `stats.converted`
+
+Mobile reference: `ndm/app/(app)/(tabs)/index.tsx` — find the `STEP 02 / TEAM LEADS` card around the middle of the file. Web should look essentially identical, scaled up for desktop.
+
+### Entry C — Submit success page (optional v1)
+
+After a creator finishes submitting a business via the existing submit flow, the success screen typically routes them to dashboard or submissions list. Consider also surfacing a "Find your next interview →" CTA there that routes to `/creators/leads`. Keeps creators moving from one interview to the next without re-navigating.
+
+Optional for v1. Low effort if your submit-success page is easy to edit.
+
+### Naming consistency with mobile
+
+The mobile app calls the same destination two different things depending on which entry point you're tapping. Match this naming on web so creators see consistent language across platforms:
+
+| Mobile button | Web equivalent | Routes to |
+|---|---|---|
+| `See Live Business` (map view of already-interviewed leads with live websites) | Same label on web — or use it as a sub-tab inside `/creators/leads` filtered to `lead.business.websiteUrl != null` | `/creators/leads?live=true` (suggested) |
+| `Find Local Business` (Outscraper discover flow for prospects to interview) | Documented in [WEB-BUILD-CRM-PAGE.md](./WEB-BUILD-CRM-PAGE.md) — Prospects tab | `/creators/leads?tab=prospects` |
+| Generic "Leads" tab/nav item | "Leads" in the top nav | `/creators/leads` |
+
+The user has been explicit: **"See Live Business" = already-interviewed leads with live websites; "Find Local Business" = Outscraper-discovered prospects.** Don't blur the distinction.
+
+---
+
 ## List page UX spec (`/creators/leads`)
 
 Visual reference: mobile's `app/(app)/leads/index.tsx`. The web should be the desktop expansion of that pattern, NOT a separate design language.
@@ -104,6 +174,8 @@ Visual reference: mobile's `app/(app)/leads/index.tsx`. The web should be the de
 │                                                                    │
 │  The whole team's hunt — including yours.                         │
 │  Last sync: 12s ago · 38 leads · 6 hot                            │
+│                                                                    │
+│  [▤ See Live Business  ↗]      [⌕ Find Local Business  ↗]        │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
@@ -111,6 +183,21 @@ Visual reference: mobile's `app/(app)/leads/index.tsx`. The web should be the de
 - Live dot pulses next to "LIVE" if Convex socket connected
 - Display headline: Instrument Serif, two-line. The italic word (here: "every") is `colors.accent` emerald
 - Sub-copy: Onest 15px, ink-2
+
+### Two action Doors directly under the headline
+
+These are the primary creator actions and must always be visible above the filter row. Match mobile's two buttons one-to-one.
+
+| Button label | Caption (mono eyebrow) | Variant | What it does | Mobile reference |
+|---|---|---|---|---|
+| **See Live Business** | `ON THE MAP` | `accent` (emerald fill, white text) | Routes to a map view showing already-interviewed businesses that have **live websites**. This is the "what's already working — and earning — on the platform" view. | Mobile: `app/(app)/leads/index.tsx` line ~244 (button), `app/(app)/leads/nearby.tsx` (destination map view). On mobile this opens a native Google Maps view with markers. Web equivalent: either embed Google Maps or open a filtered list with `?live=true` showing only leads where `lead.business.websiteUrl != null`. |
+| **Find Local Business** | `DISCOVER` | `ghost` (paper-3 with ink border) | Opens the Outscraper "discover prospects" flow. Creator picks a category (e.g. "barbershop") + radius (1/3/5/10 km) + confirms, and Convex calls Outscraper to pull nearby businesses **that nobody has interviewed yet**. These appear in the Prospects tab. | Mobile: `app/(app)/leads/index.tsx` line ~252 (button) + the `showScrape` modal lower in the file. On web, this is the gateway into `/creators/leads?tab=prospects` (see [WEB-BUILD-CRM-PAGE.md](./WEB-BUILD-CRM-PAGE.md) for the full Prospects spec). |
+
+**Critical distinction the user has spelled out:**
+- **See Live Business** → existing leads, already interviewed, has a live website → creator can study what's working, what content reads well, etc.
+- **Find Local Business** → BRAND NEW prospects from Outscraper → creator goes and interviews them to earn
+
+Don't merge these into one button. Don't swap their semantics. The labels are exact.
 
 ### Filters row (sticky on scroll)
 
@@ -177,25 +264,47 @@ Both card modes are clickable (full card → detail route). Use semantic `<artic
 
 Two-column on desktop, single-column on tablet/mobile.
 
+> **Mobile parity check.** The mobile detail screen (`ndm/app/(app)/leads/[leadId].tsx`) has SEVEN sections + four action buttons. The web detail page must include all of them — earlier versions of this spec missed Directions, View Website, and the Interviewed-by roster. Don't skip them.
+
 ### Left column (60% width)
 
 1. **Breadcrumb** — `STEP 03 / TEAM LEADS / Lorenzo's Sari-Sari Store`. Last segment serif italic if admin-curated.
 2. **Submitter strip** — Avatar + display name + relative time ("Submitted by Maria S. · 2d ago"). If `isMine`, append a small `MINE` mono pill.
 3. **Status row** — current status as a large pill. If `isMine` or admin, click to open status update dropdown. Status changes write via `leads.updateStatus`.
 4. **Admin social card** (if `hasEnrichedContent`) — exact same FB-style render as the list card, full-width.
-5. **Business details** — paper-3 Card with `business.businessName`, `businessType`, address, city, owner name + phone, etc. Click-to-call on the phone.
-6. **Other interviewers** — paper-3 Card. List of interviewers from `detail.interviewers`. Each row: avatar + display name + time + submission status pill. Used to surface "this business has been interviewed 3 times — it's hot."
-7. **Notes feed** — paper-3 Card. List of notes (latest first). Below the list, an `EditorialField` for posting a new note. POST goes to `leadNotes.add`. Optimistic update; show toast on failure.
+5. **Customer card** — paper-3 Card with `lead.name`, `lead.phone`, `lead.email` (if present). Two primary action buttons inline at the bottom of this card:
+   - **Call** — `colors.accentSolid` (emerald) ink-on-fill button, `Ionicons name="call"`. Wires to `tel:{phone}`. Skip render if no phone.
+   - **Email** — `colors.business` (ink-blue) ink-on-fill button, `Ionicons name="mail"`. Wires to `mailto:{email}`. Skip render if no email.
+6. **Business profile card** — paper-3 Card with `business.businessName` (Display sm), `business.businessType` (Body xs ink3), and a vertically-stacked metadata block with leading Ionicons:
+   - `person-outline` + `business.ownerName`
+   - `call-outline` + `business.ownerPhone`
+   - `mail-outline` + `business.ownerEmail` (if present)
+   - `location-outline` + full address line: `{address}, {city}, {province}`
+   - Optional: horizontal scrollview of `business.photos` thumbnails (104×104, rounded `radius.sm`, tap to open lightbox)
+   - **Two action buttons** below the metadata, side-by-side or stacked depending on width:
+     - **Directions** — `colors.paper2` fill + `colors.rule` border, `Ionicons name="map-outline"` + label "Directions". Opens Google Maps with the business address. URL: `https://www.google.com/maps/search/?api=1&query={encodeURIComponent(address + ', ' + city)}`. **Must always be present** when the business has an address (which is always — submissions require address).
+     - **View website** — `border: 1px solid colors.accent`, transparent fill, `Ionicons name="globe-outline"` in accent + label "View website" in accent. Wires to `business.websiteUrl`. **Only renders when `business.websiteUrl` is set** (i.e., the submission's generated site has been deployed). This is what distinguishes leads with live websites from those still in pipeline. **Don't hide the button entirely if `websiteUrl` is null — instead render a disabled/ghost version that says "Website not live yet"** so creators understand the state.
+7. **Interviewed by (interviewer roster)** — paper-3 Card with a mono `INTERVIEWED BY` eyebrow and a `{count} {count===1?'creator':'creators'}` pill in the top-right. The body is a list of every creator who has interviewed this business (matched by `business.ownerPhone` normalization, computed server-side in `getDetailForMobileCRM` and returned as `interviewers[]`). Each row:
+   - Avatar (image OR initial-on-bg fallback). If `interviewer.isMine === true`, use `colors.accent` bg and 3px left-border on the row container.
+   - Display name + small `YOU` mono pill when `isMine`
+   - Mono subtitle: `{relative time} · {submission status}` (status text in `colors.danger` when `submissionStatus === "rejected"`, otherwise `colors.ink2`)
+   - Row background: `colors.accentBg` when `isMine`, `colors.paper2` otherwise. Opacity 0.6 when rejected AND not isMine.
+   - Empty state when `interviewers.length === 0`: render serif italic "No interview history found for this business." (paper-3 background, no row)
+   - **This section is what surfaces the "this business has been interviewed 3 times — it's hot" pattern.** Don't omit it.
+8. **Notes feed** — paper-3 Card. Mono `NOTES ({count})` eyebrow. List of notes (latest first) rendered as `colors.paper2` rounded bubbles. Below the list, an `EditorialField` textarea + accent send button. POST goes to `leadNotes.add`. Optimistic update; toast on failure.
 
 ### Right column (40% width — sticky on desktop)
 
-1. **Quick contact card** — phone (click-to-call), email (click-to-mailto), copy buttons next to each.
-2. **Lead metadata** — created date, source, lead ID (small mono).
-3. **Submission link** — link to the underlying submission detail in the admin / public submission page, if visible to creators.
+The right column is the **at-a-glance contact + action shortcut bar**. It mirrors the in-card buttons from the left column but keeps them visible while the creator scrolls through interviewers + notes.
+
+1. **Quick contact card** — phone (click-to-call), email (click-to-mailto), copy-to-clipboard buttons next to each.
+2. **Quick actions card** — duplicate Door buttons for Directions + View website (or "Website not live yet" ghost when unavailable). Right column should NEVER show different state than the left — they're synced reflections of the same `lead.business.websiteUrl` and address.
+3. **Lead metadata** — created date, source (`lead.source` — `website` / `qr_code` / `direct` / `outscraper`), lead ID (small mono, click-to-copy).
+4. **Submission link** — if `lead.submissionId` is set, link to the underlying submission detail page. Renders as ghost Door: `[View submission →]`.
 
 ### Mobile (web responsive)
 
-Collapse to single column. Sticky right column becomes a "Quick actions" bottom sheet triggered by a Door button.
+Collapse to single column. Sticky right column becomes a "Quick actions" bottom sheet triggered by a Door button. The Directions + View website + Call buttons should ALSO appear inline within their respective cards on mobile (not just in the sheet) — creators tend to scroll, so the buttons need to be reachable inside the flow too.
 
 ---
 


### PR DESCRIPTION
# Latest Changes ✨

**Leads and Map Filtering Improvements:**

* [`/leads/near/page.tsx`](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428L4-R25): Added a toggle between "all mappable" leads and only those with a live website, using URL state (`?live=true`). The UI now clearly distinguishes between these modes, updates counts accordingly, and provides a mode switcher with clear labels and icons. [[1]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428L4-R25) [[2]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428R47-R63) [[3]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428L94-R129) [[4]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428R178-R233)
* [`/leads/page.tsx`](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL9-R26): Introduced Suspense for routing, a tab-based filter for "All Leads" vs. "Prospects" (`?tab=prospects`), and editorial copy that adapts per tab. The two main CTAs ("See Live Business" and "Find Local Business") are now distinct, per spec. Tab and count logic ensures accurate stats and filtering. [[1]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL9-R26) [[2]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL55-R80) [[3]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL124-R168) [[4]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL156-R217) [[5]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL165-R229) [[6]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL210-R279) [[7]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL228-R339)

**UI/UX Enhancements:**

* Both pages now use Suspense to ensure that URL state (via `useSearchParams`) is available before rendering, preventing hydration mismatches and improving perceived performance. [[1]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428R47-R63) [[2]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL55-R80)
* Added clear, spec-compliant editorial copy and navigation elements, including tab switchers and action doors, to guide users through the new modes and filters. [[1]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL156-R217) [[2]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL165-R229) [[3]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL210-R279) [[4]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL228-R339) [[5]](diffhunk://#diff-d5af3f4dd7be7b4bf9d278887d6a01e92c6c6c05cb11fdb26f8ca5714cd31428R178-R233)

**API Endpoint Simplification:**

* [`app/api/download-apk/route.ts`](diffhunk://#diff-19ea635885f26bd24767e940b4f0ae9f5c02d94eadcf840fdde6be45a1727e4bL4-L106): Simplified the APK download endpoint to a thin passthrough that redirects to the canonical `apk_download_url`. All logic for filename friendliness and storage is now handled at upload time, removing the need for presigned URLs or Content-Disposition rewrites.

