### PR TITLE
feat: Fix CRM Mapping of Leads

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -136,11 +136,68 @@ function DiscoverInner() {
         );
     }, [ready]);
 
-    // Pull unclaimed Outscraper prospects, filtered to the scrape radius.
-    const prospects = useQuery(
+    // Per the 2026-05-29 evening spec update: the discover map has TWO
+    // data sources, in priority order:
+    //
+    //   1. PRIMARY — URL `data` param. After a successful scrape, the
+    //      modal encodes result.businesses as JSON and passes it via the
+    //      URL. This bypasses the silently-failing DB write path entirely.
+    //
+    //   2. FALLBACK — listScrapedLeads query. Only used when the user
+    //      navigates here without `data` (deep link, browser back/forward,
+    //      cold start to /leads/discover).
+    //
+    // Both sources get normalized into a shared shape and feed the same
+    // downstream pin-rendering pipeline.
+    const urlData = searchParams.get("data");
+    const urlBusinesses = useMemo(() => {
+        if (!urlData) return null;
+        try {
+            const parsed = JSON.parse(decodeURIComponent(urlData));
+            if (!Array.isArray(parsed)) return null;
+            // Normalize URL businesses to match the listScrapedLeads shape
+            // the rest of the page expects (_id, submissionId, etc.). The
+            // synthetic _id is used purely as a React `key`; nothing actually
+            // looks it up in the DB.
+            return parsed.map((b: any) => ({
+                _id: b.placeId ?? `${b.businessName}:${b.businessLatitude}:${b.businessLongitude}`,
+                submissionId: null,
+                businessName: b.businessName ?? null,
+                businessAddress: b.businessAddress ?? null,
+                businessCity: b.businessCity ?? null,
+                businessCategory: b.businessCategory ?? null,
+                businessWebsite: b.businessWebsite ?? null,
+                phone: b.businessPhone ?? null,
+                businessLatitude: b.businessLatitude ?? null,
+                businessLongitude: b.businessLongitude ?? null,
+                businessRating: b.businessRating ?? null,
+                businessReviewCount: b.businessReviewCount ?? null,
+            }));
+        } catch (err) {
+            console.warn("[discover] failed to parse URL data param:", err);
+            return null;
+        }
+    }, [urlData]);
+
+    // Fallback query — ONLY subscribe when there's no URL data. Saves a
+    // round-trip + reactive subscription on the happy path (post-scrape).
+    const fallbackProspects = useQuery(
         api.outscraper.listScrapedLeads,
-        ready ? {} : "skip",
+        ready && !urlBusinesses ? {} : "skip",
     ) as any[] | undefined;
+
+    // Defensive against the deployed validator-drift shape: the deployed
+    // listScrapedLeads sometimes returns { leads, stats } instead of an
+    // array. Unwrap if needed.
+    const fallbackArray: any[] | undefined = useMemo(() => {
+        if (fallbackProspects === undefined) return undefined;
+        if (Array.isArray(fallbackProspects)) return fallbackProspects;
+        const wrapped = fallbackProspects as any;
+        if (Array.isArray(wrapped?.leads)) return wrapped.leads;
+        return [];
+    }, [fallbackProspects]);
+
+    const prospects: any[] | undefined = urlBusinesses ?? fallbackArray;
 
     // Client-side geocoder cache — keyed by lead id. Used when an Outscraper
     // prospect has an address but no latitude/longitude (sometimes happens

--- a/app/leads/live/page.tsx
+++ b/app/leads/live/page.tsx
@@ -114,7 +114,13 @@ function LiveBusinessesInner() {
     const [geocodeStatus, setGeocodeStatus] = useState<
         | { phase: "idle" }
         | { phase: "running" }
-        | { phase: "done"; geocoded: number; failed: number; scanned: number }
+        | {
+              phase: "done";
+              geocoded: number;
+              failed: number;
+              scanned: number;
+              googleBillingDisabled: boolean;
+          }
         | { phase: "error"; message: string }
     >({ phase: "idle" });
 
@@ -141,6 +147,7 @@ function LiveBusinessesInner() {
                     geocoded: res.geocoded,
                     failed: res.failed,
                     scanned: res.scanned,
+                    googleBillingDisabled: !!res.googleBillingDisabled,
                 });
             })
             .catch((err: any) => {
@@ -323,6 +330,35 @@ function LiveBusinessesInner() {
                             {geocodeStatus.failed > 0
                                 ? ` ${geocodeStatus.failed} failed (check the addresses for typos).`
                                 : ""}
+                        </span>
+                    </div>
+                )}
+
+                {/* Google billing-disabled hint — shown after a successful
+                    batch that fell back to Nominatim. Tells the user how to
+                    upgrade for better accuracy without breaking the current
+                    setup. */}
+                {geocodeStatus.phase === "done" && geocodeStatus.googleBillingDisabled && (
+                    <div
+                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-start gap-2"
+                        style={{
+                            background: "var(--ed-paper-2)",
+                            color: "var(--ed-ink-2)",
+                            border: "1px solid var(--ed-rule)",
+                        }}
+                    >
+                        <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-ink-3)" }} />
+                        <span>
+                            Pins above were resolved via OpenStreetMap (free, less accurate for informal PH addresses). To use Google Maps geocoding — same key as the map — enable Billing on your GCP project at{" "}
+                            <a
+                                href="https://console.cloud.google.com/project/_/billing/enable"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{ color: "var(--ed-accent)" }}
+                            >
+                                console.cloud.google.com/.../billing/enable
+                            </a>
+                            . Free up to $200/month — you won&apos;t be charged for normal use.
                         </span>
                     </div>
                 )}

--- a/components/leads/FindLocalBusinessModal.tsx
+++ b/components/leads/FindLocalBusinessModal.tsx
@@ -148,18 +148,20 @@ export default function FindLocalBusinessModal({
             setPhase("saving");
             await new Promise((r) => setTimeout(r, 350));
 
-            // Per the 2026-05-29 spec update: NO success toast, NO Alert
-            // dialog. The map at /leads/discover IS the success state —
-            // the modal closes and the router takes the creator straight
-            // to the result map. Don't show "X businesses added to your
-            // interview list" — that's the broken UX mobile already deleted.
-            // The result counts (res.total / inserted / skipped) are
-            // surfaced by the map's header copy instead.
+            // Per the 2026-05-29 evening spec update: pass the raw
+            // `businesses` array via URL `data` param so the discover map
+            // can render pins from in-memory state directly. This bypasses
+            // the silently-failing DB write path — the map shows pins even
+            // if `listScrapedLeads` returns empty. See WEB-BUILD-CRM.md
+            // "Map B — Find Local Business" for the new data flow.
             setPhase("idle");
             activeRef.current = false;
             onClose();
+            const businessesParam = (res as any).businesses
+                ? `&data=${encodeURIComponent(JSON.stringify((res as any).businesses))}`
+                : "";
             const discoverHref =
-                `/leads/discover?category=${encodeURIComponent(queryStr)}&radiusKm=${radius}`;
+                `/leads/discover?category=${encodeURIComponent(queryStr)}&radiusKm=${radius}${businessesParam}`;
             router.push(discoverHref);
         } catch (err: any) {
             const message = err?.message ?? String(err);

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -932,18 +932,21 @@ export const geocodePendingSubmissions = action({
     handler: async (
         ctx,
         args,
-    ): Promise<{ scanned: number; geocoded: number; skipped: number; failed: number }> => {
+    ): Promise<{
+        scanned: number;
+        geocoded: number;
+        skipped: number;
+        failed: number;
+        googleBillingDisabled: boolean;
+    }> => {
         const identity = await ctx.auth.getUserIdentity();
         if (!identity) throw new Error('Not authenticated');
 
         const apiKey =
             process.env.GOOGLE_MAPS_GEOCODING_API_KEY ||
             process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-        if (!apiKey) {
-            throw new Error(
-                'GOOGLE_MAPS_GEOCODING_API_KEY is not set on this Convex deployment. Set it with: npx convex env set GOOGLE_MAPS_GEOCODING_API_KEY <your-key>',
-            );
-        }
+        // No key is allowed — we fall straight to Nominatim. The Google
+        // path is just the preferred provider when available.
 
         // Fetch pending submissions (address but no coordinates) via an
         // internal query. We cap at `limit` to keep each invocation bounded.
@@ -960,6 +963,12 @@ export const geocodePendingSubmissions = action({
         let geocoded = 0;
         let skipped = 0;
         let failed = 0;
+        // Sticky flag — once we see Google return REQUEST_DENIED we stop
+        // trying it for the rest of the batch (saves N pointless API
+        // round-trips) and fall straight to Nominatim. Surfaced to the
+        // client so the UI can render a "Billing not enabled on GCP"
+        // hint.
+        let googleBillingDisabled = false;
 
         for (const sub of pending) {
             const queryParts = [sub.address, sub.city, sub.province, 'Philippines']
@@ -969,47 +978,120 @@ export const geocodePendingSubmissions = action({
                 skipped++;
                 continue;
             }
-            try {
-                const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
-                url.searchParams.set('address', queryParts);
-                url.searchParams.set('region', 'ph');
-                url.searchParams.set('key', apiKey);
 
-                const res = await fetch(url.toString());
-                if (!res.ok) {
+            let coords: { lat: number; lng: number } | null = null;
+
+            // ── Provider 1: Google Maps Geocoding API ──────────────────
+            // Requires Billing enabled on the GCP project. Free up to
+            // $200/month credit (~40k requests). If REQUEST_DENIED comes
+            // back, billing is the cause — stop trying for this batch.
+            if (apiKey && !googleBillingDisabled) {
+                try {
+                    const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
+                    url.searchParams.set('address', queryParts);
+                    url.searchParams.set('region', 'ph');
+                    url.searchParams.set('key', apiKey);
+
+                    const res = await fetch(url.toString());
+                    if (res.ok) {
+                        const payload: any = await res.json();
+                        if (
+                            payload.status === 'OK' &&
+                            payload.results?.[0]?.geometry?.location
+                        ) {
+                            const loc = payload.results[0].geometry.location;
+                            coords = { lat: loc.lat, lng: loc.lng };
+                        } else if (payload.status === 'REQUEST_DENIED') {
+                            // Most common cause: Billing not enabled.
+                            // Flip the sticky flag so we skip Google for
+                            // the remainder of this batch.
+                            googleBillingDisabled = true;
+                            console.warn(
+                                `[geocode] Google REQUEST_DENIED — ${payload.error_message ?? 'likely needs Billing enabled on the GCP project'}. Falling back to Nominatim for the rest of this batch.`,
+                            );
+                        } else if (payload.status === 'ZERO_RESULTS') {
+                            console.warn(
+                                `[geocode] Google zero results for "${queryParts}" — trying Nominatim.`,
+                            );
+                        } else {
+                            console.warn(
+                                `[geocode] Google non-OK status ${payload.status} for "${queryParts}": ${payload.error_message ?? ''}`,
+                            );
+                        }
+                    } else {
+                        console.warn(`[geocode] Google HTTP ${res.status} for "${queryParts}"`);
+                    }
+                } catch (err: any) {
                     console.warn(
-                        `[geocode] HTTP ${res.status} for "${queryParts}"`,
+                        `[geocode] Google threw for "${queryParts}": ${err?.message ?? err}`,
                     );
-                    failed++;
-                    continue;
                 }
-                const payload: any = await res.json();
-                if (payload.status === 'OK' && payload.results?.[0]?.geometry?.location) {
-                    const loc = payload.results[0].geometry.location;
-                    await ctx.runMutation(internal.leads._patchSubmissionCoordinates, {
-                        submissionId: sub._id,
-                        lat: loc.lat,
-                        lng: loc.lng,
+            }
+
+            // ── Provider 2: OpenStreetMap Nominatim ────────────────────
+            // Free, no API key, no Billing required. Slower (1 req/sec
+            // rate limit) and less reliable for informal PH addresses,
+            // but adequate as a fallback when Google is unavailable.
+            if (!coords) {
+                try {
+                    const url = new URL('https://nominatim.openstreetmap.org/search');
+                    url.searchParams.set('q', queryParts);
+                    url.searchParams.set('format', 'json');
+                    url.searchParams.set('countrycodes', 'ph');
+                    url.searchParams.set('limit', '1');
+
+                    const res = await fetch(url.toString(), {
+                        headers: {
+                            // Nominatim ToS requires a User-Agent that
+                            // identifies the application.
+                            'User-Agent': 'NegosyoDigital/1.0 (frmwrkd.media@gmail.com)',
+                            Accept: 'application/json',
+                        },
                     });
-                    geocoded++;
-                } else if (payload.status === 'ZERO_RESULTS') {
-                    console.warn(`[geocode] zero results for "${queryParts}"`);
-                    skipped++;
-                } else {
+                    if (res.ok) {
+                        const payload: any = await res.json();
+                        if (Array.isArray(payload) && payload[0]) {
+                            const lat = parseFloat(payload[0].lat);
+                            const lng = parseFloat(payload[0].lon);
+                            if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+                                coords = { lat, lng };
+                            }
+                        } else {
+                            console.warn(
+                                `[geocode] Nominatim zero results for "${queryParts}"`,
+                            );
+                        }
+                    } else {
+                        console.warn(`[geocode] Nominatim HTTP ${res.status} for "${queryParts}"`);
+                    }
+                    // Polite delay — Nominatim asks for ≤1 req/sec.
+                    await new Promise((r) => setTimeout(r, 1100));
+                } catch (err: any) {
                     console.warn(
-                        `[geocode] non-OK status ${payload.status} for "${queryParts}": ${payload.error_message ?? ''}`,
+                        `[geocode] Nominatim threw for "${queryParts}": ${err?.message ?? err}`,
                     );
-                    failed++;
                 }
-            } catch (err: any) {
-                console.warn(
-                    `[geocode] threw for "${queryParts}": ${err?.message ?? err}`,
-                );
+            }
+
+            if (coords) {
+                await ctx.runMutation(internal.leads._patchSubmissionCoordinates, {
+                    submissionId: sub._id,
+                    lat: coords.lat,
+                    lng: coords.lng,
+                });
+                geocoded++;
+            } else {
                 failed++;
             }
         }
 
-        return { scanned: pending.length, geocoded, skipped, failed };
+        return {
+            scanned: pending.length,
+            geocoded,
+            skipped,
+            failed,
+            googleBillingDisabled,
+        };
     },
 });
 

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -163,42 +163,128 @@ export const scrapeNearby = action({
             );
         }
 
+        // Diagnostic: log what fields the first business actually has, so we
+        // can spot Outscraper API shape changes (e.g. they rename `place_id`
+        // to `google_id`) without redeploying.
+        if (raw.length > 0) {
+            console.log(
+                `[outscraper] first business keys: ${Object.keys(raw[0] as any).join(",")}`,
+            );
+            const sample = raw[0] as any;
+            console.log(
+                `[outscraper] first business sample: ${JSON.stringify({
+                    name: sample.name,
+                    place_id: sample.place_id ?? sample.google_id ?? null,
+                    latitude: sample.latitude,
+                    longitude: sample.longitude,
+                    category: sample.category ?? sample.type ?? sample.subtypes ?? null,
+                })}`,
+            );
+        }
+
         const scrapedBy = me.clerkId;
         const scrapedAt = Date.now();
         let inserted = 0;
         let skipped = 0;
 
-        for (const place of raw) {
-            const placeId = place.google_id || place.place_id;
-            if (!placeId || !place.name) {
+        // Build the in-memory `businesses` array per the 2026-05-29 evening
+        // architecture change. The discover map renders pins from this array
+        // directly (via URL data param), so the DB write path is no longer
+        // load-bearing for the map UX. Best-effort: a failed insert just
+        // doesn't make it into the leads table, but the pin still shows.
+        const businesses: Array<{
+            placeId: string;
+            businessName: string;
+            businessAddress: string | null;
+            businessCity: string | null;
+            businessCategory: string | null;
+            businessWebsite: string | null;
+            businessPhone: string | null;
+            businessLatitude: number | null;
+            businessLongitude: number | null;
+            businessRating: number | null;
+            businessReviewCount: number | null;
+        }> = [];
+
+        for (const place of raw as any[]) {
+            // Robust placeId fallback chain. Outscraper occasionally returns
+            // records missing `place_id`; we try several other id-ish fields
+            // before falling back to a synthetic key. No business with coords
+            // gets silently dropped from the returned array.
+            const placeId: string =
+                place.place_id ||
+                place.google_id ||
+                place.cid ||
+                place.feature_id ||
+                place.id ||
+                `synthetic:${place.name ?? "unknown"}:${place.latitude ?? "0"}:${place.longitude ?? "0"}`;
+
+            if (!place.name) {
                 skipped++;
                 continue;
             }
-            const result = await ctx.runMutation(
-                internal.outscraper.insertScrapedLead,
-                {
-                    creatorId: me._id,
-                    scrapedAt,
-                    scrapedBy,
-                    businessName: place.name,
-                    businessAddress: place.full_address || place.address || undefined,
-                    businessCity: place.city || undefined,
-                    businessCategory:
-                        place.category || place.type || place.subtypes || undefined,
-                    businessWebsite: place.site || place.website || undefined,
-                    businessLatitude: place.latitude ?? undefined,
-                    businessLongitude: place.longitude ?? undefined,
-                    businessRating: place.rating ?? undefined,
-                    businessReviewCount: place.reviews ?? undefined,
-                    businessGooglePlaceId: placeId,
-                    phone: place.phone || undefined,
-                },
-            );
-            if (result.skipped) skipped++;
-            else inserted++;
+
+            // Push to in-memory `businesses` BEFORE attempting the DB write,
+            // so the array reflects what Outscraper actually returned
+            // regardless of DB write outcome.
+            businesses.push({
+                placeId: String(placeId),
+                businessName: place.name,
+                businessAddress: place.full_address || place.address || null,
+                businessCity: place.city || null,
+                businessCategory:
+                    place.category || place.type || place.subtypes || null,
+                businessWebsite: place.site || place.website || null,
+                businessPhone: place.phone || null,
+                businessLatitude:
+                    typeof place.latitude === "number" ? place.latitude : null,
+                businessLongitude:
+                    typeof place.longitude === "number" ? place.longitude : null,
+                businessRating:
+                    typeof place.rating === "number" ? place.rating : null,
+                businessReviewCount:
+                    typeof place.reviews === "number" ? place.reviews : null,
+            });
+
+            // Best-effort DB write — wrapped in try/catch so a write failure
+            // does not break the map. Failures get logged per-row so we can
+            // diagnose later.
+            try {
+                const result = await ctx.runMutation(
+                    internal.outscraper.insertScrapedLead,
+                    {
+                        creatorId: me._id,
+                        scrapedAt,
+                        scrapedBy,
+                        businessName: place.name,
+                        businessAddress: place.full_address || place.address || undefined,
+                        businessCity: place.city || undefined,
+                        businessCategory:
+                            place.category || place.type || place.subtypes || undefined,
+                        businessWebsite: place.site || place.website || undefined,
+                        businessLatitude: place.latitude ?? undefined,
+                        businessLongitude: place.longitude ?? undefined,
+                        businessRating: place.rating ?? undefined,
+                        businessReviewCount: place.reviews ?? undefined,
+                        businessGooglePlaceId: String(placeId),
+                        phone: place.phone || undefined,
+                    },
+                );
+                if (result.skipped) skipped++;
+                else inserted++;
+            } catch (err: any) {
+                console.warn(
+                    `[outscraper] insertScrapedLead failed for "${place.name}": ${err?.message ?? err}`,
+                );
+                skipped++;
+            }
         }
 
-        return { inserted, skipped, total: raw.length };
+        console.log(
+            `[outscraper] returning to client: ${businesses.length} businesses with coords (inserted=${inserted}, skipped=${skipped})`,
+        );
+
+        return { inserted, skipped, total: raw.length, businesses };
     },
 });
 

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -4,7 +4,11 @@
 >
 > URL: `/creators/leads` (exact slug owned by web team). Mirrors mobile's `app/(app)/leads/*` 1:1 in behavior, and adopts the **Editorial Paper** design system (greens + khaki — **NOT orange/terracotta**, Instrument Serif + Onest + JetBrains Mono) so the web and mobile apps feel like one product.
 >
-> **Last updated 2026-05-29.** Recent changes folded into this doc:
+> **Last updated 2026-05-29 (evening).** Recent changes folded into this doc:
+>
+> 🚨 **2026-05-29 evening — DEPLOY ACTION REQUIRED on the web side.** The mobile team has rewritten `convex/outscraper.ts` to bypass the broken DB write path entirely (details below). For the Find Local Business map to actually show pins in production, **the web agent must merge mobile's `convex/outscraper.ts` changes into the web repo and run `npx convex deploy --prod` from the WEB repo.** Mobile is NOT allowed to deploy directly — the established rule that web owns the deployed `convex/outscraper.ts` is unchanged. See **"🚀 Deploy steps for the web agent"** at the end of this doc for the exact merge recipe (which mobile changes to copy, which web-added functions to preserve).
+>
+> ✅ **2026-05-29 evening — Mobile bypassed the broken DB path entirely.** After dashboard inspection confirmed zero rows in `leads` table where `source === "outscraper"` (despite Outscraper returning data and the action logging `received 1 businesses`), mobile pivoted the architecture: **`scrapeNearby` now returns the raw businesses array DIRECTLY to the client. The discover map renders pins from that in-memory data using URL query params — no DB read needed.** The DB inserts still happen as best-effort (wrapped in try/catch, write failures don't break the map). Net effect: pins show up on the discover map even if `insertScrapedLead` is completely broken in prod and `listScrapedLeads` returns empty. The map is no longer blocked by either of those failures. See updated "Convex contract" → "Write: trigger a new scrape" and "Map B — Find Local Business (the discovery view)" for the new shape.
 >
 > 🚨 **URGENT — Outscraper currently broken on prod.** Find Local Business returns 0 results every time because the deployed `convex/outscraper.ts` builds an invalid request to Outscraper's API. Full diagnosis + fix in the "🛑 2026-05-28 — Outscraper query-format bug" section below. **Fix this first** — everything downstream of Find Local Business (Prospects tab, discover map, claim flow) is blocked until creators can actually populate prospect rows.
 >
@@ -152,9 +156,43 @@ api.outscraper.scrapeNearby({
 })
 ```
 
-**Returns** `{ inserted: number; skipped: number; total: number }`.
+**Returns (UPDATED 2026-05-29 evening):**
 
-Auth: **`requireAuth`** (any signed-in creator). The action calls Outscraper's Google Maps Search API, inserts new rows into the `leads` table with `source: "outscraper"`, and dedupes via the `by_place_id` index.
+```typescript
+{
+  inserted: number;   // how many rows were successfully written to leads table
+  skipped: number;    // how many were skipped (dedupe match OR no placeId OR insert failed)
+  total: number;      // how many businesses Outscraper returned
+  businesses: Array<{ // 🟢 NEW — raw businesses array, used by mobile to render pins directly
+    placeId: string;
+    businessName: string;
+    businessAddress: string | null;
+    businessCity: string | null;
+    businessCategory: string | null;
+    businessWebsite: string | null;
+    businessPhone: string | null;
+    businessLatitude: number | null;
+    businessLongitude: number | null;
+    businessRating: number | null;
+    businessReviewCount: number | null;
+  }>;
+}
+```
+
+> ⚠️ **Critical for web parity:** the `businesses` array is the primary data path for the discover map. Mobile reads it from the action's return value and passes it via URL query params to the discover screen, which renders pins from in-memory data. Web MUST also use this array — do NOT rebuild the map to query `listScrapedLeads` instead. The DB write path is best-effort (try/catch wrapped); the `businesses` array always reflects what Outscraper actually returned, regardless of whether the DB write succeeded.
+
+Auth: **`requireAuth`** (any signed-in creator). The action calls Outscraper's Google Maps Search API, returns the raw businesses array to the client, AND best-effort inserts each into the `leads` table with `source: "outscraper"` (deduped via the `by_place_id` index, errors swallowed and logged so they don't break the map).
+
+**Robust placeId fallback in the action body:** Outscraper occasionally returns business records without a `place_id` field. The action tries `place_id` → `google_id` → `cid` → `feature_id` → `id` → synthetic `name:lat:lng`. No business with coords gets silently dropped from the `businesses` return array — even if all placeId candidates are missing, it gets included with a synthetic key for the map's React `key` prop.
+
+**Diagnostic logs the deployed action now emits (in Convex prod logs):**
+- `[outscraper] scrapeNearby → {query} (limit={N})` — the outbound Outscraper query
+- `[outscraper] received {N} businesses from Outscraper` — count from upstream
+- `[outscraper] first business keys: {keys}` — fields present on first business (so we can spot Outscraper API shape changes)
+- `[outscraper] first business sample: {name, place_id, latitude, longitude, category}` — values for verification
+- `[outscraper] EMPTY RESULTS — full response keys={...}` — only when the API returned zero results, with the upstream status/message/error_message for diagnosing billing vs format vs genuine-zero
+- `[outscraper] insertScrapedLead failed for "X": {error}` — DB write failure surfaced rather than silently swallowed
+- `[outscraper] returning to client: {N} businesses with coords (inserted=X, skipped=Y)` — final count handed back to mobile
 
 ### Write: add a note
 
@@ -364,24 +402,47 @@ and live.
 - The currently-rendered blank Leaflet view must be removed entirely — do NOT layer Google Maps on top of Leaflet
 - Mirror mobile's header (eyebrow + Display + Body) above the map container — don't render the map full-bleed without context
 
-### Map B — Find Local Business (the discovery view, NEW)
+### Map B — Find Local Business (the discovery view)
 
-**Mobile status:** ✅ shipped 2026-05-29 at `app/(app)/leads/discover.tsx`. The scrape modal's success path is `router.push('/(app)/leads/discover?category=${cat}&radiusKm=${radius}')` — no Alert dialog, no list intermediate. The map opens immediately after the saving phase. Read that file as the canonical implementation.
+**Mobile status:** ✅ shipped 2026-05-29 at `app/(app)/leads/discover.tsx`.
 
-**Web status:** mirror mobile. Web route: `/creators/leads/discover?category=...&radiusKm=...`.
+**Data flow (UPDATED 2026-05-29 evening — was previously DB-query-based):**
 
-**What it pins:** every Outscraper-sourced lead in the visible radius that is NOT yet interviewed. Exact SELECT criteria:
+The discover map has **two data sources**, in priority order:
+
+1. **Primary — URL-passed `data` param.** After a successful scrape, the modal's success path is:
+   ```typescript
+   const businessesJSON = encodeURIComponent(JSON.stringify(result.businesses));
+   router.push(`/(app)/leads/discover?category=${cat}&radiusKm=${radius}&data=${businessesJSON}`);
+   ```
+   The discover screen reads the `data` param, JSON-parses it, and renders pins immediately from in-memory state. **No DB query, no `useQuery`.** This works even if `listScrapedLeads` is broken or the DB write never landed.
+
+2. **Fallback — `listScrapedLeads` query.** Used ONLY when the user navigates to `/discover` without `data` (e.g., a deep link, browser back+forward, app cold start to the discover route). The fallback also filters defensively against the broken-deployed-shape cases (wrapped `{leads, stats}` return, source/coords missing).
+
+The web equivalent should use the same priority: read the `data` URL param first; only call `listScrapedLeads` if there's no URL data.
+
+**Why the bypass:** The 2026-05-29 evening dashboard inspection found zero rows in the `leads` table with `source === "outscraper"`, despite Outscraper returning data and `scrapeNearby` reporting success. The DB write path is silently failing somewhere between `received N businesses` and the row actually landing. Rather than wait for that to be diagnosed, mobile pivoted to consume `result.businesses` directly. The map now works regardless of DB state.
+
+**Web route:** `/creators/leads/discover?category=...&radiusKm=...&data=...` — same query-param contract as mobile.
+
+**What gets pinned (when `data` param is present — the normal flow):**
 
 ```typescript
+// Render every business from the URL-passed array that has coords
+businesses
+  .filter(b => typeof b.businessLatitude === 'number' && typeof b.businessLongitude === 'number')
+  .map(/* build pin */)
+```
+
+**What gets pinned (fallback path — DB query):**
+
+```typescript
+// Filter as defensively as possible to handle deployed-function variations
 lead.source === "outscraper"
   && lead.submissionId == null               // not interviewed yet
   && lead.businessLatitude  != null
   && lead.businessLongitude != null
-  // (optional) within the search radius the user just scraped
-  && haversine(userLatLng, [lead.businessLatitude, lead.businessLongitude]) <= radiusKm
 ```
-
-This includes BOTH the just-scraped results AND any existing Outscraper rows in the radius that other creators previously discovered but nobody has interviewed yet. Showing both is intentional — a creator might claim and interview an older prospect they hadn't seen.
 
 **Pin style — keyed by business category.** This is the key visual: a creator opens the map and can scan for "barbershops near me" or "restaurants near me" at a glance.
 
@@ -1093,6 +1154,8 @@ The action source is at `ndm/convex/outscraper.ts` — copy it verbatim if your 
 
 ## 🛑 Three Outscraper blockers — triage tree
 
+> **2026-05-29 evening update:** after the architectural pivot, Blocker 2 (the `listScrapedLeads` validator drift) no longer blocks the map's primary path — mobile reads businesses directly from `scrapeNearby`'s return value via a URL `data` param. Blocker 2 only affects the fallback (deep-link / cold-start to the discover route without a fresh scrape). Blocker 1 (Outscraper query format) and Blocker 3 (billing balance) still apply directly.
+
 If Find Local Business shows an empty map / zero pins, work through these three causes in order. They cover every known failure mode as of 2026-05-29.
 
 ```
@@ -1514,6 +1577,100 @@ After deploy, sign in as a regular creator (NOT admin) and:
 > 3. Notify mobile — the new claim/release mutations are creator-callable, so mobile can ALSO add "I'll interview this" buttons on its prospect cards in a future release if you want parity
 
 Schema changes are additive-only. Safe to deploy.
+
+---
+
+## 🚀 Deploy steps for the web agent (2026-05-29 evening)
+
+> **Hard rule:** The mobile team must NOT run `npx convex deploy`. All deploys to prod come from the web repo. This is the established project convention and is unchanged. The mobile team made changes locally to `ndm/convex/outscraper.ts` to fix the discover map — the web agent's job is to port those changes into the web repo's `convex/outscraper.ts` and deploy.
+
+### Step 1 — Open both files side by side
+
+- **Source (mobile)**: `ndm/convex/outscraper.ts` — has the new fixes
+- **Target (web)**: `<web-repo>/convex/outscraper.ts` — receives the merge
+
+### Step 2 — Port the `scrapeNearby` function body from mobile to web
+
+Replace your current `scrapeNearby` handler entirely with mobile's version. The diff covers:
+
+- **Return type:** add `businesses: Array<...>` to the return shape (full type listed in the "Convex contract" section above)
+- **Query building:** location + radius embedded into the query string (`"businesses, 14.30,121.00, 3mi"` format), NOT passed as separate `coordinates`/`radius` params
+- **Diagnostic logs:** the seven `console.log` lines listed in the Convex contract section
+- **`businesses` array assembly:** new code that builds the array with full placeId fallback chain (`place_id → google_id → cid → feature_id → id → synthetic`)
+- **try/catch around `ctx.runMutation(internal.outscraper.insertScrapedLead, ...)`:** so a DB write failure doesn't break the map
+
+Mobile's `scrapeNearby` is the entire export between `export const scrapeNearby = action({` and the closing `});`. Copy that block verbatim.
+
+### Step 3 — Preserve the four web-added functions
+
+Mobile's local `outscraper.ts` does NOT contain these four functions, but the production deployment DOES (your team added them per the prospects/claim spec):
+
+- `claimProspect`
+- `releaseProspect`
+- `getProspect`
+- `releaseStaleClaimsInternal`
+
+**Do NOT delete these from the web repo's `outscraper.ts`.** Their implementations stay exactly as they currently are. Only `scrapeNearby` is being replaced.
+
+If `listScrapedLeads` was rewritten in your web copy to a `listForMobileCRM`-style wrapper (with `{ search?, statusFilter? }` args), **restore it to mobile's signature** while you're in the file:
+
+```typescript
+export const listScrapedLeads = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireAuth(ctx);
+    const cap = Math.min(args.limit ?? 100, 500);
+    const all = await ctx.db.query("leads").order("desc").take(cap * 4);
+    return all.filter((l) => l.source === "outscraper").slice(0, cap);
+  },
+});
+```
+
+This makes the discover map's fallback path work for deep-link / cold-start cases.
+
+### Step 4 — Sanity-check the merged file
+
+After your edits, the web repo's `convex/outscraper.ts` should export ALL of these:
+
+| Export | Source | Purpose |
+|---|---|---|
+| `scrapeNearby` | Mobile (copy verbatim) | Outscraper API + return businesses array + best-effort DB insert |
+| `insertScrapedLead` | Mobile (copy verbatim) | Internal mutation called by scrapeNearby |
+| `listScrapedLeads` | Mobile (copy verbatim — restore signature) | Read query for fallback path |
+| `claimProspect` | Web (preserve existing) | Creator claims a prospect |
+| `releaseProspect` | Web (preserve existing) | Creator releases their claim |
+| `getProspect` | Web (preserve existing) | Read single prospect with claimer info |
+| `releaseStaleClaimsInternal` | Web (preserve existing) | Cron-driven stale-claim sweeper |
+
+### Step 5 — Deploy
+
+From the web repo root:
+
+```bash
+# Validate against shared dev deployment first
+npx convex dev
+
+# When that succeeds, deploy to prod
+npx convex deploy --prod
+```
+
+### Step 6 — Verify on mobile
+
+After your deploy:
+
+1. Tell the mobile team to rebuild the APK (or use the existing build)
+2. Sign in as a creator, tap **Find Local Business**, complete the scrape
+3. Check Convex prod logs — you should see the new diagnostic lines:
+   - `[outscraper] scrapeNearby → businesses, 14.29,121.00, 3mi (limit=20)`
+   - `[outscraper] received N businesses from Outscraper`
+   - `[outscraper] first business keys: name, place_id, latitude, longitude, ...`
+   - `[outscraper] returning to client: N businesses with coords (inserted=X, skipped=Y)`
+4. The mobile discover map should show pins immediately (in-memory, no DB query)
+5. If `inserted=0` consistently and the leads table still shows zero `source="outscraper"` rows, the DB write path still has a bug we haven't found yet — but the map will work regardless
+
+### Step 7 — Sister deploy from mobile? NO.
+
+Even if the discover map appears broken on mobile after a deploy, **do not have the mobile team run `npx convex deploy`**. That would overwrite all four of the web-added functions (claim/release/getProspect/cron). The fix path is always: mobile edits `ndm/convex/outscraper.ts` → web agent ports the changes → web agent deploys.
 
 ---
 


### PR DESCRIPTION
# Latest Changes ✨

**Business discovery and map data flow improvements:**

* The discover map at `/leads/discover` now prioritizes displaying businesses passed via a URL `data` parameter immediately after a scrape, falling back to the database (`listScrapedLeads`) only if no URL data is present. This ensures that users always see their newly scraped businesses, even if the DB write fails. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L139-R201) [[2]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL151-R164)
* The scraping action (`scrapeNearby` in `convex/outscraper.ts`) now returns an in-memory `businesses` array with normalized fields, robustly handling missing IDs and logging diagnostic info about the Outscraper API shape. The DB write is now best-effort and failures do not prevent pins from appearing on the map. [[1]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R166-R252) [[2]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68L193-R287)

**Geocoding enhancements and user feedback:**

* The geocoding action (`geocodePendingSubmissions` in `convex/leads.ts`) now attempts Google Maps geocoding first, falling back to OpenStreetMap Nominatim if Google is unavailable or billing is disabled. A sticky flag prevents repeated failed Google requests in a batch, and the result includes a `googleBillingDisabled` flag for the client. [[1]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L935-R949) [[2]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701R966-R971) [[3]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701R981-R1094)
* The live leads page (`/leads/live`) surfaces a user-friendly hint when Google Maps geocoding falls back to Nominatim due to billing not being enabled, including a direct link to enable billing in GCP. [[1]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL117-R123) [[2]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eR150) [[3]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eR336-R364)
