### PR TITLE
feat: Fix and Outscrapper v2 and Log Results

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -22,14 +22,19 @@
  * URL state: ?category=salon&radiusKm=5 — passed by the modal on
  * success so the map can scope distance + headline copy.
  */
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
-    APIProvider, Map, AdvancedMarker, InfoWindow, useMap,
+    APIProvider,
+    Map as GoogleMap,
+    AdvancedMarker,
+    InfoWindow,
+    useMap,
+    useMapsLibrary,
 } from "@vis.gl/react-google-maps";
 import { toast } from "sonner";
 import {
@@ -137,29 +142,66 @@ function DiscoverInner() {
         ready ? {} : "skip",
     ) as any[] | undefined;
 
-    // Strict candidate set per spec: unclaimed Outscraper rows with coords.
-    // Filtering by radius is its own step below so we can fall back if it
-    // yields zero pins (e.g. the user is in a different area than their
-    // older scrape, or the radius is too tight).
+    // Client-side geocoder cache — keyed by lead id. Used when an Outscraper
+    // prospect has an address but no latitude/longitude (sometimes happens
+    // when Outscraper can't resolve precise coords for informal places).
+    const [geocoded, setGeocoded] = useState<Map<string, { lat: number; lng: number }>>(
+        new Map(),
+    );
+
+    // Candidate set per spec — unclaimed Outscraper rows. Includes both
+    // rows with coords and rows with only an address (the latter get
+    // geocoded client-side via <AddressGeocoder> below). Filtering by
+    // radius is a separate step so we can fall back if the radius yields
+    // zero pins (e.g. user is in a different area than their older scrape).
     const allMappableProspects = useMemo(() => {
         if (!prospects) return [] as any[];
+        return prospects
+            .filter((p: any) => !p.submissionId)
+            .map((p: any) => {
+                // Resolve coords: Outscraper-provided first, then geocoded.
+                let lat: number | null = p.businessLatitude ?? null;
+                let lng: number | null = p.businessLongitude ?? null;
+                if (lat == null || lng == null) {
+                    const g = geocoded.get(String(p._id));
+                    if (g) {
+                        lat = g.lat;
+                        lng = g.lng;
+                    }
+                }
+                if (lat == null || lng == null) return null;
+                return {
+                    ...p,
+                    lat,
+                    lng,
+                    categoryKey: classifyCategory(p.businessCategory),
+                    distanceKm: userLoc
+                        ? haversineKm(userLoc, { lat, lng })
+                        : null,
+                };
+            })
+            .filter((p): p is any => p !== null);
+    }, [prospects, userLoc, geocoded]);
+
+    // Pending geocode set — prospects with an address but no coords yet.
+    // The <AddressGeocoder> child resolves these in batch.
+    const pendingGeocodes = useMemo(() => {
+        if (!prospects) return [] as Array<{ id: string; address: string }>;
         return prospects
             .filter(
                 (p: any) =>
                     !p.submissionId &&
-                    p.businessLatitude != null &&
-                    p.businessLongitude != null,
+                    (p.businessLatitude == null || p.businessLongitude == null) &&
+                    p.businessAddress,
             )
             .map((p: any) => ({
-                ...p,
-                lat: p.businessLatitude,
-                lng: p.businessLongitude,
-                categoryKey: classifyCategory(p.businessCategory),
-                distanceKm: userLoc
-                    ? haversineKm(userLoc, { lat: p.businessLatitude, lng: p.businessLongitude })
-                    : null,
-            }));
-    }, [prospects, userLoc]);
+                id: String(p._id),
+                address: [p.businessAddress, p.businessCity, "Philippines"]
+                    .filter(Boolean)
+                    .join(", "),
+            }))
+            .filter((p: { id: string; address: string }) => !geocoded.has(p.id));
+    }, [prospects, geocoded]);
 
     const withinRadius = useMemo(() => {
         if (!userLoc) return allMappableProspects;
@@ -259,7 +301,17 @@ function DiscoverInner() {
                     style={{ border: "1px solid var(--ed-rule)", height: 480, background: "var(--ed-paper-2)" }}
                 >
                     <APIProvider apiKey={MAPS_API_KEY}>
-                        <Map
+                        <AddressGeocoder
+                            pending={pendingGeocodes}
+                            onResolved={(id, lat, lng) => {
+                                setGeocoded((prev) => {
+                                    const next = new Map(prev);
+                                    next.set(id, { lat, lng });
+                                    return next;
+                                });
+                            }}
+                        />
+                        <GoogleMap
                             mapId="leads-discover-map"
                             defaultCenter={userLoc ?? PH_CENTER}
                             defaultZoom={userLoc ? 13 : 6}
@@ -283,7 +335,7 @@ function DiscoverInner() {
                                 </AdvancedMarker>
                             )}
                             <CategoryPins pins={pins} />
-                        </Map>
+                        </GoogleMap>
                     </APIProvider>
 
                     {/* Sticky legend — only categories present on the map */}
@@ -427,6 +479,35 @@ function DiscoverInner() {
                         <p className="text-[13px] mt-2 mb-4" style={{ color: "var(--ed-ink-3)", lineHeight: 1.5 }}>
                             Tap Find Local Business again with a wider radius or a different category to add more pins here.
                         </p>
+
+                        {/* DEBUG strip — per WEB-BUILD-CRM.md "Three Outscraper blockers"
+                            triage tree. Surfaces the data shape so creators (and
+                            us during support) can tell at a glance which
+                            blocker is in play:
+                              rows=0          → no Outscraper rows at all (BLOCKER 1 or 3)
+                              outscraper>0, with-coords=0  → BLOCKER 2 (validator drift)
+                              outscraper>0, with-coords>0  → frontend filter bug */}
+                        <div
+                            className="rounded-md px-3 py-2 mb-4 text-[10px] inline-block"
+                            style={{
+                                background: "var(--ed-paper-2)",
+                                color: "var(--ed-ink-3)",
+                                border: "1px solid var(--ed-rule)",
+                                fontFamily: "var(--ed-mono)",
+                                letterSpacing: "0.08em",
+                            }}
+                        >
+                            DEBUG · rows={prospects?.length ?? 0} ·
+                            outscraper={(prospects ?? []).filter((p: any) => !p.submissionId).length} ·
+                            with-coords={
+                                (prospects ?? []).filter(
+                                    (p: any) =>
+                                        !p.submissionId &&
+                                        p.businessLatitude != null &&
+                                        p.businessLongitude != null,
+                                ).length
+                            }
+                        </div>
                         <Link
                             href="/leads"
                             className="inline-flex items-center justify-center gap-1.5 text-[12px] px-4 py-2.5 rounded-xl w-full"
@@ -715,14 +796,56 @@ function FitToBoundsOnLoad({
     userLoc: { lat: number; lng: number } | null;
 }) {
     const map = useMap();
-    const [done, setDone] = useState(false);
+    const [lastCount, setLastCount] = useState(0);
     useEffect(() => {
-        if (done || !map || pins.length === 0) return;
+        // Re-fit when the pin set grows (e.g. geocoding finishes after
+        // first paint and new pins arrive). Skips when nothing changed to
+        // avoid camera jitter on every render.
+        if (!map || pins.length === 0 || pins.length === lastCount) return;
         const bounds = new google.maps.LatLngBounds();
         for (const p of pins) bounds.extend({ lat: p.lat, lng: p.lng });
         if (userLoc) bounds.extend(userLoc);
         map.fitBounds(bounds, 64);
-        setDone(true);
-    }, [map, pins, userLoc, done]);
+        setLastCount(pins.length);
+    }, [map, pins, userLoc, lastCount]);
+    return null;
+}
+
+/**
+ * Same client-side Google Geocoder pattern as /leads/live. Lives inside
+ * <APIProvider> so useMapsLibrary can hand back the loaded geocoding lib.
+ * The parent caches results in a Map keyed by lead id so each address is
+ * geocoded once per session.
+ */
+function AddressGeocoder({
+    pending, onResolved,
+}: {
+    pending: Array<{ id: string; address: string }>;
+    onResolved: (id: string, lat: number, lng: number) => void;
+}) {
+    const geocodingLib = useMapsLibrary("geocoding");
+    const inFlightRef = useRef<Set<string>>(new Set());
+
+    useEffect(() => {
+        if (!geocodingLib || pending.length === 0) return;
+        const geocoder = new geocodingLib.Geocoder();
+        for (const item of pending) {
+            if (inFlightRef.current.has(item.id)) continue;
+            inFlightRef.current.add(item.id);
+            geocoder
+                .geocode({ address: item.address })
+                .then((res) => {
+                    const loc = res.results[0]?.geometry.location;
+                    if (loc) onResolved(item.id, loc.lat(), loc.lng());
+                })
+                .catch((err) => {
+                    console.warn(
+                        `[geocoder] failed for "${item.address}":`,
+                        err?.message ?? err,
+                    );
+                });
+        }
+    }, [geocodingLib, pending, onResolved]);
+
     return null;
 }

--- a/app/leads/live/page.tsx
+++ b/app/leads/live/page.tsx
@@ -23,7 +23,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
-import { useQuery } from "convex/react";
+import { useAction, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
     APIProvider,
@@ -105,10 +105,55 @@ function LiveBusinessesInner() {
 
     const mappable = useQuery(api.leads.listForMap, ready ? {} : "skip");
 
-    // Client-side geocoding cache. Many submissions have address but no
-    // coordinates (the coordinates field is optional on the schema). We
-    // resolve address → lat/lng client-side via the Google Maps Geocoding
-    // API and merge into the lead row before rendering pins.
+    // Server-side geocoding — calls the Convex action that geocodes
+    // submission addresses via Google's REST API and persists the result
+    // to `submission.coordinates`. listForMap is reactive, so the new coords
+    // surface here automatically once the action returns.
+    const geocodePending = useAction(api.leads.geocodePendingSubmissions);
+    const geocodeKickedOffRef = useRef(false);
+    const [geocodeStatus, setGeocodeStatus] = useState<
+        | { phase: "idle" }
+        | { phase: "running" }
+        | { phase: "done"; geocoded: number; failed: number; scanned: number }
+        | { phase: "error"; message: string }
+    >({ phase: "idle" });
+
+    // Count of leads we'd want to map but that lack coords. If > 0 and we
+    // haven't kicked off the action yet, do so now. The action is idempotent
+    // (already-geocoded submissions are skipped) so this is safe.
+    const needsGeocoding = useMemo(() => {
+        if (!mappable) return 0;
+        return mappable.filter(
+            (m: any) => m.hasSubmission && (m.lat == null || m.lng == null),
+        ).length;
+    }, [mappable]);
+
+    useEffect(() => {
+        if (!ready || !mappable) return;
+        if (needsGeocoding === 0) return;
+        if (geocodeKickedOffRef.current) return;
+        geocodeKickedOffRef.current = true;
+        setGeocodeStatus({ phase: "running" });
+        geocodePending({ limit: 50 })
+            .then((res) => {
+                setGeocodeStatus({
+                    phase: "done",
+                    geocoded: res.geocoded,
+                    failed: res.failed,
+                    scanned: res.scanned,
+                });
+            })
+            .catch((err: any) => {
+                setGeocodeStatus({
+                    phase: "error",
+                    message: err?.message ?? "Geocoding failed.",
+                });
+            });
+    }, [ready, mappable, needsGeocoding, geocodePending]);
+
+    // Client-side geocoding cache — kept as a SECONDARY path for any
+    // residual misses after the server-side action runs (or while the
+    // action is in flight). Resolved coords merge into enrichedMappable.
     const [geocoded, setGeocoded] = useState<Map<string, { lat: number; lng: number }>>(
         new Map(),
     );
@@ -237,6 +282,65 @@ function LiveBusinessesInner() {
                         <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-warn)" }} />
                         <span>
                             No team submissions have a live website yet. Once a website is deployed (admin publishes from the submission detail page), the strict filter will kick back in.
+                        </span>
+                    </div>
+                )}
+
+                {/* Geocoding status — visible so the user can see what's
+                    happening when addresses haven't resolved yet. Hides
+                    automatically once everything is done. */}
+                {geocodeStatus.phase === "running" && (
+                    <div
+                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-center gap-2"
+                        style={{
+                            background: "var(--ed-paper-3)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Loader2 className="w-3.5 h-3.5 animate-spin flex-shrink-0" style={{ color: "var(--ed-accent)" }} />
+                        <span>
+                            Geocoding {needsGeocoding} address
+                            {needsGeocoding === 1 ? "" : "es"} via Google Maps —
+                            pins will appear as soon as this finishes (usually
+                            a few seconds).
+                        </span>
+                    </div>
+                )}
+                {geocodeStatus.phase === "done" && geocodeStatus.geocoded > 0 && (
+                    <div
+                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-center gap-2"
+                        style={{
+                            background: "var(--ed-accent-bg, #D1FAE5)",
+                            color: "var(--ed-accent-ink, #064E3B)",
+                            border: "1px solid var(--ed-accent)",
+                        }}
+                    >
+                        <Globe className="w-3.5 h-3.5 flex-shrink-0" />
+                        <span>
+                            Geocoded {geocodeStatus.geocoded} of {geocodeStatus.scanned} address
+                            {geocodeStatus.scanned === 1 ? "" : "es"}.
+                            {geocodeStatus.failed > 0
+                                ? ` ${geocodeStatus.failed} failed (check the addresses for typos).`
+                                : ""}
+                        </span>
+                    </div>
+                )}
+                {geocodeStatus.phase === "error" && (
+                    <div
+                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-start gap-2"
+                        style={{
+                            background: "var(--ed-status-lost-bg, #F3D7CF)",
+                            color: "var(--ed-danger)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+                        <span>
+                            <strong>Geocoding failed.</strong> {geocodeStatus.message}{" "}
+                            Most commonly this means the <code>GOOGLE_MAPS_GEOCODING_API_KEY</code> env
+                            var isn&apos;t set in Convex. Run{" "}
+                            <code>npx convex env set GOOGLE_MAPS_GEOCODING_API_KEY &lt;your-key&gt;</code> and reload.
                         </span>
                     </div>
                 )}

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { query, mutation, action, internalQuery } from './_generated/server';
+import { query, mutation, action, internalQuery, internalMutation } from './_generated/server';
 import { internal } from './_generated/api';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
@@ -881,5 +881,161 @@ export const getDetailForAdmin = query({
                   }
                 : null,
         };
+    },
+});
+
+
+// ============================================================================
+// SERVER-SIDE GEOCODING
+//
+// Many submissions have an `address` but no `coordinates`. Without coordinates,
+// the live-business map can't pin them. We solve this with a Convex action
+// that calls Google's Geocoding REST API server-side, then patches
+// `submission.coordinates` so the result is cached forever — listForMap
+// surfaces the coords on the next reactive re-fetch and the pin shows up.
+//
+// Env var required: GOOGLE_MAPS_GEOCODING_API_KEY (set via `npx convex env set`).
+// The mobile / web Maps API key can be reused — the only requirement is that
+// the key has the Geocoding API enabled in the GCP project.
+// ============================================================================
+
+/**
+ * Internal — patch a submission with resolved lat/lng.
+ */
+export const _patchSubmissionCoordinates = internalMutation({
+    args: {
+        submissionId: v.id('submissions'),
+        lat: v.number(),
+        lng: v.number(),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.submissionId, {
+            coordinates: { lat: args.lat, lng: args.lng },
+        });
+    },
+});
+
+/**
+ * Geocode every submission that has an address but no coordinates. Calls
+ * Google's Geocoding REST API server-side, then persists the result to
+ * `submission.coordinates` so the next listForMap call surfaces it.
+ *
+ * Returns a summary { scanned, geocoded, skipped, failed } so the caller
+ * can show a progress badge.
+ *
+ * The action is auth-gated — any signed-in user can trigger it. The work
+ * is idempotent (already-geocoded submissions are skipped) so calling
+ * repeatedly is safe.
+ */
+export const geocodePendingSubmissions = action({
+    args: { limit: v.optional(v.number()) },
+    handler: async (
+        ctx,
+        args,
+    ): Promise<{ scanned: number; geocoded: number; skipped: number; failed: number }> => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+
+        const apiKey =
+            process.env.GOOGLE_MAPS_GEOCODING_API_KEY ||
+            process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+        if (!apiKey) {
+            throw new Error(
+                'GOOGLE_MAPS_GEOCODING_API_KEY is not set on this Convex deployment. Set it with: npx convex env set GOOGLE_MAPS_GEOCODING_API_KEY <your-key>',
+            );
+        }
+
+        // Fetch pending submissions (address but no coordinates) via an
+        // internal query. We cap at `limit` to keep each invocation bounded.
+        const pending = (await ctx.runQuery(
+            internal.leads._listSubmissionsPendingGeocode,
+            { limit: args.limit ?? 25 },
+        )) as Array<{
+            _id: any;
+            address: string;
+            city: string | null;
+            province: string | null;
+        }>;
+
+        let geocoded = 0;
+        let skipped = 0;
+        let failed = 0;
+
+        for (const sub of pending) {
+            const queryParts = [sub.address, sub.city, sub.province, 'Philippines']
+                .filter(Boolean)
+                .join(', ');
+            if (!queryParts) {
+                skipped++;
+                continue;
+            }
+            try {
+                const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
+                url.searchParams.set('address', queryParts);
+                url.searchParams.set('region', 'ph');
+                url.searchParams.set('key', apiKey);
+
+                const res = await fetch(url.toString());
+                if (!res.ok) {
+                    console.warn(
+                        `[geocode] HTTP ${res.status} for "${queryParts}"`,
+                    );
+                    failed++;
+                    continue;
+                }
+                const payload: any = await res.json();
+                if (payload.status === 'OK' && payload.results?.[0]?.geometry?.location) {
+                    const loc = payload.results[0].geometry.location;
+                    await ctx.runMutation(internal.leads._patchSubmissionCoordinates, {
+                        submissionId: sub._id,
+                        lat: loc.lat,
+                        lng: loc.lng,
+                    });
+                    geocoded++;
+                } else if (payload.status === 'ZERO_RESULTS') {
+                    console.warn(`[geocode] zero results for "${queryParts}"`);
+                    skipped++;
+                } else {
+                    console.warn(
+                        `[geocode] non-OK status ${payload.status} for "${queryParts}": ${payload.error_message ?? ''}`,
+                    );
+                    failed++;
+                }
+            } catch (err: any) {
+                console.warn(
+                    `[geocode] threw for "${queryParts}": ${err?.message ?? err}`,
+                );
+                failed++;
+            }
+        }
+
+        return { scanned: pending.length, geocoded, skipped, failed };
+    },
+});
+
+/**
+ * Internal — fetch submissions that have an address but no coordinates.
+ * Used by the action above; not exposed publicly.
+ */
+export const _listSubmissionsPendingGeocode = internalQuery({
+    args: { limit: v.number() },
+    handler: async (ctx, args) => {
+        const all = await ctx.db.query('submissions').collect();
+        const pending = all
+            .filter(
+                (s: any) =>
+                    typeof s.address === 'string' &&
+                    s.address.trim().length > 0 &&
+                    (!s.coordinates ||
+                        s.coordinates.lat == null ||
+                        s.coordinates.lng == null),
+            )
+            .slice(0, args.limit);
+        return pending.map((s: any) => ({
+            _id: s._id,
+            address: s.address,
+            city: s.city ?? null,
+            province: s.province ?? null,
+        }));
     },
 });

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -141,6 +141,28 @@ export const scrapeNearby = action({
 
         console.log(`[outscraper] received ${raw.length} businesses from Outscraper`);
 
+        // EMPTY-RESULTS diagnostic — when Outscraper returns 0 places, surface
+        // the upstream response keys so we can tell billing-empty from
+        // genuine-zero in Convex prod logs. Outscraper does NOT throw a
+        // billing error: when the account is out of credits, the response is
+        // HTTP 200 with `status: "Success"` and `data: [[]]` — indistinguishable
+        // from a legitimate zero-match search by shape alone. Logging
+        // `status` / `message` / `error_message` + `has_data` lets us read
+        // off the cause from the log line. See WEB-BUILD-CRM.md "🛑 Three
+        // Outscraper blockers" for the full triage tree.
+        if (raw.length === 0) {
+            const diag = {
+                id: payload?.id ?? null,
+                status: payload?.status ?? null,
+                message: payload?.message ?? null,
+                error_message: payload?.error_message ?? null,
+                has_data: Array.isArray(payload?.data),
+            };
+            console.log(
+                `[outscraper] EMPTY RESULTS — full response keys=${JSON.stringify(diag)}. If you see this with status="Success" and your billing balance is $0, the account is out of credits — top up at app.outscraper.cloud/billing.`,
+            );
+        }
+
         const scrapedBy = me.clerkId;
         const scrapedAt = Date.now();
         let inserted = 0;

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -12,6 +12,8 @@
 >
 > 🚨 **2026-05-29 — `outscraper.listScrapedLeads` validator drift.** The deployed function on prod rejects `{ limit: number }` with `ArgumentValidationError: Object contains extra field 'limit' that is not in the validator`. The deployed validator only accepts `{ search?, statusFilter? }` — likely got accidentally rewritten as a `listForMobileCRM`-style wrapper. **The original signature `{ limit?: number }` returning raw outscraper leads (with `businessLatitude`, `businessLongitude`, `businessCategory`, `businessRating`, etc.) must be restored** — mobile's discover map needs those raw fields, and `listForMobileCRM` strips them out (it only surfaces submission-derived business fields). Source of truth: `ndm/convex/outscraper.ts`. Mobile's caller in `discover.tsx` now sends `{}` defensively and filters client-side as a workaround, but the proper fix is restoring the validator + return shape per the mobile copy. See "Convex contract" section for the required signature.
 >
+> 🚨 **2026-05-29 — Outscraper account balance must be > $0.** Find Local Business will silently return 0 results if the Outscraper account is out of credits, with NO explicit API error. The HTTP request returns 200 with `status: "Success"` + `data: [[]]` (or just an empty array) — the same shape we get from a successful zero-match search. From the mobile UX side, this looks identical to "the scrape worked but nothing was nearby" — the discover map opens with an empty state and the user has no way to tell that billing is the blocker. The current account uses an AppSumo deal ($30 credits/month, no expiration), but the credit doesn't always auto-apply at the start of each billing period. **Check balance at https://app.outscraper.cloud/billing/payments before assuming the API is broken.** Mobile's `convex/outscraper.ts` now logs `[outscraper] EMPTY RESULTS — full response keys={...}` whenever `rawResults.length === 0` — that diagnostic line surfaces the upstream `status` / `message` / `error_message` so you can tell billing-empty from genuine-zero in Convex prod logs. See "🛑 Three Outscraper blockers" section below for the full triage tree.
+>
 > **Mobile-as-source-of-truth alignment** — mobile owns the canonical behavior for both action buttons. Web is currently misaligned and must catch up.
 >
 > | Button | Mobile (canonical — DO NOT change) | Web (currently broken — fix to match mobile) |
@@ -1089,6 +1091,54 @@ The action source is at `ndm/convex/outscraper.ts` — copy it verbatim if your 
 
 ---
 
+## 🛑 Three Outscraper blockers — triage tree
+
+If Find Local Business shows an empty map / zero pins, work through these three causes in order. They cover every known failure mode as of 2026-05-29.
+
+```
+Creator taps Find Local Business → 3-stage loader → discover map opens empty
+                                                                │
+                  ┌─────────────────────────────────────────────┴─┐
+                  ▼                                                ▼
+   Check the debug strip on the discover map's empty state:
+   "DEBUG · rows=N · outscraper=N · with-coords=N"
+                  │
+   ┌──────────────┼──────────────────────────────────────────────────────┐
+   ▼              ▼                                                      ▼
+rows=0     rows>0, with-coords=0                              rows>0, with-coords>0
+   │              │                                                      │
+   │              │                                            Should render pins.
+   │              │                                            If not, look at filter logic
+   │              │                                            in discover.tsx pinned useMemo.
+   │              │
+   │     BLOCKER 2 — listScrapedLeads validator drift
+   │     (web's deployed copy strips the raw lat/lng/category fields).
+   │     Fix: restore the original signature per "Convex contract" section + redeploy.
+   │
+   │
+Two sub-cases, check Convex prod logs for the most-recent `outscraper:scrapeNearby` run:
+   │
+   ├── Log shows `[outscraper] received 0 businesses from Outscraper`
+   │   AND `[outscraper] EMPTY RESULTS — full response keys={status:"Success",...}`
+   │   AND your account balance is $0
+   │   → BLOCKER 3 — billing. Top up at app.outscraper.cloud/billing/payments.
+   │
+   ├── Log shows `[outscraper] received 0 businesses` with non-empty `message`/`error_message`
+   │   → Read the message — could be quota exceeded, key revoked, region blocked, etc.
+   │
+   ├── Log shows the OLD format (no `[outscraper] scrapeNearby → query…` line)
+   │   → BLOCKER 1 — query-format bug. The deployed function predates the
+   │     2026-05-28 fix. Redeploy `convex/outscraper.ts` from mobile.
+   │
+   └── Logs look clean, real query, no errors, but zero results
+       → Genuine zero matches. Try a wider radius or a category with more
+         density in your area (e.g. "businesses" instead of "vulcanizing").
+```
+
+Each blocker has its own section below.
+
+---
+
 ## 🛑 2026-05-28 — Outscraper query-format bug (currently broken on prod)
 
 > **Symptom:** Creator taps Find Local Business → 3-stage loader runs for 20–25 seconds → success alert appears with **"0 businesses found nearby. Added 0 new ones."** Convex log shows `outscraper:scrapeNearby success 24.2s` — no error, just empty results.
@@ -1136,6 +1186,35 @@ The action source is at `ndm/convex/outscraper.ts` — copy it verbatim if your 
 > 1. Tap Find Local Business with category `salon`, radius 5km, anywhere with businesses around you
 > 2. Check Convex prod logs — should see `[outscraper] scrapeNearby → salon, 14.30,121.00, 3mi (limit=20)` followed by `[outscraper] received N businesses from Outscraper` where N > 0
 > 3. Alert should now show `N businesses found nearby. Added N new ones to your interview list (0 were already on it).`
+
+---
+
+## 🛑 2026-05-29 — Outscraper billing balance must be > $0
+
+> **Symptom:** Find Local Business completes the 3-stage loader successfully, the discover map opens, but no pins appear. The diagnostic strip on the map's empty state shows `DEBUG · rows=0 · outscraper=0 · with-coords=0`. Convex prod logs show `outscraper:scrapeNearby success` with `[outscraper] received 0 businesses from Outscraper` — no error thrown, no HTTP failure.
+>
+> **Root cause:** Outscraper's API does NOT return an explicit error (no HTTP 402, no `status: "Failed"`) when the account is out of credits. Instead it returns HTTP 200 with `status: "Success"` and `data: [[]]` — indistinguishable from a legitimate zero-match search. The 20–25 second latency that earlier appeared to suggest async-mode fallback may actually be the upstream running a billing precheck on every request.
+>
+> **Diagnosing it:** mobile's `convex/outscraper.ts` (2026-05-29) now logs a second line whenever the result count is zero:
+>
+> ```
+> [outscraper] EMPTY RESULTS — full response keys={"id":null,"status":"Success","message":null,"error_message":null,"has_data":true}. If you see this with status="Success" and your billing balance is $0, the account is out of credits — top up at app.outscraper.cloud/billing.
+> ```
+>
+> If the log line shows `status: "Success"` AND `has_data: true` (meaning Outscraper returned `data: []` not nothing), AND your account balance is $0, billing is the cause.
+>
+> **Action required:**
+> 1. Open **https://app.outscraper.cloud/billing/payments**
+> 2. Check `Current Balance` — if it's `$0.00`, that's the blocker
+> 3. The current account uses an **AppSumo deal** ($30 credits/month, no expiration). The credit should auto-apply at the start of each billing cycle but does NOT always do so cleanly. Confirm under `Invoices` whether the $30 credit has actually been applied for the current period
+> 4. Top up manually with any amount (even $5) to confirm whether billing is the blocker. After top-up, retry Find Local Business immediately
+> 5. If the AppSumo $30 didn't auto-apply, contact Outscraper support — that's their bug to fix
+>
+> **How to prevent this from recurring:**
+> - Add an alert when the balance drops below $5 (Outscraper's billing settings support email alerts)
+> - For the long-term: switch to a usage-based prepaid balance (`Top Up Balance` section on the billing page) so each scrape draws from a known pot, rather than depending on the AppSumo monthly credit applying cleanly
+>
+> **Cost reference:** Outscraper charges ~$0.001 per result. At default `limit: 20` per scrape, each Find Local Business tap costs ~$0.02. The AppSumo $30/month covers ~1,500 scrapes per month — plenty for a small creator team but watch out if usage spikes.
 
 ---
 


### PR DESCRIPTION
# Latest Changes ✨

**Server-side geocoding for submissions:**

- Added a new Convex action `geocodePendingSubmissions` in `convex/leads.ts` that scans submissions missing coordinates, geocodes them using Google's Geocoding API, and patches the results to the database. This ensures that pins can appear on the map for all submissions with addresses.
- Added supporting internal mutation `_patchSubmissionCoordinates` and internal query `_listSubmissionsPendingGeocode` to update and fetch pending submissions, respectively.

**Client-side and UI improvements (Live and Discover pages):**

- In `app/leads/live/page.tsx`, switched to using the new server-side geocoding action, displaying real-time status updates to the user about geocoding progress, errors, or completion. The client-side geocoding is now a fallback for any residual misses. [[1]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL108-R156) [[2]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eR289-R347)
- In `app/leads/discover/page.tsx`, improved the prospect filtering and geocoding logic to support both server- and client-side geocoding. Added a reusable `AddressGeocoder` component for batch geocoding and updating pins as results arrive. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L140-R204) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L262-R314) [[3]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L718-R849)
- Updated the map to use the correct Google Maps component and ensured pins are re-fitted as new coordinates become available. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L25-R37) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L286-R338) [[3]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L718-R849)

**Debugging and support:**

- Added a debug strip to the Discover page to surface the data shape and help quickly identify common Outscraper blockers during support or triage.