### PR TITLE
feat: Fix v3 query format

### DIFF
--- a/app/leads/live/page.tsx
+++ b/app/leads/live/page.tsx
@@ -119,7 +119,6 @@ function LiveBusinessesInner() {
               geocoded: number;
               failed: number;
               scanned: number;
-              googleBillingDisabled: boolean;
           }
         | { phase: "error"; message: string }
     >({ phase: "idle" });
@@ -147,7 +146,6 @@ function LiveBusinessesInner() {
                     geocoded: res.geocoded,
                     failed: res.failed,
                     scanned: res.scanned,
-                    googleBillingDisabled: !!res.googleBillingDisabled,
                 });
             })
             .catch((err: any) => {
@@ -334,34 +332,6 @@ function LiveBusinessesInner() {
                     </div>
                 )}
 
-                {/* Google billing-disabled hint — shown after a successful
-                    batch that fell back to Nominatim. Tells the user how to
-                    upgrade for better accuracy without breaking the current
-                    setup. */}
-                {geocodeStatus.phase === "done" && geocodeStatus.googleBillingDisabled && (
-                    <div
-                        className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-start gap-2"
-                        style={{
-                            background: "var(--ed-paper-2)",
-                            color: "var(--ed-ink-2)",
-                            border: "1px solid var(--ed-rule)",
-                        }}
-                    >
-                        <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-ink-3)" }} />
-                        <span>
-                            Pins above were resolved via OpenStreetMap (free, less accurate for informal PH addresses). To use Google Maps geocoding — same key as the map — enable Billing on your GCP project at{" "}
-                            <a
-                                href="https://console.cloud.google.com/project/_/billing/enable"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                style={{ color: "var(--ed-accent)" }}
-                            >
-                                console.cloud.google.com/.../billing/enable
-                            </a>
-                            . Free up to $200/month — you won&apos;t be charged for normal use.
-                        </span>
-                    </div>
-                )}
                 {geocodeStatus.phase === "error" && (
                     <div
                         className="rounded-xl px-3 py-2 mb-5 text-[12px] flex items-start gap-2"
@@ -373,10 +343,7 @@ function LiveBusinessesInner() {
                     >
                         <Globe className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
                         <span>
-                            <strong>Geocoding failed.</strong> {geocodeStatus.message}{" "}
-                            Most commonly this means the <code>GOOGLE_MAPS_GEOCODING_API_KEY</code> env
-                            var isn&apos;t set in Convex. Run{" "}
-                            <code>npx convex env set GOOGLE_MAPS_GEOCODING_API_KEY &lt;your-key&gt;</code> and reload.
+                            <strong>Geocoding failed.</strong> {geocodeStatus.message}
                         </span>
                     </div>
                 )}

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -937,16 +937,9 @@ export const geocodePendingSubmissions = action({
         geocoded: number;
         skipped: number;
         failed: number;
-        googleBillingDisabled: boolean;
     }> => {
         const identity = await ctx.auth.getUserIdentity();
         if (!identity) throw new Error('Not authenticated');
-
-        const apiKey =
-            process.env.GOOGLE_MAPS_GEOCODING_API_KEY ||
-            process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-        // No key is allowed — we fall straight to Nominatim. The Google
-        // path is just the preferred provider when available.
 
         // Fetch pending submissions (address but no coordinates) via an
         // internal query. We cap at `limit` to keep each invocation bounded.
@@ -963,12 +956,6 @@ export const geocodePendingSubmissions = action({
         let geocoded = 0;
         let skipped = 0;
         let failed = 0;
-        // Sticky flag — once we see Google return REQUEST_DENIED we stop
-        // trying it for the rest of the batch (saves N pointless API
-        // round-trips) and fall straight to Nominatim. Surfaced to the
-        // client so the UI can render a "Billing not enabled on GCP"
-        // hint.
-        let googleBillingDisabled = false;
 
         for (const sub of pending) {
             const queryParts = [sub.address, sub.city, sub.province, 'Philippines']
@@ -979,98 +966,48 @@ export const geocodePendingSubmissions = action({
                 continue;
             }
 
+            // OpenStreetMap Nominatim — free, no API key, no billing setup.
+            // Slower than Google (1 req/sec rate limit) and less accurate
+            // for informal PH addresses, but it doesn't require any GCP
+            // configuration and works out of the box.
             let coords: { lat: number; lng: number } | null = null;
+            try {
+                const url = new URL('https://nominatim.openstreetmap.org/search');
+                url.searchParams.set('q', queryParts);
+                url.searchParams.set('format', 'json');
+                url.searchParams.set('countrycodes', 'ph');
+                url.searchParams.set('limit', '1');
 
-            // ── Provider 1: Google Maps Geocoding API ──────────────────
-            // Requires Billing enabled on the GCP project. Free up to
-            // $200/month credit (~40k requests). If REQUEST_DENIED comes
-            // back, billing is the cause — stop trying for this batch.
-            if (apiKey && !googleBillingDisabled) {
-                try {
-                    const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
-                    url.searchParams.set('address', queryParts);
-                    url.searchParams.set('region', 'ph');
-                    url.searchParams.set('key', apiKey);
-
-                    const res = await fetch(url.toString());
-                    if (res.ok) {
-                        const payload: any = await res.json();
-                        if (
-                            payload.status === 'OK' &&
-                            payload.results?.[0]?.geometry?.location
-                        ) {
-                            const loc = payload.results[0].geometry.location;
-                            coords = { lat: loc.lat, lng: loc.lng };
-                        } else if (payload.status === 'REQUEST_DENIED') {
-                            // Most common cause: Billing not enabled.
-                            // Flip the sticky flag so we skip Google for
-                            // the remainder of this batch.
-                            googleBillingDisabled = true;
-                            console.warn(
-                                `[geocode] Google REQUEST_DENIED — ${payload.error_message ?? 'likely needs Billing enabled on the GCP project'}. Falling back to Nominatim for the rest of this batch.`,
-                            );
-                        } else if (payload.status === 'ZERO_RESULTS') {
-                            console.warn(
-                                `[geocode] Google zero results for "${queryParts}" — trying Nominatim.`,
-                            );
-                        } else {
-                            console.warn(
-                                `[geocode] Google non-OK status ${payload.status} for "${queryParts}": ${payload.error_message ?? ''}`,
-                            );
+                const res = await fetch(url.toString(), {
+                    headers: {
+                        // Nominatim ToS requires a User-Agent that
+                        // identifies the application.
+                        'User-Agent': 'NegosyoDigital/1.0 (frmwrkd.media@gmail.com)',
+                        Accept: 'application/json',
+                    },
+                });
+                if (res.ok) {
+                    const payload: any = await res.json();
+                    if (Array.isArray(payload) && payload[0]) {
+                        const lat = parseFloat(payload[0].lat);
+                        const lng = parseFloat(payload[0].lon);
+                        if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+                            coords = { lat, lng };
                         }
                     } else {
-                        console.warn(`[geocode] Google HTTP ${res.status} for "${queryParts}"`);
+                        console.warn(
+                            `[geocode] Nominatim zero results for "${queryParts}"`,
+                        );
                     }
-                } catch (err: any) {
-                    console.warn(
-                        `[geocode] Google threw for "${queryParts}": ${err?.message ?? err}`,
-                    );
+                } else {
+                    console.warn(`[geocode] Nominatim HTTP ${res.status} for "${queryParts}"`);
                 }
-            }
-
-            // ── Provider 2: OpenStreetMap Nominatim ────────────────────
-            // Free, no API key, no Billing required. Slower (1 req/sec
-            // rate limit) and less reliable for informal PH addresses,
-            // but adequate as a fallback when Google is unavailable.
-            if (!coords) {
-                try {
-                    const url = new URL('https://nominatim.openstreetmap.org/search');
-                    url.searchParams.set('q', queryParts);
-                    url.searchParams.set('format', 'json');
-                    url.searchParams.set('countrycodes', 'ph');
-                    url.searchParams.set('limit', '1');
-
-                    const res = await fetch(url.toString(), {
-                        headers: {
-                            // Nominatim ToS requires a User-Agent that
-                            // identifies the application.
-                            'User-Agent': 'NegosyoDigital/1.0 (frmwrkd.media@gmail.com)',
-                            Accept: 'application/json',
-                        },
-                    });
-                    if (res.ok) {
-                        const payload: any = await res.json();
-                        if (Array.isArray(payload) && payload[0]) {
-                            const lat = parseFloat(payload[0].lat);
-                            const lng = parseFloat(payload[0].lon);
-                            if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
-                                coords = { lat, lng };
-                            }
-                        } else {
-                            console.warn(
-                                `[geocode] Nominatim zero results for "${queryParts}"`,
-                            );
-                        }
-                    } else {
-                        console.warn(`[geocode] Nominatim HTTP ${res.status} for "${queryParts}"`);
-                    }
-                    // Polite delay — Nominatim asks for ≤1 req/sec.
-                    await new Promise((r) => setTimeout(r, 1100));
-                } catch (err: any) {
-                    console.warn(
-                        `[geocode] Nominatim threw for "${queryParts}": ${err?.message ?? err}`,
-                    );
-                }
+                // Polite delay — Nominatim asks for ≤1 req/sec.
+                await new Promise((r) => setTimeout(r, 1100));
+            } catch (err: any) {
+                console.warn(
+                    `[geocode] Nominatim threw for "${queryParts}": ${err?.message ?? err}`,
+                );
             }
 
             if (coords) {
@@ -1090,7 +1027,6 @@ export const geocodePendingSubmissions = action({
             geocoded,
             skipped,
             failed,
-            googleBillingDisabled,
         };
     },
 });

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -78,26 +78,39 @@ export const scrapeNearby = action({
         const limit = Math.min(args.limit ?? 20, 200);
         const radiusKm = Math.max(0.5, args.radiusKm ?? 5);
 
-        // 🛑 2026-05-28 FIX (per WEB-BUILD-CRM.md Outscraper query-format bug):
-        // Outscraper's /maps/search-v3 endpoint silently drops `coordinates`
-        // and `radius` when passed as separate query params, then runs the
-        // category as a worldwide search, exceeds the synchronous budget,
-        // and returns `data: [[]]`. The fix is to embed both inside the
-        // query string per Outscraper's documented format:
-        //   query=salon, 14.30,121.00, 3mi
-        const radiusMiles = Math.max(1, Math.round(radiusKm * 0.621371));
+        // Query-format history (per WEB-BUILD-CRM.md):
+        //   v1 (original): query=salon, coordinates=14.29,121.00, radius=3
+        //     → Outscraper ignored `radius`, returned 0 results.
+        //   v2 (2026-05-28 "fix"): query="salon, 14.29,121.00, 3mi"
+        //     → Outscraper treats the comma-soup as a literal place query,
+        //       fails to resolve it, returns a sentinel record with
+        //       place_id="__NO_PLACE_FOUND__" — looks like 1 result but
+        //       contains no usable data.
+        //   v3 (2026-05-29 late evening — current): query="salon",
+        //     coordinates=14.29,121.00, zoom=13 (no radius)
+        //     → Matches Outscraper's documented API.
+        //
+        // Zoom derivation per the spec's radius→zoom mapping for PH latitudes:
+        const zoom =
+            radiusKm <= 1 ? 15 :
+            radiusKm <= 3 ? 14 :
+            radiusKm <= 5 ? 13 :
+            radiusKm <= 10 ? 12 :
+            11;
         const userCategory = args.query.trim() || "businesses";
-        const queryString = `${userCategory}, ${args.location.trim()}, ${radiusMiles}mi`;
+        const coordinates = args.location.trim();
 
         const url = new URL("https://api.outscraper.com/maps/search-v3");
-        url.searchParams.set("query", queryString);
+        url.searchParams.set("query", userCategory);
+        url.searchParams.set("coordinates", coordinates);
+        url.searchParams.set("zoom", String(zoom));
         url.searchParams.set("limit", String(limit));
         url.searchParams.set("language", "en");
         url.searchParams.set("region", "PH");
         url.searchParams.set("async", "false");
 
         console.log(
-            `[outscraper] scrapeNearby → ${queryString} (limit=${limit})`,
+            `[outscraper] scrapeNearby → query="${userCategory}" coords=${coordinates} zoom=${zoom} (limit=${limit}, radiusKm=${radiusKm})`,
         );
 
         let payload: any;
@@ -180,6 +193,20 @@ export const scrapeNearby = action({
                     category: sample.category ?? sample.type ?? sample.subtypes ?? null,
                 })}`,
             );
+        }
+
+        // Sentinel detection — when Outscraper can't resolve the query to
+        // a place to search, it returns a single record with
+        // place_id="__NO_PLACE_FOUND__" and nulled-out fields. Bail out
+        // cleanly so we don't insert junk rows or render junk pins.
+        if (
+            raw.length > 0 &&
+            (raw[0] as any).place_id === "__NO_PLACE_FOUND__"
+        ) {
+            console.warn(
+                `[outscraper] __NO_PLACE_FOUND__ sentinel detected — Outscraper couldn't resolve the query. Returning empty results.`,
+            );
+            return { inserted: 0, skipped: 0, total: 0, businesses: [] };
         }
 
         const scrapedBy = me.clerkId;

--- a/docs/changes/WEB-BUILD-CRM.md
+++ b/docs/changes/WEB-BUILD-CRM.md
@@ -6,6 +6,8 @@
 >
 > **Last updated 2026-05-29 (evening).** Recent changes folded into this doc:
 >
+> 🚨 **2026-05-29 LATE evening — Outscraper query format wrong AGAIN — third attempt now in place.** Diagnostic logs from a live test surfaced Outscraper's sentinel response: when the query format is wrong, Outscraper returns a single record with `place_id: "__NO_PLACE_FOUND__"` and no useful fields. The previous "embedded comma-soup" format (`"businesses, 14.29,121.00, 3mi"`) triggers this. **The correct format per Outscraper's actual docs is `query=businesses&coordinates=14.29,121.00&zoom=13` — query is just the category, coordinates separate, zoom controls the area, no `radius` parameter exists.** Mobile's `convex/outscraper.ts` now uses this format and also detects the sentinel so it returns `{businesses: []}` instead of polluting the leads table. See "🛑 2026-05-29 late — Outscraper sentinel response" section below for full diagnosis.
+>
 > 🚨 **2026-05-29 evening — DEPLOY ACTION REQUIRED on the web side.** The mobile team has rewritten `convex/outscraper.ts` to bypass the broken DB write path entirely (details below). For the Find Local Business map to actually show pins in production, **the web agent must merge mobile's `convex/outscraper.ts` changes into the web repo and run `npx convex deploy --prod` from the WEB repo.** Mobile is NOT allowed to deploy directly — the established rule that web owns the deployed `convex/outscraper.ts` is unchanged. See **"🚀 Deploy steps for the web agent"** at the end of this doc for the exact merge recipe (which mobile changes to copy, which web-added functions to preserve).
 >
 > ✅ **2026-05-29 evening — Mobile bypassed the broken DB path entirely.** After dashboard inspection confirmed zero rows in `leads` table where `source === "outscraper"` (despite Outscraper returning data and the action logging `received 1 businesses`), mobile pivoted the architecture: **`scrapeNearby` now returns the raw businesses array DIRECTLY to the client. The discover map renders pins from that in-memory data using URL query params — no DB read needed.** The DB inserts still happen as best-effort (wrapped in try/catch, write failures don't break the map). Net effect: pins show up on the discover map even if `insertScrapedLead` is completely broken in prod and `listScrapedLeads` returns empty. The map is no longer blocked by either of those failures. See updated "Convex contract" → "Write: trigger a new scrape" and "Map B — Find Local Business (the discovery view)" for the new shape.
@@ -1249,6 +1251,65 @@ Each blocker has its own section below.
 > 1. Tap Find Local Business with category `salon`, radius 5km, anywhere with businesses around you
 > 2. Check Convex prod logs — should see `[outscraper] scrapeNearby → salon, 14.30,121.00, 3mi (limit=20)` followed by `[outscraper] received N businesses from Outscraper` where N > 0
 > 3. Alert should now show `N businesses found nearby. Added N new ones to your interview list (0 were already on it).`
+
+---
+
+## 🛑 2026-05-29 (late evening) — Outscraper sentinel response: query format STILL wrong
+
+> **Symptom:** Convex prod logs show `[outscraper] received 1 businesses from Outscraper`, but `[outscraper] first business sample: {"place_id":"__NO_PLACE_FOUND__","category":null}` — the "1 business" is actually a sentinel record with no usable data. `inserted=0, skipped=1`. The discover map shows zero pins.
+>
+> **Root cause:** Outscraper returns a placeholder record with `place_id: "__NO_PLACE_FOUND__"` and nulled-out fields when it can't resolve the query to a place to search. The previous "embedded comma format" (`query="businesses, 14.29,121.00, 3mi"`) triggers this — Outscraper treats the comma-separated string as a single literal search query, can't find a place matching that text, returns the sentinel.
+>
+> **The format Outscraper's `/maps/search` actually expects (per their published API docs):**
+>
+> ```typescript
+> // ✅ Per Outscraper docs at app.outscraper.com/api-docs
+> //   - `query` is just the natural-language category (no embedded location)
+> //   - `coordinates` is a SEPARATE param accepting "lat,lng"
+> //   - `zoom` controls search area: 1 = world, 21 = building. ~13 for 5km.
+> //   - There is NO `radius` parameter on /maps/search
+> new URLSearchParams({
+>   query: userCategory,            // "businesses" — just the category
+>   coordinates: args.location,     // "14.29,121.00" — separate param
+>   zoom: "13",                     // derived from radiusKm
+>   limit: String(limit),
+>   async: "false",
+>   language: "en",
+>   region: "PH",
+> });
+> ```
+>
+> **Radius-to-zoom mapping (Philippines latitude band):**
+>
+> | Mobile UI radius pill | Zoom level passed to Outscraper |
+> |---|---|
+> | 1 km | 15 |
+> | 3 km | 14 |
+> | 5 km (default) | 13 |
+> | 10 km | 12 |
+> | (>10 km) | 11 |
+>
+> **Sentinel detection in mobile's code:** after parsing Outscraper's response, mobile checks if the first business has `place_id === "__NO_PLACE_FOUND__"`. If so, the action logs a WARNING line and returns `{ inserted: 0, skipped: 0, total: 0, businesses: [] }` — no junk row gets inserted, no junk pin on the map.
+>
+> **Action required on web side:** When porting `scrapeNearby` per the "🚀 Deploy steps for the web agent" section, make sure your copy uses this v3 format (separate `coordinates` + `zoom`). The diagnostic logs in mobile's version will surface the sentinel if it ever happens again, so you'll see immediately if the format reverts.
+>
+> **What history of attempts looks like in code comments:**
+>
+> ```
+> v1 (original): query=salon, coordinates=14.29,121.00, radius=3
+>   → Outscraper ignored `radius`, returned 0 results
+> v2 (2026-05-28 "fix"): query="salon, 14.29,121.00, 3mi"  (location embedded)
+>   → Outscraper returns sentinel {place_id:"__NO_PLACE_FOUND__"}
+> v3 (2026-05-29 late evening — current): query="salon"&coordinates=14.29,121.00&zoom=13
+>   → Matches Outscraper's documented API. Expected to return real results.
+> ```
+>
+> **How to verify after deploy:**
+> 1. Tap Find Local Business with category `salon` (or leave blank for "businesses"), radius 5km
+> 2. Check Convex prod logs — should see `[outscraper] scrapeNearby → query="salon" coords=14.29,121.00 zoom=13 (limit=20, radiusKm=5)`
+> 3. Then `[outscraper] received N businesses from Outscraper` where N > 0
+> 4. `[outscraper] first business sample` should show a REAL `place_id` (a string starting with `ChIJ...`), NOT `__NO_PLACE_FOUND__`
+> 5. Discover map should show N pins
 
 ---
 


### PR DESCRIPTION
# Latest Changes ✨

**Outscraper integration fixes and improvements:**

* Updated `scrapeNearby` in `convex/outscraper.ts` to use the correct query format per Outscraper's API: category as `query`, coordinates as a separate param, and a derived `zoom` level instead of a `radius` param. This prevents Outscraper from returning sentinel records with `place_id="__NO_PLACE_FOUND__"` and ensures real results are returned. Sentinel responses are now detected and filtered out before returning results. [[1]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68L81-R113) [[2]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R198-R211)
* Documentation in `docs/changes/WEB-BUILD-CRM.md` updated to explain the query format issue, the sentinel response, and the new correct format, including a new troubleshooting section and verification steps. [[1]](diffhunk://#diff-4e0a169dba9061725636e7b968da10435492b46761c72dfd627e91662ae5ec35R9-R10) [[2]](diffhunk://#diff-4e0a169dba9061725636e7b968da10435492b46761c72dfd627e91662ae5ec35R1257-R1315)

**Geocoding pipeline simplification:**

* Removed all code and UI related to Google Maps Geocoding API, including the fallback logic, status tracking, and the UI hint about enabling billing. The geocoding process now exclusively uses OpenStreetMap Nominatim, which does not require billing or API keys. [[1]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L940-L950) [[2]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L966-L971) [[3]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701R969-L1035) [[4]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L1074) [[5]](diffhunk://#diff-6a7497f092cd60c5310320cfac37413d10462a8de7e3851a45d66c8c5a6bc701L1093) [[6]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL122) [[7]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL150) [[8]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL337-L364)
* Simplified error messaging for geocoding failures in the UI, removing references to Google API key setup.