### PR TITLE
Devpatch7

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -136,19 +136,28 @@ function DiscoverInner() {
         );
     }, [ready]);
 
-    // Per the 2026-05-29 evening spec update: the discover map has TWO
-    // data sources, in priority order:
+    // Per the 2026-06-01 P1 prospect-pool deploy: the discover map has
+    // THREE data sources, merged in priority order with place_id dedup:
     //
     //   1. PRIMARY — URL `data` param. After a successful scrape, the
     //      modal encodes result.businesses as JSON and passes it via the
     //      URL. This bypasses the silently-failing DB write path entirely.
     //
-    //   2. FALLBACK — listScrapedLeads query. Only used when the user
-    //      navigates here without `data` (deep link, browser back/forward,
-    //      cold start to /leads/discover).
+    //   2. POOL — prospects.searchNearby. The new global prospect pool
+    //      (shared across creators, replenished by background cron in P4).
+    //      Subscribes once the user's GPS resolves; no Outscraper call.
     //
-    // Both sources get normalized into a shared shape and feed the same
-    // downstream pin-rendering pipeline.
+    //   3. LEGACY FALLBACK — outscraper.listScrapedLeads. The old per-creator
+    //      scraped leads. Kept during the migration window so cold-start
+    //      navigations (deep link, browser back/forward) still have data.
+    //      Will be removed in Phase M.4 cleanup.
+    //
+    // All three sources get normalized into a shared shape (with a
+    // `__source` tag for the DEBUG strip + claim-button gating) and feed
+    // the same downstream pin-rendering pipeline. The "I'll interview
+    // this" button is hidden on pool-sourced pins until P2's
+    // prospects.reserve mutation ships — legacy/url pins still use
+    // outscraper.claimProspect as before.
     const urlData = searchParams.get("data");
     const urlBusinesses = useMemo(() => {
         if (!urlData) return null;
@@ -161,6 +170,8 @@ function DiscoverInner() {
             // looks it up in the DB.
             return parsed.map((b: any) => ({
                 _id: b.placeId ?? `${b.businessName}:${b.businessLatitude}:${b.businessLongitude}`,
+                __source: "url" as const,
+                businessGooglePlaceId: b.placeId ?? null,
                 submissionId: null,
                 businessName: b.businessName ?? null,
                 businessAddress: b.businessAddress ?? null,
@@ -179,8 +190,48 @@ function DiscoverInner() {
         }
     }, [urlData]);
 
-    // Fallback query — ONLY subscribe when there's no URL data. Saves a
-    // round-trip + reactive subscription on the happy path (post-scrape).
+    // P1 pool query — prospects.searchNearby reads from the new global
+    // pool. Subscribes only once GPS resolves so we have a real (lat, lng);
+    // suspending earlier would cost a wasted query. The (api as any) cast
+    // lets us ship before the next-build codegen refresh wires up the
+    // typed binding — drops to `api.prospects.searchNearby` once codegen
+    // catches up. Safe because P1 web deploy already shipped this function.
+    const poolProspects = useQuery(
+        (api as any).prospects?.searchNearby,
+        ready && userLoc
+            ? { lat: userLoc.lat, lng: userLoc.lng, radiusKm, limit: 200 }
+            : "skip",
+    ) as any[] | undefined;
+
+    const poolArray = useMemo(() => {
+        if (!Array.isArray(poolProspects)) return [];
+        // Map prospects.* shape → the discover-map row shape. Pool docs use
+        // `latitude`/`longitude` (no `business` prefix), `phone`, `rating`,
+        // `reviewCount`, `address`. We also stamp `__source: "pool"` so the
+        // claim button can be hidden until P2's reserve mutation lands.
+        return poolProspects.map((p: any) => ({
+            _id: p._id,
+            __source: "pool" as const,
+            businessGooglePlaceId: p.googlePlaceId ?? null,
+            // submissionId on the pool side means "already converted" —
+            // map it through so the candidate filter below excludes it
+            // (same semantics as the legacy lead.submissionId).
+            submissionId: p.submissionId ?? null,
+            businessName: p.businessName ?? null,
+            businessAddress: p.address ?? null,
+            businessCity: p.city ?? null,
+            businessCategory: p.category ?? null,
+            businessWebsite: p.website ?? null,
+            phone: p.phone ?? null,
+            businessLatitude: p.latitude ?? null,
+            businessLongitude: p.longitude ?? null,
+            businessRating: p.rating ?? null,
+            businessReviewCount: p.reviewCount ?? null,
+        }));
+    }, [poolProspects]);
+
+    // Legacy fallback query — ONLY subscribe when there's no URL data.
+    // Stays during the migration window; removed in Phase M.4.
     const fallbackProspects = useQuery(
         api.outscraper.listScrapedLeads,
         ready && !urlBusinesses ? {} : "skip",
@@ -191,13 +242,51 @@ function DiscoverInner() {
     // array. Unwrap if needed.
     const fallbackArray: any[] | undefined = useMemo(() => {
         if (fallbackProspects === undefined) return undefined;
-        if (Array.isArray(fallbackProspects)) return fallbackProspects;
-        const wrapped = fallbackProspects as any;
-        if (Array.isArray(wrapped?.leads)) return wrapped.leads;
-        return [];
+        const arr = Array.isArray(fallbackProspects)
+            ? fallbackProspects
+            : Array.isArray((fallbackProspects as any)?.leads)
+                ? (fallbackProspects as any).leads
+                : [];
+        return arr.map((p: any) => ({ ...p, __source: "legacy" as const }));
     }, [fallbackProspects]);
 
-    const prospects: any[] | undefined = urlBusinesses ?? fallbackArray;
+    // Per-source counts for the DEBUG strip — matches mobile's debug
+    // string so cross-platform support reads the same numbers.
+    const sourceCounts = useMemo(() => ({
+        url: urlBusinesses?.length ?? 0,
+        pool: poolArray.length,
+        legacy: fallbackArray?.length ?? 0,
+    }), [urlBusinesses, poolArray, fallbackArray]);
+
+    // Merge sources with place_id dedup. Priority: url > pool > legacy.
+    // Falls back to the legacy-only path when URL data is present (post-
+    // scrape happy path) — pool + legacy still ride along so a partial
+    // URL set doesn't hide nearby pool rows.
+    const prospects: any[] | undefined = useMemo(() => {
+        // Suspense gate: wait until at least ONE source has resolved.
+        // (poolProspects can resolve faster than fallbackProspects since
+        // it doesn't depend on the legacy list-all path.)
+        const haveAnyResolved =
+            urlBusinesses != null ||
+            poolProspects !== undefined ||
+            fallbackProspects !== undefined;
+        if (!haveAnyResolved) return undefined;
+
+        const byKey = new Map<string, any>();
+        const stash = (row: any) => {
+            // Dedup key: prefer Google place_id (the only stable cross-source
+            // identity), fall back to lat,lng,name when place_id is missing
+            // (rare — only happens for very old legacy rows).
+            const key =
+                row.businessGooglePlaceId
+                ?? `${row.businessLatitude},${row.businessLongitude},${row.businessName}`;
+            if (!byKey.has(key)) byKey.set(key, row);
+        };
+        if (urlBusinesses) urlBusinesses.forEach(stash);
+        poolArray.forEach(stash);
+        if (fallbackArray) fallbackArray.forEach(stash);
+        return Array.from(byKey.values());
+    }, [urlBusinesses, poolProspects, poolArray, fallbackProspects, fallbackArray]);
 
     // Client-side geocoder cache — keyed by lead id. Used when an Outscraper
     // prospect has an address but no latitude/longitude (sometimes happens
@@ -537,13 +626,12 @@ function DiscoverInner() {
                             Tap Find Local Business again with a wider radius or a different category to add more pins here.
                         </p>
 
-                        {/* DEBUG strip — per WEB-BUILD-CRM.md "Three Outscraper blockers"
-                            triage tree. Surfaces the data shape so creators (and
-                            us during support) can tell at a glance which
-                            blocker is in play:
-                              rows=0          → no Outscraper rows at all (BLOCKER 1 or 3)
-                              outscraper>0, with-coords=0  → BLOCKER 2 (validator drift)
-                              outscraper>0, with-coords>0  → frontend filter bug */}
+                        {/* DEBUG strip — per-source breakdown matching mobile's
+                            discover.tsx format for cross-platform support.
+                              direct=N      → pins from the URL ?data= param (post-scrape)
+                              pool=N        → pins from prospects.searchNearby (P1 pool)
+                              legacy=N      → pins from outscraper.listScrapedLeads (pre-P1)
+                              with-coords=N → final pin count after coord filtering */}
                         <div
                             className="rounded-md px-3 py-2 mb-4 text-[10px] inline-block"
                             style={{
@@ -554,9 +642,7 @@ function DiscoverInner() {
                                 letterSpacing: "0.08em",
                             }}
                         >
-                            DEBUG · rows={prospects?.length ?? 0} ·
-                            outscraper={(prospects ?? []).filter((p: any) => !p.submissionId).length} ·
-                            with-coords={
+                            DEBUG · direct={sourceCounts.url} · pool={sourceCounts.pool} · legacy={sourceCounts.legacy} · with-coords={
                                 (prospects ?? []).filter(
                                     (p: any) =>
                                         !p.submissionId &&
@@ -721,7 +807,12 @@ function CategoryPins({ pins }: { pins: any[] }) {
                             </div>
                         )}
                         <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                            {!selected.claimedBy && (
+                            {/* Claim button: shown for legacy/url-sourced pins only.
+                                Pool-sourced pins are reserved via prospects.reserve
+                                in P2; until that mutation ships, the button is
+                                hidden on pool entries to prevent leadId type
+                                mismatches with outscraper.claimProspect. */}
+                            {!selected.claimedBy && selected.__source !== "pool" && (
                                 <button
                                     type="button"
                                     onClick={async () => {
@@ -746,6 +837,21 @@ function CategoryPins({ pins }: { pins: any[] }) {
                                 >
                                     I&apos;ll interview this
                                 </button>
+                            )}
+                            {selected.__source === "pool" && !selected.claimedBy && (
+                                <span
+                                    title="Reserve flow ships in P2 — for now, pool pins are read-only."
+                                    style={{
+                                        fontSize: 11,
+                                        fontWeight: 600,
+                                        padding: "4px 10px",
+                                        borderRadius: 999,
+                                        background: "#EFEBE0",
+                                        color: "#7A7E8A",
+                                    }}
+                                >
+                                    Pool · reserve coming soon
+                                </span>
                             )}
                             <a
                                 href={`https://www.google.com/maps/search/?api=1&query=${selected.lat},${selected.lng}`}

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -39,6 +39,60 @@ interface OutscraperPlace {
     longitude?: number;
 }
 
+// ── Path B: Google Places hyper-local merge (per WEB-PROPECT-POOL.md §Path B) ──
+// Outscraper ranks by popularity/relevance, not physical distance. A creator
+// 50m from "PARES SA GARAHE" gets back restaurants 1.2-1.7km away because
+// Google ranks the bigger places higher. Google Places Nearby Search with
+// `rankby=distance` ranks purely by physical distance and surfaces those
+// hyper-local hits Outscraper drops. We call BOTH APIs in `scrapeNearby`
+// and merge by `place_id`. Path B fires only for short-radius searches
+// (≤ PLACES_HYPERLOCAL_RADIUS_KM) — Outscraper still owns wider-area
+// coverage because Places caps at 60 results across 3 paginated requests.
+const GOOGLE_PLACES_NEARBY_URL =
+    "https://maps.googleapis.com/maps/api/place/nearbysearch/json";
+const PLACES_HYPERLOCAL_RADIUS_KM = 2;
+
+interface PlacesNearbyResult {
+    place_id?: string;
+    name?: string;
+    vicinity?: string;
+    formatted_address?: string;
+    types?: string[];
+    rating?: number;
+    user_ratings_total?: number;
+    geometry?: {
+        location?: { lat?: number; lng?: number };
+    };
+}
+
+/**
+ * Map a free-text user category to Google Places' `type` parameter.
+ * When this returns a string, Places is called with `rankby=distance` +
+ * `type=<that>` (distance-sorted, type-filtered). When this returns
+ * `undefined`, we fall back to `radius=N` mode (the same approach
+ * Outscraper takes, just from Google directly).
+ *
+ * Table mirrors mobile's helper (see WEB-PROPECT-POOL.md §Path B table).
+ */
+function mapCategoryToPlacesType(userCategory: string): string | undefined {
+    const k = userCategory.trim().toLowerCase();
+    if (!k) return undefined;
+    if (/\b(barbershop|barber)\b/.test(k)) return "hair_care";
+    if (/\b(hair\s*salon|salon)\b/.test(k)) return "beauty_salon";
+    if (/\b(nail|manicure)\b/.test(k)) return "beauty_salon";
+    if (/\b(spa|massage)\b/.test(k)) return "spa";
+    if (/\b(auto|mechanic|vulcanizing|car\s*repair)\b/.test(k)) return "car_repair";
+    if (/\b(dental|dentist)\b/.test(k)) return "dentist";
+    if (/\b(pharmacy|drugstore)\b/.test(k)) return "pharmacy";
+    if (/\b(restaurant|carinderia|eatery|fastfood)\b/.test(k)) return "restaurant";
+    if (/\b(cafe|coffee)\b/.test(k)) return "cafe";
+    if (/\b(bakery|panaderia)\b/.test(k)) return "bakery";
+    if (/\b(sari[-\s]?sari|convenience)\b/.test(k)) return "convenience_store";
+    if (/\b(grocery|supermarket)\b/.test(k)) return "supermarket";
+    if (/\b(store|shop|mart)\b/.test(k)) return "store";
+    return undefined;
+}
+
 /**
  * Scrape Google Maps near a location, insert dedup'd leads. Creator-callable
  * (was admin-only, changed per the 2026-05-27 WEB-BUILD-CRM.md update).
@@ -310,6 +364,128 @@ export const scrapeNearby = action({
         console.log(
             `[outscraper] returning to client: ${businesses.length} businesses with coords (inserted=${inserted}, skipped=${skipped})`,
         );
+
+        // ── Path B: Google Places hyper-local merge ──────────────────
+        // Only fires for short-radius searches AND when both the env var
+        // and a parseable lat/lng coordinate string are present. Failures
+        // are non-fatal — Outscraper results still return.
+        try {
+            const placesKey = process.env.GOOGLE_PLACES_API_KEY;
+            const coordMatch = /^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/.exec(
+                coordinates,
+            );
+            if (
+                placesKey &&
+                coordMatch &&
+                radiusKm <= PLACES_HYPERLOCAL_RADIUS_KM
+            ) {
+                const lat = Number(coordMatch[1]);
+                const lng = Number(coordMatch[2]);
+                const placesType = mapCategoryToPlacesType(userCategory);
+
+                const placesUrl = new URL(GOOGLE_PLACES_NEARBY_URL);
+                placesUrl.searchParams.set("key", placesKey);
+                placesUrl.searchParams.set("location", `${lat},${lng}`);
+                if (placesType) {
+                    // rankby=distance + type=X surfaces the nearest businesses
+                    // of that type, sorted by physical distance. radius is
+                    // NOT allowed in this mode.
+                    placesUrl.searchParams.set("rankby", "distance");
+                    placesUrl.searchParams.set("type", placesType);
+                } else {
+                    // No type mapping — fall back to radius-mode keyword search.
+                    placesUrl.searchParams.set(
+                        "radius",
+                        String(Math.round(radiusKm * 1000)),
+                    );
+                    placesUrl.searchParams.set("keyword", userCategory);
+                }
+
+                console.log(
+                    `[outscraper] hyper-local Places call → location=${lat},${lng} type=${placesType ?? "(none)"} (radiusKm=${radiusKm})`,
+                );
+
+                const placesRes = await fetch(placesUrl.toString(), {
+                    method: "GET",
+                    headers: { Accept: "application/json" },
+                });
+                if (!placesRes.ok) {
+                    throw new Error(`Places HTTP ${placesRes.status}`);
+                }
+                const placesPayload = (await placesRes.json()) as {
+                    status?: string;
+                    results?: PlacesNearbyResult[];
+                    error_message?: string;
+                };
+                if (
+                    placesPayload.status &&
+                    placesPayload.status !== "OK" &&
+                    placesPayload.status !== "ZERO_RESULTS"
+                ) {
+                    throw new Error(
+                        `Places status=${placesPayload.status}${placesPayload.error_message ? ": " + placesPayload.error_message : ""}`,
+                    );
+                }
+
+                const placesResults = placesPayload.results ?? [];
+                console.log(
+                    `[outscraper] Places returned ${placesResults.length} hyper-local businesses`,
+                );
+
+                // Build a dedup set from the existing Outscraper results.
+                // Anything already in `businesses` (by place_id) is skipped.
+                const seenPlaceIds = new Set<string>();
+                for (const b of businesses) seenPlaceIds.add(b.placeId);
+
+                let mergedCount = 0;
+                for (const r of placesResults) {
+                    const placeId = r.place_id;
+                    if (!placeId || seenPlaceIds.has(placeId)) continue;
+                    const placeLat = r.geometry?.location?.lat;
+                    const placeLng = r.geometry?.location?.lng;
+                    if (
+                        typeof placeLat !== "number" ||
+                        typeof placeLng !== "number"
+                    )
+                        continue;
+                    if (!r.name) continue;
+
+                    businesses.push({
+                        placeId,
+                        businessName: r.name,
+                        businessAddress: r.vicinity || r.formatted_address || null,
+                        businessCity: null,
+                        // Places returns `types: string[]` — first one is usually
+                        // the most specific. Stringify for our flat field.
+                        businessCategory:
+                            Array.isArray(r.types) && r.types.length > 0
+                                ? r.types[0]
+                                : null,
+                        businessWebsite: null,
+                        businessPhone: null,
+                        businessLatitude: placeLat,
+                        businessLongitude: placeLng,
+                        businessRating:
+                            typeof r.rating === "number" ? r.rating : null,
+                        businessReviewCount:
+                            typeof r.user_ratings_total === "number"
+                                ? r.user_ratings_total
+                                : null,
+                    });
+                    seenPlaceIds.add(placeId);
+                    mergedCount += 1;
+                }
+
+                console.log(
+                    `[outscraper] merged ${mergedCount} new businesses from Places (total now ${businesses.length})`,
+                );
+            }
+        } catch (err: any) {
+            // Non-fatal — never let a Places failure break the scrape.
+            console.warn(
+                `[outscraper] Places hyper-local merge failed (non-fatal): ${err?.message ?? err}`,
+            );
+        }
 
         return { inserted, skipped, total: raw.length, businesses };
     },

--- a/docs/changes/WEB-PROPECT-POOL.md
+++ b/docs/changes/WEB-PROPECT-POOL.md
@@ -51,6 +51,112 @@
 > - ❌ Background `scrapeAndStore` action — P4
 > - ❌ Replenishment cron — P4
 > - ❌ Mobile UI changes for the "I'll interview this" → reserve flow — P2 mobile work
+>
+> ---
+>
+> ## 🟢 Path B — Google Places hyper-local fix (2026-06-02)
+>
+> **Why this exists:** Outscraper Maps Search returns results ranked by Google's relevance/popularity algorithm, NOT by physical distance. A creator standing 50m from "PARES SA GARAHE" (a roadside food stall listed on Google Maps) gets back restaurants 1.2-1.7km away because Google ranks the bigger places higher. Even with `category="restaurant"` and `radius=1km`, the hyper-local stall is missing.
+>
+> **The fix:** Google Places API "Nearby Search" with `rankby=distance` ranks purely by physical distance, surfacing informal local businesses that Outscraper drops. We call BOTH APIs and merge results by `place_id`. Outscraper still owns wider-area coverage (>2km radius) because Places caps at 60 results across 3 paginated requests.
+>
+> **Cost impact for current scale:** $0 out-of-pocket. Google Cloud Maps Platform includes a $200/month free credit that covers ~6,250 Places Nearby Search calls per month. At present testing volume (~100 scrapes/month), this is well within the free tier.
+>
+> **Web agent: porting steps for Path B**
+>
+> 1. **Enable Places API on the existing Google Cloud project** (30 seconds, no new project needed):
+>    - https://console.cloud.google.com → select the existing project (the one the Maps API key `AIzaSyAt-knwNJgQ-Nx5ZY5aZUC-T8sj8D3QZ7U` lives in — same project as `negosyo-digital`)
+>    - APIs & Services → Library → search "Places API" → click → **Enable**
+>    - The existing API key automatically gains Places API access — no new key needed
+>    - Optional but recommended: API key → Edit → "Set application restriction" → "API restrictions" → check "Places API" so the same key can be reused
+>
+> 2. **Set the Convex env var** (the action reads `GOOGLE_PLACES_API_KEY` — graceful fallback if absent):
+>    ```bash
+>    npx convex env set GOOGLE_PLACES_API_KEY AIzaSyAt-knwNJgQ-Nx5ZY5aZUC-T8sj8D3QZ7U --prod
+>    ```
+>    (Reuses the existing Maps API key. If you'd rather scope a separate key for server-side Places usage, create a second key restricted to Places API only and use that instead.)
+>
+> 3. **Port mobile's `scrapeNearby` changes** from `ndm/convex/outscraper.ts` to the web repo's `convex/outscraper.ts`:
+>    - Add the new constants: `GOOGLE_PLACES_NEARBY_URL`, `PLACES_HYPERLOCAL_RADIUS_KM`
+>    - Add the new helper function: `mapCategoryToPlacesType(userCategory: string): string | undefined`
+>    - Add the `PlacesNearbyResult` type
+>    - Inject the hyper-local merge block right BEFORE the existing `return { inserted, skipped, total, businesses };` line (search for `[outscraper] returning to client:` log line — the merge sits immediately after that log)
+>    - The merge is wrapped in try/catch — Places failures are non-fatal, scrape still returns Outscraper results
+>
+> 4. **Deploy:** `npx convex deploy --prod` from the web repo
+>
+> 5. **Verify after deploy:**
+>    - Open Convex prod logs
+>    - On mobile, tap Find Local Business with category `restaurant` and 1km radius
+>    - Watch for new log lines:
+>      - `[outscraper] hyper-local Places call → location=14.29,121.00 type=restaurant (radiusKm=1)`
+>      - `[outscraper] Places returned N hyper-local businesses`
+>      - `[outscraper] merged M new businesses from Places (total now X)`
+>    - Discover map should now show businesses < 1km away. PARES SA GARAHE should appear.
+>
+> **Web creator page UI changes — implement on the web platform's `/creators/leads/discover` page**
+>
+> The merge happens server-side, so the web creator page's data flow doesn't change. BUT three UI polish items should be implemented to match what creators expect:
+>
+> 1. **Distance filter on the client** — when the user picks `radius=1km`, show ONLY businesses where `distanceKm <= 1`. The merged response can include businesses slightly beyond the radius (Places returns 20 nearest regardless of radius hint in `rankby=distance` mode). Filter client-side so the header sub-copy "20 businesses within 1km" is honest.
+>
+>    ```typescript
+>    // In your web discover map's React component:
+>    const filteredBusinesses = businesses.filter((b) => {
+>      if (!userGps || b.businessLatitude == null || b.businessLongitude == null) return true;
+>      const km = haversineKm(userGps, { lat: b.businessLatitude, lng: b.businessLongitude });
+>      return km <= radiusKm;
+>    });
+>    ```
+>
+> 2. **Sub-copy accuracy** — match mobile. Show the filtered count, not the merged-total count:
+>
+>    ```typescript
+>    const headerSubCopy = `${filteredBusinesses.length} ${category} businesses within ${radiusKm} km. Pin colors show categories.`;
+>    ```
+>
+> 3. **"Hyper-local" indicator pin** — businesses that came from Places API (not Outscraper) should have a small badge or different pin style indicating they're hyper-local discovery hits. This signals trust to the creator ("the system found this one specifically because it's close to you"). One way: add a `source: 'outscraper' | 'places'` field to each business in the return shape (server-side change), then render a `[hyper-local]` mono-label badge next to the business name on the prospect card when source === 'places'.
+>
+>    Mobile has NOT shipped this badge in the current Path B implementation — both sources merge into the same business shape. If you want this visual distinction on web, propose it as a P-B.5 follow-up and we'll add a `discoveredVia` field to the server return.
+>
+> **What `mapCategoryToPlacesType` covers:**
+>
+> The category mapping is 1:1 with mobile's helper. Categories that map cleanly to Google Places types:
+>
+> | User category | Google Places `type` |
+> |---|---|
+> | barbershop, barber | `hair_care` |
+> | hair salon, salon | `beauty_salon` |
+> | nail, manicure | `beauty_salon` |
+> | spa, massage | `spa` |
+> | auto, mechanic | `car_repair` |
+> | dental, dentist | `dentist` |
+> | pharmacy, drugstore | `pharmacy` |
+> | restaurant, carinderia, eatery | `restaurant` |
+> | cafe, coffee | `cafe` |
+> | bakery | `bakery` |
+> | sari-sari, convenience | `convenience_store` |
+> | grocery, supermarket | `supermarket` |
+> | store, shop, mart | `store` |
+> | (anything else) | undefined → falls back to radius-mode |
+>
+> When `mapCategoryToPlacesType` returns `undefined`, the Places call uses `radius=N` mode (not `rankby=distance`) — same approach Outscraper takes, just from Google directly.
+>
+> **What does NOT change on the existing Outscraper integration:**
+>
+> - ✅ `outscraper.scrapeNearby` args unchanged
+> - ✅ Outscraper async-mode + query-format fixes from prior callouts still apply
+> - ✅ The `__NO_PLACE_FOUND__` sentinel detection still applies
+> - ✅ Mobile `discover.tsx` dual-read merge logic unchanged — businesses array is unified
+> - ✅ The P4 background `scrapeAndStore` (future) will use the SAME Path B merge pattern so the inventory pool gets the benefit too
+>
+> **Files in mobile's Path B spec (already written, ready to port):**
+> - `ndm/convex/outscraper.ts` — Places API integration in `scrapeNearby`, new `mapCategoryToPlacesType` helper, `PlacesNearbyResult` type, two new constants
+>
+> **What's NOT in Path B (would be a P-B.2 enhancement):**
+> - ❌ Fetching business phone/website via Places Details API (extra cost ~$0.017/call × 20 results = $0.34/scrape — only do if creators report missing phone/website on hyper-local businesses)
+> - ❌ Pagination beyond the first 20 Places results (Places caps at 60 total, but each extra page costs and adds latency)
+> - ❌ Separate `source: 'outscraper' | 'places'` field on returned businesses (proposed for P-B.5 if web UI wants to badge them differently)
 
 ---
 


### PR DESCRIPTION
# Latest Changes ✨

**Lead data source integration and UI improvements:**

* The discover map now merges three data sources (URL param, global prospect pool, and legacy scraped leads) with deduplication by `place_id`, normalizing all sources with a `__source` tag for downstream logic and debugging. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L139-R160) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R173-R174) [[3]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L194-R289)
* Introduced the new global prospect pool (`prospects.searchNearby`), subscribing once GPS resolves, and mapped its data into the unified pin format.
* Updated the DEBUG strip to show per-source counts (direct, pool, legacy) and the post-filtered pin count, matching mobile for cross-platform support. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L540-R634) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L557-R645)
* The claim button is now only shown for legacy/url-sourced pins; pool-sourced pins display a "reserve coming soon" notice until the reservation mutation ships. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L724-R815) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R841-R855)

**Backend scraping enhancements:**

* Added a "Path B" hyper-local merge: for short-radius searches, Google Places Nearby Search is called in addition to Outscraper, and new results (by `place_id`) are merged into the businesses array. Includes a category-to-type mapping for optimal Places API usage. [[1]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R42-R95) [[2]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R368-R489)

