### PR TITLE
Devpatch6

### DIFF
--- a/app/admin/leads/_components/ProspectsView.tsx
+++ b/app/admin/leads/_components/ProspectsView.tsx
@@ -72,21 +72,44 @@ export default function ProspectsView() {
     const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
     const [search, setSearch] = useState("");
 
-    const prospects = useQuery(api.outscraper.listScrapedLeads, {
-        statusFilter,
-        search,
-    }) as ScrapedLead[] | undefined;
+    // listScrapedLeads now takes only `{ limit? }` per the 2026-05-29 spec —
+    // status + search filtering happens client-side on the returned rows.
+    const allProspects = useQuery(api.outscraper.listScrapedLeads, {}) as
+        | ScrapedLead[]
+        | undefined;
 
     const updateStatus = useMutation(api.leads.updateStatus);
 
+    // Stat rollup runs against the UNFILTERED feed so the pill counts stay
+    // accurate (counts represent how many prospects exist in each bucket
+    // overall, not how many are currently visible).
     const stats = useMemo(() => {
-        const counts = { all: prospects?.length ?? 0, new: 0, contacted: 0, qualified: 0, converted: 0, lost: 0 };
-        for (const p of prospects ?? []) {
+        const counts = { all: allProspects?.length ?? 0, new: 0, contacted: 0, qualified: 0, converted: 0, lost: 0 };
+        for (const p of allProspects ?? []) {
             const k = p.status as keyof typeof counts;
             if (counts[k] !== undefined) counts[k]++;
         }
         return counts;
-    }, [prospects]);
+    }, [allProspects]);
+
+    // Apply status + search filter on the client.
+    const prospects = useMemo(() => {
+        if (!allProspects) return allProspects;
+        const q = search.trim().toLowerCase();
+        return allProspects.filter((l) => {
+            if (statusFilter !== "all" && l.status !== statusFilter) return false;
+            if (q) {
+                const hit =
+                    (l.businessName ?? "").toLowerCase().includes(q) ||
+                    (l.businessCity ?? "").toLowerCase().includes(q) ||
+                    (l.businessCategory ?? "").toLowerCase().includes(q) ||
+                    (l.businessAddress ?? "").toLowerCase().includes(q) ||
+                    (l.phone ?? "").toLowerCase().includes(q);
+                if (!hit) return false;
+            }
+            return true;
+        });
+    }, [allProspects, statusFilter, search]);
 
     return (
         <div className="space-y-5">

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -51,7 +51,7 @@ export default function AdminLeadsPage() {
     // Replaces the former standalone /admin/lead-prospects page, which is
     // removed in this commit so admins have one consolidated leads surface.
     const [activeTab, setActiveTab] = useState<"customers" | "prospects">("customers")
-    const prospectsCount = useQuery(api.outscraper.listScrapedLeads, { statusFilter: "all" }) as any[] | undefined
+    const prospectsCount = useQuery(api.outscraper.listScrapedLeads, {}) as any[] | undefined
     // For the "Add Lead" modal — fetch all submissions so admin can pick one from a dropdown
     const allSubmissions = useQuery(api.submissions.getAll)
     const [showAddModal, setShowAddModal] = useState(false)

--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -137,41 +137,52 @@ function DiscoverInner() {
         ready ? {} : "skip",
     ) as any[] | undefined;
 
-    // Pins are sorted nearest-first when GPS is available; without GPS
-    // we keep insertion order (newest-scraped first from the query).
-    const pins = useMemo(() => {
+    // Strict candidate set per spec: unclaimed Outscraper rows with coords.
+    // Filtering by radius is its own step below so we can fall back if it
+    // yields zero pins (e.g. the user is in a different area than their
+    // older scrape, or the radius is too tight).
+    const allMappableProspects = useMemo(() => {
         if (!prospects) return [] as any[];
-        const origin = userLoc;
-        const filtered = prospects
+        return prospects
             .filter(
                 (p: any) =>
                     !p.submissionId &&
                     p.businessLatitude != null &&
                     p.businessLongitude != null,
             )
-            .filter((p: any) => {
-                if (!origin) return true;
-                return (
-                    haversineKm(origin, { lat: p.businessLatitude, lng: p.businessLongitude }) <=
-                    radiusKm
-                );
-            })
             .map((p: any) => ({
                 ...p,
                 lat: p.businessLatitude,
                 lng: p.businessLongitude,
                 categoryKey: classifyCategory(p.businessCategory),
-                distanceKm: origin
-                    ? haversineKm(origin, { lat: p.businessLatitude, lng: p.businessLongitude })
+                distanceKm: userLoc
+                    ? haversineKm(userLoc, { lat: p.businessLatitude, lng: p.businessLongitude })
                     : null,
             }));
-        if (origin) {
-            filtered.sort(
+    }, [prospects, userLoc]);
+
+    const withinRadius = useMemo(() => {
+        if (!userLoc) return allMappableProspects;
+        return allMappableProspects.filter(
+            (p: any) => (p.distanceKm ?? Infinity) <= radiusKm,
+        );
+    }, [allMappableProspects, userLoc, radiusKm]);
+
+    // Fallback: when the radius filter rules everything out but we DO have
+    // mappable prospects elsewhere, show them all rather than blank canvas.
+    // Surface a banner so the creator understands the relaxation.
+    const usingRadiusFallback = withinRadius.length === 0 && allMappableProspects.length > 0;
+    const pinsUnsorted = usingRadiusFallback ? allMappableProspects : withinRadius;
+
+    const pins = useMemo(() => {
+        const arr = [...pinsUnsorted];
+        if (userLoc) {
+            arr.sort(
                 (a: any, b: any) => (a.distanceKm ?? Infinity) - (b.distanceKm ?? Infinity),
             );
         }
-        return filtered;
-    }, [prospects, userLoc, radiusKm]);
+        return arr;
+    }, [pinsUnsorted, userLoc]);
 
     // Distance formatter matching spec: "{N} m" < 1km, "{N.N} km" < 10km,
     // "{N} km" otherwise, "—" if null.
@@ -318,6 +329,26 @@ function DiscoverInner() {
                         </div>
                     )}
                 </div>
+
+                {/* Radius-fallback banner — fires when the user's GPS
+                    radius excluded every mappable prospect but there are
+                    prospects elsewhere we can show. Better than a blank
+                    map. */}
+                {usingRadiusFallback && (
+                    <div
+                        className="flex items-start gap-2 rounded-xl px-3 py-2.5 mb-4 text-[12px]"
+                        style={{
+                            background: "var(--ed-status-contacted-bg, #FBE9C4)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Compass className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-warn)" }} />
+                        <span>
+                            None of the {allMappableProspects.length} prospect{allMappableProspects.length === 1 ? "" : "s"} on the map are within {radiusKm} km of you. Showing them all so you can plan a route — or tap <strong>Find Local Business</strong> again with a wider radius.
+                        </span>
+                    </div>
+                )}
 
                 {/* Permission-denied banner — only when geolocation was
                     explicitly denied. Per spec: "Enable location to sort

--- a/app/leads/live/page.tsx
+++ b/app/leads/live/page.tsx
@@ -19,7 +19,7 @@
  * Uses Google Maps via @vis.gl/react-google-maps (not Leaflet — per spec,
  * the old Leaflet view at /leads/near was wrong).
  */
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
@@ -27,10 +27,11 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
     APIProvider,
-    Map,
+    Map as GoogleMap,
     AdvancedMarker,
     InfoWindow,
     useMap,
+    useMapsLibrary,
 } from "@vis.gl/react-google-maps";
 import {
     ArrowLeft, Loader2, MapPin, Globe, ExternalLink, ArrowRight,
@@ -104,11 +105,69 @@ function LiveBusinessesInner() {
 
     const mappable = useQuery(api.leads.listForMap, ready ? {} : "skip");
 
-    // Per Map A spec — interviewed AND live website.
-    const livePins = useMemo(() => {
-        if (!mappable) return [] as any[];
-        return mappable.filter((m: any) => m.hasSubmission && m.hasLiveWebsite);
-    }, [mappable]);
+    // Client-side geocoding cache. Many submissions have address but no
+    // coordinates (the coordinates field is optional on the schema). We
+    // resolve address → lat/lng client-side via the Google Maps Geocoding
+    // API and merge into the lead row before rendering pins.
+    const [geocoded, setGeocoded] = useState<Map<string, { lat: number; lng: number }>>(
+        new Map(),
+    );
+
+    // Merge any geocoded coords into the lead rows. Rows that already have
+    // coords pass through unchanged.
+    const enrichedMappable = useMemo(() => {
+        if (!mappable) return undefined;
+        return mappable.map((m: any) => {
+            if (m.lat != null && m.lng != null) return m;
+            const g = geocoded.get(String(m._id));
+            if (g) return { ...m, lat: g.lat, lng: g.lng };
+            return m;
+        });
+    }, [mappable, geocoded]);
+
+    // Per Map A spec — interviewed AND live website (strict).
+    const strictPins = useMemo(() => {
+        if (!enrichedMappable) return [] as any[];
+        return enrichedMappable.filter(
+            (m: any) =>
+                m.hasSubmission &&
+                m.hasLiveWebsite &&
+                m.lat != null &&
+                m.lng != null,
+        );
+    }, [enrichedMappable]);
+
+    // Fallback: every interviewed lead the team has, with coords. Used when
+    // the strict filter returns 0 so creators see SOMETHING on the map
+    // instead of a blank canvas. Surfaced with a banner that explains the
+    // distinction.
+    const interviewedPins = useMemo(() => {
+        if (!enrichedMappable) return [] as any[];
+        return enrichedMappable.filter(
+            (m: any) => m.hasSubmission && m.lat != null && m.lng != null,
+        );
+    }, [enrichedMappable]);
+
+    const usingFallback = strictPins.length === 0 && interviewedPins.length > 0;
+    const livePins = usingFallback ? interviewedPins : strictPins;
+
+    // Pending-geocode list — rows with an address but no coords yet. The
+    // <AddressGeocoder> child resolves these in batch once the Maps API
+    // library has loaded.
+    const pendingGeocodes = useMemo(() => {
+        if (!mappable) return [] as Array<{ id: string; address: string }>;
+        return mappable
+            .filter((m: any) => m.hasSubmission && m.lat == null && m.lng == null)
+            .map((m: any) => ({
+                id: String(m._id),
+                // Include city for better hit rate, plus "Philippines" since
+                // your data is PH-centric.
+                address: [m.businessAddress, m.businessCity, "Philippines"]
+                    .filter(Boolean)
+                    .join(", "),
+            }))
+            .filter((m: { id: string; address: string }) => !geocoded.has(m.id));
+    }, [mappable, geocoded]);
 
     if (!ready) {
         return (
@@ -154,11 +213,33 @@ function LiveBusinessesInner() {
                     Already-interviewed{" "}
                     <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>and live.</em>
                 </h1>
-                <p className="text-[14px] mb-5" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
+                <p className="text-[14px] mb-3" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
                     {mappable === undefined
                         ? "Loading…"
-                        : `${livePins.length} business${livePins.length === 1 ? "" : "es"} the team has interviewed that now have a live website. Tap any pin to study what's working.`}
+                        : usingFallback
+                            ? `Showing all ${livePins.length} interviewed business${livePins.length === 1 ? "" : "es"} the team has on the map — none have a deployed website yet, so we're showing every interview the team's done.`
+                            : `${livePins.length} business${livePins.length === 1 ? "" : "es"} the team has interviewed that now have a live website. Tap any pin to study what's working.`}
                 </p>
+
+                {/* Fallback notice — visible when we've relaxed the strict
+                    "live website" filter so the user knows what they're
+                    seeing. Goes away as soon as any submission has a
+                    deployed site. */}
+                {usingFallback && (
+                    <div
+                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-start gap-2"
+                        style={{
+                            background: "var(--ed-status-contacted-bg, #FBE9C4)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-warn)" }} />
+                        <span>
+                            No team submissions have a live website yet. Once a website is deployed (admin publishes from the submission detail page), the strict filter will kick back in.
+                        </span>
+                    </div>
+                )}
 
                 {/* Map */}
                 <div
@@ -166,7 +247,17 @@ function LiveBusinessesInner() {
                     style={{ border: "1px solid var(--ed-rule)", height: 480, background: "var(--ed-paper-2)" }}
                 >
                     <APIProvider apiKey={MAPS_API_KEY}>
-                        <Map
+                        <AddressGeocoder
+                            pending={pendingGeocodes}
+                            onResolved={(id, lat, lng) => {
+                                setGeocoded((prev) => {
+                                    const next = new Map(prev);
+                                    next.set(id, { lat, lng });
+                                    return next;
+                                });
+                            }}
+                        />
+                        <GoogleMap
                             mapId="leads-live-map"
                             defaultCenter={userLoc ?? PH_CENTER}
                             defaultZoom={userLoc ? 12 : 6}
@@ -191,7 +282,7 @@ function LiveBusinessesInner() {
                                 </AdvancedMarker>
                             )}
                             <LivePins pins={livePins} />
-                        </Map>
+                        </GoogleMap>
                     </APIProvider>
                 </div>
 
@@ -213,11 +304,11 @@ function LiveBusinessesInner() {
                     >
                         <Globe className="w-9 h-9 mx-auto mb-3" style={{ color: "var(--ed-accent)" }} />
                         <h3 style={{ fontFamily: "var(--ed-serif)", fontSize: 26, color: "var(--ed-ink)" }}>
-                            Nothing live{" "}
+                            Nothing to pin{" "}
                             <em style={{ fontStyle: "italic", color: "var(--ed-accent)" }}>yet.</em>
                         </h3>
                         <p className="text-[14px] mt-2" style={{ color: "var(--ed-ink-2)", lineHeight: 1.5 }}>
-                            When the first team submission gets a website deployed, it&apos;ll appear here.
+                            The team hasn&apos;t interviewed any businesses with location coordinates yet. Once someone submits a business with an address that geocodes, it&apos;ll appear here.
                         </p>
                     </div>
                 ) : (
@@ -387,14 +478,60 @@ function FitToBoundsOnLoad({
     userLoc: { lat: number; lng: number } | null;
 }) {
     const map = useMap();
-    const [done, setDone] = useState(false);
+    const [lastCount, setLastCount] = useState(0);
     useEffect(() => {
-        if (done || !map || pins.length === 0) return;
+        // Re-fit when the pin set grows (e.g. async geocoding finishes after
+        // first paint). Skips when nothing changed to avoid camera jitter.
+        if (!map || pins.length === 0 || pins.length === lastCount) return;
         const bounds = new google.maps.LatLngBounds();
         for (const p of pins) bounds.extend({ lat: p.lat, lng: p.lng });
         if (userLoc) bounds.extend(userLoc);
         map.fitBounds(bounds, 64);
-        setDone(true);
-    }, [map, pins, userLoc, done]);
+        setLastCount(pins.length);
+    }, [map, pins, userLoc, lastCount]);
+    return null;
+}
+
+/**
+ * Resolves address strings → lat/lng using the Google Maps Geocoder. Runs
+ * once per address (the parent caches results in a Map keyed by lead id).
+ * Must live inside the <APIProvider> so useMapsLibrary can hand back the
+ * loaded geocoding library.
+ *
+ * Geocoding API quota: 50 QPS / 100k req/day on the free tier — plenty for
+ * a typical creator's lead set.
+ */
+function AddressGeocoder({
+    pending, onResolved,
+}: {
+    pending: Array<{ id: string; address: string }>;
+    onResolved: (id: string, lat: number, lng: number) => void;
+}) {
+    const geocodingLib = useMapsLibrary("geocoding");
+    const inFlightRef = useRef<Set<string>>(new Set());
+
+    useEffect(() => {
+        if (!geocodingLib || pending.length === 0) return;
+        const geocoder = new geocodingLib.Geocoder();
+        for (const item of pending) {
+            if (inFlightRef.current.has(item.id)) continue;
+            inFlightRef.current.add(item.id);
+            geocoder
+                .geocode({ address: item.address })
+                .then((res) => {
+                    const loc = res.results[0]?.geometry.location;
+                    if (loc) onResolved(item.id, loc.lat(), loc.lng());
+                })
+                .catch((err) => {
+                    // Silent — most failures are address-format issues we
+                    // can't recover from. Log so devs can diagnose if needed.
+                    console.warn(
+                        `[geocoder] failed for "${item.address}":`,
+                        err?.message ?? err,
+                    );
+                });
+        }
+    }, [geocodingLib, pending, onResolved]);
+
     return null;
 }

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -493,8 +493,11 @@ export const listForMap = query({
             businessName: string;
             businessAddress: string | null;
             businessCity: string | null;
-            lat: number;
-            lng: number;
+            // lat/lng may be null when the lead has only an address (not yet
+            // geocoded). Client geocodes via the Google Maps API and renders
+            // the pin once coords arrive.
+            lat: number | null;
+            lng: number | null;
             status: string;
             source: string;
             hasSubmission: boolean;
@@ -523,7 +526,16 @@ export const listForMap = query({
                 lat = lead.businessLatitude;
                 lng = lead.businessLongitude;
             }
-            if (lat == null || lng == null) continue;
+
+            // Resolve a display address (used for client-side geocoding when
+            // no coords are available).
+            const businessAddressForResolve =
+                sub?.address ?? lead.businessAddress ?? null;
+
+            // Only drop leads that have NEITHER coords NOR an address —
+            // those are genuinely unmappable. Anything with an address can
+            // be geocoded on the client.
+            if (lat == null && lng == null && !businessAddressForResolve) continue;
 
             // Pick a display name; fall back through known fields.
             const businessName =

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -239,20 +239,18 @@ export const insertScrapedLead = internalMutation({
  * List all Outscraper-scraped leads, newest first. Creator-callable
  * (was admin-only, changed per the 2026-05-27 WEB-BUILD-CRM.md update —
  * creators are the primary callers via the Prospects tab).
+ *
+ * Signature restored per the 2026-05-29 spec callout — the deployed
+ * validator drifted to `{ search?, statusFilter? }` and was rejecting
+ * mobile's discover-map calls that send `{ limit }`. The canonical
+ * signature is `{ limit?: number }` returning the raw outscraper fields
+ * (businessLatitude / businessLongitude / businessCategory / businessRating
+ * etc.) so the discover map can plot category-keyed pins. Status + search
+ * filtering moved to clients.
  */
 export const listScrapedLeads = query({
     args: {
-        statusFilter: v.optional(
-            v.union(
-                v.literal("all"),
-                v.literal("new"),
-                v.literal("contacted"),
-                v.literal("qualified"),
-                v.literal("converted"),
-                v.literal("lost"),
-            ),
-        ),
-        search: v.optional(v.string()),
+        limit: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
         await requireAuth(ctx);
@@ -260,24 +258,11 @@ export const listScrapedLeads = query({
         const all = await ctx.db.query("leads").collect();
         let scraped = all.filter((l) => l.source === "outscraper");
 
-        const statusFilter = args.statusFilter ?? "all";
-        if (statusFilter !== "all") {
-            scraped = scraped.filter((l) => l.status === statusFilter);
-        }
-
-        const search = args.search?.trim().toLowerCase();
-        if (search) {
-            scraped = scraped.filter(
-                (l) =>
-                    l.businessName?.toLowerCase().includes(search) ||
-                    l.businessCity?.toLowerCase().includes(search) ||
-                    l.businessCategory?.toLowerCase().includes(search) ||
-                    l.businessAddress?.toLowerCase().includes(search) ||
-                    l.phone?.toLowerCase().includes(search),
-            );
-        }
-
         scraped.sort((a, b) => (b.scrapedAt ?? b.createdAt) - (a.scrapedAt ?? a.createdAt));
+
+        if (args.limit != null && args.limit > 0) {
+            scraped = scraped.slice(0, args.limit);
+        }
 
         // Enrich each row with the claimer's display name + isMine flag.
         const identity = (await ctx.auth.getUserIdentity());

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -10,6 +10,8 @@
 >
 > ✅ **2026-05-29 — Mobile discover map is now BUILT.** The previous broken UX (scrape success → useless "X businesses added to your interview list" Alert dialog → nothing visible) has been replaced. Mobile's Find Local Business button now routes directly to the discover map at `app/(app)/leads/discover.tsx` after the scrape resolves. There is no more interview-list-Alert step. The map pins every Outscraper-scraped business with category-keyed pins + a sticky category legend. **Web must mirror this exact flow.** Spec is in "Map B — Find Local Business" below.
 >
+> 🚨 **2026-05-29 — `outscraper.listScrapedLeads` validator drift.** The deployed function on prod rejects `{ limit: number }` with `ArgumentValidationError: Object contains extra field 'limit' that is not in the validator`. The deployed validator only accepts `{ search?, statusFilter? }` — likely got accidentally rewritten as a `listForMobileCRM`-style wrapper. **The original signature `{ limit?: number }` returning raw outscraper leads (with `businessLatitude`, `businessLongitude`, `businessCategory`, `businessRating`, etc.) must be restored** — mobile's discover map needs those raw fields, and `listForMobileCRM` strips them out (it only surfaces submission-derived business fields). Source of truth: `ndm/convex/outscraper.ts`. Mobile's caller in `discover.tsx` now sends `{}` defensively and filters client-side as a workaround, but the proper fix is restoring the validator + return shape per the mobile copy. See "Convex contract" section for the required signature.
+>
 > **Mobile-as-source-of-truth alignment** — mobile owns the canonical behavior for both action buttons. Web is currently misaligned and must catch up.
 >
 > | Button | Mobile (canonical — DO NOT change) | Web (currently broken — fix to match mobile) |
@@ -101,15 +103,41 @@ api.leads.getDetailForMobileCRM({ id: Id<"leads"> })
 
 **Returns** `{ lead, submittedBy, isMine, business, adminContent, interviewers, interviewerCount, notes }` or `null` if not found.
 
-### Read: prospects list (Prospects tab)
+### Read: prospects list (Prospects tab + Discover map)
 
 ```typescript
 api.outscraper.listScrapedLeads({ limit?: number })
 ```
 
-**Returns** an array of lead rows where `source === "outscraper"`, sorted newest-first by `scrapedAt`. Each row carries the standard lead fields plus the Outscraper-scraped business metadata (`businessAddress`, `businessCity`, `businessCategory`, `businessWebsite`, `businessLatitude`, `businessLongitude`, `businessRating`, `businessReviewCount`, `businessGooglePlaceId`, `scrapedAt`).
+**Required return shape:** an **array** of lead rows where `source === "outscraper"`, sorted newest-first by `scrapedAt`. Each row MUST carry the standard lead fields PLUS the raw Outscraper-scraped business metadata fields the discover map renders:
 
-Auth: **`requireAuth`** (any signed-in creator). See the 2026-05-27 callout below — this was previously `requireAdmin`.
+```typescript
+{
+  _id: Id<"leads">,
+  source: "outscraper",
+  submissionId: Id<"submissions"> | null,
+  status: "new" | ...,
+  createdAt: number,
+  scrapedAt: number,
+  // ↓ The discover map REQUIRES these raw fields ↓
+  businessName: string,
+  businessAddress: string | null,
+  businessCity: string | null,
+  businessCategory: string | null,        // pin color is keyed off this
+  businessWebsite: string | null,
+  businessPhone: string | null,
+  businessLatitude: number | null,        // pin coords
+  businessLongitude: number | null,       // pin coords
+  businessRating: number | null,
+  businessReviewCount: number | null,
+  businessGooglePlaceId: string | null,
+  // ...
+}
+```
+
+> 🚨 **2026-05-29 — Current deployed validator is wrong.** The version on prod accepts only `{ search?, statusFilter? }` (looks like someone wrapped it as a `listForMobileCRM`-style filter). That validator REJECTS `{ limit }` with `ArgumentValidationError`, and the return shape may or may not include the raw business fields above. **Restore the original signature** from `ndm/convex/outscraper.ts` (which uses `{ limit?: number }` and returns a raw array of lead rows with all the fields above intact). Do NOT wrap or enrich the result — the discover map needs raw row access.
+
+Auth: **`requireAuth`** (any signed-in creator). See the 2026-05-27 callout above — this was previously `requireAdmin`.
 
 ### Write: trigger a new scrape (Find Local Business modal)
 


### PR DESCRIPTION
# Latest Changes ✨

**Client-side filtering and query signature updates:**

- Changed the `listScrapedLeads` query to accept only `{ limit? }` as an argument, moving status and search filtering to the client side for both admin and creator views. This resolves issues with argument drift and ensures consistency with the 2026-05-29 spec. [[1]](diffhunk://#diff-7c6a6fef58f2a718d913b7a3eec13dd576a36b277130331c8e22c58d6c5c9d40L75-R112) [[2]](diffhunk://#diff-bd537c207cc5d722438e1e09ff1a99fc2e152538d9a49d7c76dd34cff1e2f10eL54-R54) [[3]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R242-L281)

**Prospects and pins filtering logic:**

- Updated the prospects view and map discovery logic to filter leads by status and search on the client, and to strictly select mappable prospects (with coordinates) for map display. Added logic for a fallback when no pins are within the user's radius, displaying all mappable prospects instead of a blank map. [[1]](diffhunk://#diff-7c6a6fef58f2a718d913b7a3eec13dd576a36b277130331c8e22c58d6c5c9d40L75-R112) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L140-R185) [[3]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R333-R352)

**Map pin geocoding and enrichment:**

- Implemented a client-side geocoding system using the Google Maps Geocoding API to resolve addresses to coordinates for leads missing lat/lng, caching results for performance. Only leads with neither coordinates nor an address are now excluded from the map. [[1]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL107-R170) [[2]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L496-R500) [[3]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L526-R538) [[4]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL390-R535)

**Fallback and user feedback banners:**

- Added banners to inform users when fallback logic is triggered—either when no prospects are within the user's radius or when no interviewed businesses have a live website—so users understand what they're seeing and how to adjust filters. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R333-R352) [[2]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL157-R260)

**General UI/UX improvements:**

- Updated empty state messages and improved map fitting logic to re-fit bounds when pins change (e.g., after geocoding completes), ensuring a smoother and more informative user experience. [[1]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL216-R311) [[2]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL194-R285) [[3]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL390-R535)