### PR TITLE
Devpatch7

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -747,6 +747,10 @@ function DiscoverInner() {
 function CategoryPins({ pins }: { pins: any[] }) {
     const [selected, setSelected] = useState<any | null>(null);
     const claim = useMutation(api.outscraper.claimProspect);
+    // P2: prospects.reserve for pool-sourced pins (replaces the old hint chip).
+    // `(api as any)` cast keeps web buildable when codegen hasn't refreshed yet;
+    // drops to `api.prospects.reserve` once everyone's local codegen catches up.
+    const reservePool = useMutation((api as any).prospects?.reserve);
     return (
         <>
             {pins.map((pin) => (
@@ -839,19 +843,30 @@ function CategoryPins({ pins }: { pins: any[] }) {
                                 </button>
                             )}
                             {selected.__source === "pool" && !selected.claimedBy && (
-                                <span
-                                    title="Reserve flow ships in P2 — for now, pool pins are read-only."
+                                <button
+                                    type="button"
+                                    onClick={async () => {
+                                        try {
+                                            await reservePool({ prospectId: selected._id });
+                                            toast.success("Reserved — it's yours for the next 24h.");
+                                            setSelected(null);
+                                        } catch (e: any) {
+                                            toast.error(e?.message ?? "Couldn't reserve.");
+                                        }
+                                    }}
                                     style={{
                                         fontSize: 11,
                                         fontWeight: 600,
                                         padding: "4px 10px",
                                         borderRadius: 999,
-                                        background: "#EFEBE0",
-                                        color: "#7A7E8A",
+                                        background: "#1B1C24",
+                                        color: "#FCFAF5",
+                                        border: "none",
+                                        cursor: "pointer",
                                     }}
                                 >
-                                    Pool · reserve coming soon
-                                </span>
+                                    I&apos;ll interview this
+                                </button>
                             )}
                             <a
                                 href={`https://www.google.com/maps/search/?api=1&query=${selected.lat},${selected.lng}`}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -44,6 +44,7 @@ import type * as prospects from "../prospects.js";
 import type * as prospectsMigration from "../prospectsMigration.js";
 import type * as r2 from "../r2.js";
 import type * as referrals from "../referrals.js";
+import type * as scrape from "../scrape.js";
 import type * as settings from "../settings.js";
 import type * as storage from "../storage.js";
 import type * as submissions from "../submissions.js";
@@ -94,6 +95,7 @@ declare const fullApi: ApiFromModules<{
   prospectsMigration: typeof prospectsMigration;
   r2: typeof r2;
   referrals: typeof referrals;
+  scrape: typeof scrape;
   settings: typeof settings;
   storage: typeof storage;
   submissions: typeof submissions;

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -18,6 +18,27 @@ import { action, internalMutation, mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { requireAuth } from "./lib/auth";
 import type { Id } from "./_generated/dataModel";
+import { bucketCategory } from "./lib/quality";
+import { latLngToH3Cells } from "./lib/h3";
+
+/**
+ * Wrapper around `bucketCategory` that returns `null` instead of "other"
+ * for unknown categories. Used by the pool-aware path so we DON'T pool-
+ * query the "other" bucket (which is rarely seeded and would force a
+ * scrape every time on a miss). Known categories still get pool-checked.
+ */
+function mapCategoryToBucket(categoryRaw: string): string | null {
+    const b = bucketCategory(categoryRaw);
+    return b && b !== "other" ? b : null;
+}
+
+// ── Async-batch mode constants (per spec §"Async batch mode") ────────
+// Same values as convex/scrape.ts — duplicated here because the legacy
+// scrapeNearby path used to be sync-mode and is now async-batch too.
+const ASYNC_POLL_INTERVAL_MS = 5000;
+const ASYNC_POLL_MAX_ATTEMPTS = 60; // 5 min total — Convex action timeout is 10 min, leaves 5 min headroom
+const MAX_LIMIT = 400;
+const DEFAULT_LIMIT = 400;
 
 // Outscraper response is loosely typed — keep this flexible.
 interface OutscraperPlace {
@@ -129,7 +150,78 @@ export const scrapeNearby = action({
             );
         }
 
-        const limit = Math.min(args.limit ?? 20, 200);
+        // ── REVISED 2026-06: pool-aware scrape (on-demand only) ──────
+        // Before hitting Outscraper, check whether the prospect pool
+        // already has enough rows for this area + category. If yes,
+        // return them in the businesses shape — zero API cost, instant.
+        //
+        // Pool sufficiency = ≥ 10 available prospects in the user's
+        // res-7 cell + matching categoryBucket. Below that we fall
+        // through to the async-batch scrape path so the pool grows.
+        //
+        // The pool check + ingest only run when `args.location` is a
+        // parseable "lat,lng" coordinate string. Free-text location
+        // (city/neighbourhood) still uses the legacy single-shot
+        // sync-mode scrape path further down — those should be rare
+        // now that mobile always sends GPS coords.
+        const __poolCoordMatch = /^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/.exec(
+            args.location.trim(),
+        );
+        const userCategoryRaw = args.query.trim().toLowerCase();
+        // Map the free-text query to one of the seeded category buckets.
+        // The mapping mirrors lib/quality.ts#bucketCategory exactly so
+        // the ingest path (in prospects.ingestScrapeResults) groups new
+        // rows into the same bucket the pool check just queried.
+        const __categoryBucket = mapCategoryToBucket(userCategoryRaw);
+        if (__poolCoordMatch && __categoryBucket) {
+            const lat = Number(__poolCoordMatch[1]);
+            const lng = Number(__poolCoordMatch[2]);
+            const poolRows = (await ctx.runQuery(
+                internal.prospects.searchNearbyInternal,
+                {
+                    lat,
+                    lng,
+                    radiusKm: Math.max(0.5, args.radiusKm ?? 5),
+                    categoryBucket: __categoryBucket,
+                    limit: 200,
+                },
+            )) as any[];
+            console.log(
+                `[outscraper] pool check: found ${poolRows.length} existing prospects in (${lat},${lng}) bucket="${__categoryBucket}"`,
+            );
+            if (poolRows.length >= 10) {
+                console.log(
+                    `[outscraper] pool sufficient — skipping Outscraper, serving from pool`,
+                );
+                const businessesFromPool = poolRows.map((p) => ({
+                    placeId: p.googlePlaceId,
+                    businessName: p.businessName,
+                    businessAddress: p.address ?? null,
+                    businessCity: p.city ?? null,
+                    businessCategory: p.category ?? p.categoryBucket ?? null,
+                    businessWebsite: p.website ?? null,
+                    businessPhone: p.phone ?? null,
+                    businessLatitude: p.latitude ?? null,
+                    businessLongitude: p.longitude ?? null,
+                    businessRating: p.rating ?? null,
+                    businessReviewCount: p.reviewCount ?? null,
+                }));
+                return {
+                    inserted: 0,
+                    skipped: 0,
+                    total: businessesFromPool.length,
+                    businesses: businessesFromPool,
+                };
+            }
+            // Pool insufficient → fall through to async-batch scrape.
+            // The ingest at the bottom will stock the pool with results.
+        }
+
+        // Revised 2026-06: bumped from 20/200 → DEFAULT_LIMIT/MAX_LIMIT
+        // so async-batch mode returns up to 400 results per call (vs ~50
+        // in the prior sync-mode). 8× pool growth per scrape; same cost
+        // per result (~$0.001), so cost-per-future-creator drops ~5×.
+        const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
         const radiusKm = Math.max(0.5, args.radiusKm ?? 5);
 
         // Query-format history (per WEB-BUILD-CRM.md):
@@ -154,46 +246,116 @@ export const scrapeNearby = action({
         const userCategory = args.query.trim() || "businesses";
         const coordinates = args.location.trim();
 
-        const url = new URL("https://api.outscraper.com/maps/search-v3");
-        url.searchParams.set("query", userCategory);
-        url.searchParams.set("coordinates", coordinates);
-        url.searchParams.set("zoom", String(zoom));
-        url.searchParams.set("limit", String(limit));
-        url.searchParams.set("language", "en");
-        url.searchParams.set("region", "PH");
-        url.searchParams.set("async", "false");
+        // ── REVISED 2026-06: async-batch mode with inline polling ────
+        // The legacy path was a single-shot sync fetch (async=false,
+        // ~50 results, 5-30s). The revised path submits an async job
+        // and polls every 5s inline for up to 5 min. Trade-off:
+        //   - User waits 30-90s on a fresh scrape (was 5-30s)
+        //   - But one async call returns up to 400 results (vs ~50)
+        //   - Pool grows 8× faster per scrape → 5× cheaper per future creator
+        // See spec §"Async batch mode" for the full rationale.
+        const submitUrl = new URL("https://api.outscraper.com/maps/search-v3");
+        submitUrl.searchParams.set("query", userCategory);
+        submitUrl.searchParams.set("coordinates", coordinates);
+        submitUrl.searchParams.set("zoom", String(zoom));
+        submitUrl.searchParams.set("limit", String(limit));
+        submitUrl.searchParams.set("language", "en");
+        submitUrl.searchParams.set("region", "PH");
+        submitUrl.searchParams.set("async", "true");
 
         console.log(
-            `[outscraper] scrapeNearby → query="${userCategory}" coords=${coordinates} zoom=${zoom} (limit=${limit}, radiusKm=${radiusKm})`,
+            `[outscraper] scrapeNearby (async batch) → query="${userCategory}" coords=${coordinates} zoom=${zoom} (limit=${limit}, radiusKm=${radiusKm})`,
         );
 
-        let payload: any;
+        // Submit the async job.
+        let outscraperJobId: string;
         try {
-            const res = await fetch(url.toString(), {
+            const submitRes = await fetch(submitUrl.toString(), {
                 method: "GET",
                 headers: { "X-API-KEY": apiKey, Accept: "application/json" },
             });
-            if (!res.ok) {
-                const body = await res.text();
+            if (!submitRes.ok) {
+                const body = await submitRes.text();
                 throw new Error(
-                    `Outscraper HTTP ${res.status}: ${body.slice(0, 300)}`,
+                    `Outscraper submit HTTP ${submitRes.status}: ${body.slice(0, 300)}`,
                 );
             }
-            payload = await res.json();
+            const submitPayload = (await submitRes.json()) as {
+                id?: string;
+                status?: string;
+            };
+            if (!submitPayload.id) {
+                throw new Error(
+                    `Outscraper submit returned no job id: ${JSON.stringify(submitPayload).slice(0, 200)}`,
+                );
+            }
+            outscraperJobId = submitPayload.id;
+            console.log(
+                `[outscraper] async job submitted → outscraperJobId=${outscraperJobId}`,
+            );
         } catch (err: any) {
-            throw new Error(`Outscraper request failed: ${err?.message ?? err}`);
+            throw new Error(`Outscraper submit failed: ${err?.message ?? err}`);
         }
 
-        // Guard against async fallback — if Outscraper couldn't satisfy the
-        // request synchronously and returned a pending job descriptor, we
-        // surface that rather than silently report "0 businesses found"
-        // (which used to mask the original query-format bug).
-        if (
-            payload?.status === "Pending" ||
-            (payload?.id && !payload?.data)
-        ) {
+        // Poll inline until the job completes or the budget expires.
+        let payload: any = null;
+        for (let attempt = 1; attempt <= ASYNC_POLL_MAX_ATTEMPTS; attempt++) {
+            await new Promise((resolve) =>
+                setTimeout(resolve, ASYNC_POLL_INTERVAL_MS),
+            );
+            let pollPayload: any;
+            try {
+                const pollRes = await fetch(
+                    `https://api.outscraper.com/requests/${outscraperJobId}`,
+                    {
+                        headers: {
+                            "X-API-KEY": apiKey,
+                            Accept: "application/json",
+                        },
+                    },
+                );
+                if (!pollRes.ok) {
+                    // Transient HTTP failure — keep polling.
+                    console.warn(
+                        `[outscraper] poll HTTP ${pollRes.status} (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}) — retrying`,
+                    );
+                    continue;
+                }
+                pollPayload = await pollRes.json();
+            } catch (err: any) {
+                console.warn(
+                    `[outscraper] poll fetch failed (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}): ${err?.message ?? err}`,
+                );
+                continue;
+            }
+            const status = String(pollPayload?.status ?? "").toLowerCase();
+            if (status === "success") {
+                console.log(
+                    `[outscraper] async job complete after ${attempt} poll(s) (~${attempt * 5}s)`,
+                );
+                payload = pollPayload;
+                break;
+            }
+            if (status === "failed" || status === "error") {
+                const errMsg =
+                    pollPayload?.error_message ??
+                    pollPayload?.message ??
+                    status;
+                throw new Error(
+                    `Outscraper async job ${outscraperJobId} ${status}: ${errMsg}`,
+                );
+            }
+            // "pending" / "inprogress" / unknown — keep looping.
+            if (attempt % 6 === 0) {
+                console.log(
+                    `[outscraper] async still pending (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}, status=${pollPayload?.status ?? "unknown"})`,
+                );
+            }
+        }
+
+        if (!payload) {
             throw new Error(
-                "Outscraper fell back to async mode for this query — try a smaller radius or a more specific category.",
+                `Outscraper async job ${outscraperJobId} timed out after ${ASYNC_POLL_MAX_ATTEMPTS * ASYNC_POLL_INTERVAL_MS / 1000}s`,
             );
         }
 
@@ -484,6 +646,56 @@ export const scrapeNearby = action({
             // Non-fatal — never let a Places failure break the scrape.
             console.warn(
                 `[outscraper] Places hyper-local merge failed (non-fatal): ${err?.message ?? err}`,
+            );
+        }
+
+        // ── REVISED 2026-06: pool ingest ─────────────────────────────
+        // Archive every business (Outscraper + Places merged) into the
+        // prospects table. Subsequent requests in this area get served
+        // from the pool for free. Non-fatal — a failed ingest just
+        // means the next creator will pay for a fresh scrape, the
+        // current creator still gets their results back.
+        try {
+            if (__poolCoordMatch && __categoryBucket && businesses.length > 0) {
+                // Record a synthetic scrape_history row so the ingest
+                // mutation can look up locale defaults for quality
+                // scoring + bump the inventory.lastScrapedAt telemetry.
+                const ingestJobId = `legacy-scrapeNearby-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+                const lat = Number(__poolCoordMatch[1]);
+                const lng = Number(__poolCoordMatch[2]);
+                const cells = latLngToH3Cells(lat, lng);
+                await ctx.runMutation(internal.prospects.recordScrapeStart, {
+                    jobId: ingestJobId,
+                    h3CellRes7: cells.res7,
+                    categoryBucket: __categoryBucket,
+                    country: "PH",
+                    outscraperQuery: userCategory,
+                    outscraperCoordinates: coordinates,
+                    outscraperZoom: zoom,
+                    outscraperLimit: limit,
+                });
+                const ingest = (await ctx.runMutation(
+                    internal.prospects.ingestScrapeResults,
+                    {
+                        jobId: ingestJobId,
+                        businesses,
+                        country: "PH",
+                    },
+                )) as { inserted: number; updated: number; skipped: number };
+                await ctx.runMutation(internal.prospects.recordScrapeComplete, {
+                    jobId: ingestJobId,
+                    rawResultCount: businesses.length,
+                    insertedCount: ingest.inserted,
+                    dedupedCount: ingest.updated + ingest.skipped,
+                    hitLimitCap: businesses.length >= MAX_LIMIT,
+                });
+                console.log(
+                    `[outscraper] pool ingest: ${ingest.inserted} new prospects added to global pool (updated=${ingest.updated}, skipped=${ingest.skipped})`,
+                );
+            }
+        } catch (err: any) {
+            console.warn(
+                `[outscraper] pool ingest failed (non-fatal): ${err?.message ?? err}`,
             );
         }
 

--- a/convex/prospects.ts
+++ b/convex/prospects.ts
@@ -1,36 +1,71 @@
 /**
- * Prospect Pool — public read surface + internal helpers (P1).
+ * Prospect Pool — public reads, reservation state machine, scrape ingest.
  *
- * P1 scope (per docs/changes/WEB-PROPECT-POOL.md):
- *   - `searchNearby` (public query)   — H3-indexed nearby search, sorted by quality
- *   - `getByPlaceId` (internal query) — dedup lookup helper
- *   - `adjustInventory` (internal mut) — atomic per-cell counter bookkeeping
- *
- * Reservation mutations (reserve/markContacted/etc.) + the
- * releaseExpiredReservations cron land in P2.
- * Background scrape + replenish cron land in P4.
- *
- * Mobile's discover map dual-reads from `searchNearby` AND the legacy
- * `outscraper.listScrapedLeads` and merges. Both are valid during the
- * migration window. Outscraper-side reads stay until Phase M.4 cleanup.
+ * Per docs/changes/WEB-PROPECT-POOL.md (revised 2026-06):
+ *   - On-demand only: NO crons, NO scheduled jobs.
+ *   - Reservation expiry is enforced via lazy filter in `searchNearby` +
+ *     reclaim-on-reserve in `reserve` — replaces the cron-based release.
+ *   - Scrape flow lives in convex/scrape.ts (async-batch with inline poll).
+ *   - This file holds: 1 public read + 6 reservation mutations + read-side
+ *     helpers + scrape_history recorders + the load-bearing
+ *     `ingestScrapeResults` mutation (4-layer dedup + quality + inventory).
  */
-import { query, internalQuery, internalMutation } from './_generated/server';
+import {
+    query,
+    mutation,
+    internalQuery,
+    internalMutation,
+} from './_generated/server';
 import { v } from 'convex/values';
 import { Doc, Id } from './_generated/dataModel';
+import { internal } from './_generated/api';
 import { requireAuth } from './lib/auth';
-import { latLngToH3Cells, getNeighborCellsRes7 } from './lib/h3';
+import {
+    latLngToH3Cells,
+    getNeighborCellsRes7,
+} from './lib/h3';
+import { normalizePhoneE164 } from './lib/phone';
+import {
+    computeQualityScore,
+    normalizeBusinessName,
+    bucketCategory,
+} from './lib/quality';
+
+const RESERVATION_DURATION_MS = 24 * 60 * 60 * 1000; // 24h — spec default
+
+// Shared shape: a "pool row visible to a caller as available." Used by
+// both `searchNearby` and `searchNearbyInternal`. The lazy-expiry filter
+// promotes state=reserved rows whose `reservationExpiresAt` is in the
+// past back to the caller as if they were "available" — without writing
+// state back. The next `reserve` call reclaims them properly.
+type AvailableProspect = Doc<'prospects'>;
+
+/**
+ * Lazy-expiry predicate: true for rows the caller should see as available.
+ *
+ * Replaces the deprecated `releaseExpiredReservations` cron. State is NOT
+ * mutated here — that's `reserve`'s job. We just surface expired-reserved
+ * rows alongside genuinely-available ones in the result set.
+ */
+function isAvailableLazy(p: Doc<'prospects'>, now: number): boolean {
+    if (p.state === 'available') return true;
+    if (
+        p.state === 'reserved' &&
+        p.reservationExpiresAt != null &&
+        p.reservationExpiresAt < now
+    ) {
+        return true;
+    }
+    return false;
+}
 
 /**
  * PRIMARY READ — called by mobile + web discover map.
  *
- * Computes the caller's H3 res-7 cell + a k-ring of neighbors, queries
- * each cell's `prospects` index, merges, sorts by `qualityScore` desc,
- * and returns up to `limit` rows. No Outscraper call — pure read from
- * the pool. Empty result is a normal outcome (cell not yet replenished).
- *
- * Ring sizing:
- *   radiusKm ≤ 5 → ringSize 1 (~5km coverage, 7 cells queried)
- *   radiusKm > 5 → ringSize 2 (~10km coverage, 19 cells queried)
+ * Computes the caller's H3 res-7 cell + k-ring of neighbors, queries
+ * each cell's `prospects` index, applies the lazy-expiry filter so
+ * stale reservations surface as available, sorts by `qualityScore`,
+ * caps at `limit`. No Outscraper call — pure read.
  */
 export const searchNearby = query({
     args: {
@@ -47,27 +82,39 @@ export const searchNearby = query({
         const ringSize = args.radiusKm && args.radiusKm > 5 ? 2 : 1;
         const { res7 } = latLngToH3Cells(args.lat, args.lng);
         const cells = getNeighborCellsRes7(res7, ringSize);
+        const now = Date.now();
 
-        // Per-cell pull. Convex has no multi-cell IN clause, so we iterate.
-        // Each call is O(log N) via the index. The per-cell cap caps total
-        // work at cells.length * limit — bounded for ringSize ≤ 2.
-        const all: Doc<'prospects'>[] = [];
+        const all: AvailableProspect[] = [];
         for (const cell of cells) {
+            // We pull both `available` AND `reserved` rows (the latter so the
+            // lazy filter can promote expired ones). The per-cell take cap
+            // bounds work: cells.length * limit * 2 worst case.
             const cellResults = args.categoryBucket
                 ? await ctx.db
                     .query('prospects')
                     .withIndex('by_h3_res7_and_category', (q) =>
                         q.eq('h3CellRes7', cell).eq('categoryBucket', args.categoryBucket!),
                     )
-                    .filter((q) => q.eq(q.field('state'), 'available'))
-                    .take(limit)
+                    .filter((q) =>
+                        q.or(
+                            q.eq(q.field('state'), 'available'),
+                            q.eq(q.field('state'), 'reserved'),
+                        ),
+                    )
+                    .take(limit * 2)
                 : await ctx.db
                     .query('prospects')
-                    .withIndex('by_h3_res7_and_state', (q) =>
-                        q.eq('h3CellRes7', cell).eq('state', 'available'),
+                    .withIndex('by_h3_res7', (q) => q.eq('h3CellRes7', cell))
+                    .filter((q) =>
+                        q.or(
+                            q.eq(q.field('state'), 'available'),
+                            q.eq(q.field('state'), 'reserved'),
+                        ),
                     )
-                    .take(limit);
-            all.push(...cellResults);
+                    .take(limit * 2);
+            for (const row of cellResults) {
+                if (isAvailableLazy(row, now)) all.push(row);
+            }
         }
 
         all.sort((a, b) => b.qualityScore - a.qualityScore);
@@ -76,9 +123,93 @@ export const searchNearby = query({
 });
 
 /**
- * Internal lookup — used by the backfill migration and the future scrape
- * ingest path to check dedup layer 2 (place_id) before inserting.
- * Returns null if no row exists.
+ * Action-callable variant of searchNearby. Same logic; no requireAuth
+ * (actions enforce their own auth before invoking). Used by the
+ * pool-aware `outscraper.scrapeNearby` to check whether the pool can
+ * serve the request before hitting Outscraper.
+ */
+export const searchNearbyInternal = internalQuery({
+    args: {
+        lat: v.number(),
+        lng: v.number(),
+        radiusKm: v.optional(v.number()),
+        categoryBucket: v.optional(v.string()),
+        limit: v.optional(v.number()),
+    },
+    handler: async (ctx, args): Promise<AvailableProspect[]> => {
+        const limit = Math.min(args.limit ?? 50, 400);
+        const ringSize = args.radiusKm && args.radiusKm > 5 ? 2 : 1;
+        const { res7 } = latLngToH3Cells(args.lat, args.lng);
+        const cells = getNeighborCellsRes7(res7, ringSize);
+        const now = Date.now();
+
+        const all: AvailableProspect[] = [];
+        for (const cell of cells) {
+            const cellResults = args.categoryBucket
+                ? await ctx.db
+                    .query('prospects')
+                    .withIndex('by_h3_res7_and_category', (q) =>
+                        q.eq('h3CellRes7', cell).eq('categoryBucket', args.categoryBucket!),
+                    )
+                    .filter((q) =>
+                        q.or(
+                            q.eq(q.field('state'), 'available'),
+                            q.eq(q.field('state'), 'reserved'),
+                        ),
+                    )
+                    .take(limit * 2)
+                : await ctx.db
+                    .query('prospects')
+                    .withIndex('by_h3_res7', (q) => q.eq('h3CellRes7', cell))
+                    .filter((q) =>
+                        q.or(
+                            q.eq(q.field('state'), 'available'),
+                            q.eq(q.field('state'), 'reserved'),
+                        ),
+                    )
+                    .take(limit * 2);
+            for (const row of cellResults) {
+                if (isAvailableLazy(row, now)) all.push(row);
+            }
+        }
+        all.sort((a, b) => b.qualityScore - a.qualityScore);
+        return all.slice(0, limit);
+    },
+});
+
+/**
+ * Count available prospects in a single (cell, category, country) bucket.
+ * Used by `outscraper.scrapeNearby` for a coarse pool-sufficiency check
+ * (≥ 10 → skip Outscraper). Cheap — caps at 20 reads.
+ */
+export const countAvailableInCell = internalQuery({
+    args: {
+        h3CellRes7: v.string(),
+        categoryBucket: v.string(),
+    },
+    handler: async (ctx, args): Promise<number> => {
+        const now = Date.now();
+        const rows = await ctx.db
+            .query('prospects')
+            .withIndex('by_h3_res7_and_category', (q) =>
+                q.eq('h3CellRes7', args.h3CellRes7).eq('categoryBucket', args.categoryBucket),
+            )
+            .filter((q) =>
+                q.or(
+                    q.eq(q.field('state'), 'available'),
+                    q.eq(q.field('state'), 'reserved'),
+                ),
+            )
+            .take(50);
+        let count = 0;
+        for (const row of rows) if (isAvailableLazy(row, now)) count += 1;
+        return count;
+    },
+});
+
+/**
+ * Internal lookup — dedup layer 2 (place_id is primary identity).
+ * Used by ingestScrapeResults + the P1 backfill migration.
  */
 export const getByPlaceId = internalQuery({
     args: { googlePlaceId: v.string() },
@@ -92,21 +223,647 @@ export const getByPlaceId = internalQuery({
 });
 
 /**
- * Single source of truth for `prospect_inventory` counter updates.
+ * Fetch the category_locales row for (country, categoryBucket).
+ * Returns null if not seeded — caller decides whether to proceed with
+ * defaults or abort.
+ */
+export const getLocaleConfig = internalQuery({
+    args: {
+        country: v.string(),
+        categoryBucket: v.string(),
+    },
+    handler: async (ctx, args): Promise<Doc<'category_locales'> | null> => {
+        return ctx.db
+            .query('category_locales')
+            .withIndex('by_country_and_bucket', (q) =>
+                q.eq('country', args.country).eq('categoryBucket', args.categoryBucket),
+            )
+            .first();
+    },
+});
+
+// ── Reservation mutations (P2) ────────────────────────────────────────
+
+/**
+ * Reserve a prospect for the calling creator.
  *
- * Called from:
- *   - backfillBatch (P1) — inserts into "available" or "reserved"
- *   - reservation mutations (P2) — transitions through the state machine
- *   - scrape ingest (P4) — fresh inserts into "available"
+ * Allowed source states:
+ *   - "available" → standard path
+ *   - "reserved" with `reservationExpiresAt < now` → reclaim (replaces
+ *     the deprecated `releaseExpiredReservations` cron)
+ *
+ * Rejects every other state with a clear error.
+ *
+ * Inventory: when reclaiming an expired reservation, no inventory delta
+ * is recorded (the original reservation's `reserved` count stays put —
+ * we're swapping owners, not moving buckets). When reserving a fresh
+ * available row, we move 1 from `available` → `reserved`.
+ */
+export const reserve = mutation({
+    args: { prospectId: v.id('prospects') },
+    handler: async (ctx, args) => {
+        const identity = await requireAuth(ctx);
+        const prospect = await ctx.db.get(args.prospectId);
+        if (!prospect) throw new Error('Prospect not found');
+
+        const now = Date.now();
+        const isExpiredReserved =
+            prospect.state === 'reserved' &&
+            prospect.reservationExpiresAt != null &&
+            prospect.reservationExpiresAt < now;
+
+        if (prospect.state !== 'available' && !isExpiredReserved) {
+            throw new Error(
+                `Cannot reserve a prospect in state "${prospect.state}"`,
+            );
+        }
+
+        const creator = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!creator) throw new Error('Creator profile not found');
+
+        await ctx.db.patch(args.prospectId, {
+            state: 'reserved',
+            stateUpdatedAt: now,
+            reservedByCreatorId: creator._id,
+            reservedAt: now,
+            reservationExpiresAt: now + RESERVATION_DURATION_MS,
+        });
+
+        // Only adjust inventory on the fresh-available path. Reclaiming
+        // an expired reservation is a no-op for counters (still 1
+        // reserved, just with a new owner).
+        if (!isExpiredReserved) {
+            await ctx.runMutation(internal.prospects.adjustInventory, {
+                h3CellRes7: prospect.h3CellRes7,
+                categoryBucket: prospect.categoryBucket,
+                country: prospect.country,
+                from: 'available',
+                to: 'reserved',
+            });
+        }
+
+        return { prospectId: args.prospectId, reclaimed: isExpiredReserved };
+    },
+});
+
+/**
+ * Reserved → contacted. Only the reserving creator can advance state.
+ * Clears `reservationExpiresAt` since contacts don't auto-expire (a
+ * future P6 cron handles 7-day idle release; not in this revision).
+ */
+export const markContacted = mutation({
+    args: { prospectId: v.id('prospects') },
+    handler: async (ctx, args) => {
+        const { prospect } = await assertOwnedByCaller(ctx, args.prospectId);
+        if (prospect.state !== 'reserved') {
+            throw new Error(
+                `Cannot mark contacted from state "${prospect.state}"`,
+            );
+        }
+        await ctx.db.patch(args.prospectId, {
+            state: 'contacted',
+            stateUpdatedAt: Date.now(),
+            reservationExpiresAt: undefined,
+        });
+        await ctx.runMutation(internal.prospects.adjustInventory, {
+            h3CellRes7: prospect.h3CellRes7,
+            categoryBucket: prospect.categoryBucket,
+            country: prospect.country,
+            from: 'reserved',
+            to: 'contacted',
+        });
+    },
+});
+
+/**
+ * Contacted → qualified. Only the reserving creator can advance.
+ */
+export const markQualified = mutation({
+    args: { prospectId: v.id('prospects') },
+    handler: async (ctx, args) => {
+        const { prospect } = await assertOwnedByCaller(ctx, args.prospectId);
+        if (prospect.state !== 'contacted') {
+            throw new Error(
+                `Cannot mark qualified from state "${prospect.state}"`,
+            );
+        }
+        await ctx.db.patch(args.prospectId, {
+            state: 'qualified',
+            stateUpdatedAt: Date.now(),
+        });
+        await ctx.runMutation(internal.prospects.adjustInventory, {
+            h3CellRes7: prospect.h3CellRes7,
+            categoryBucket: prospect.categoryBucket,
+            country: prospect.country,
+            from: 'contacted',
+            to: 'qualified',
+        });
+    },
+});
+
+/**
+ * Any non-terminal state → converted. Links the resulting submission
+ * back to the prospect. Only the reserving creator can perform.
+ */
+export const markConverted = mutation({
+    args: {
+        prospectId: v.id('prospects'),
+        submissionId: v.id('submissions'),
+    },
+    handler: async (ctx, args) => {
+        const { prospect } = await assertOwnedByCaller(ctx, args.prospectId);
+        if (prospect.state === 'converted' || prospect.state === 'lost') {
+            throw new Error(
+                `Cannot mark converted from terminal state "${prospect.state}"`,
+            );
+        }
+        await ctx.db.patch(args.prospectId, {
+            state: 'converted',
+            stateUpdatedAt: Date.now(),
+            submissionId: args.submissionId,
+            reservationExpiresAt: undefined,
+        });
+        await ctx.runMutation(internal.prospects.adjustInventory, {
+            h3CellRes7: prospect.h3CellRes7,
+            categoryBucket: prospect.categoryBucket,
+            country: prospect.country,
+            from: prospect.state,
+            to: 'converted',
+        });
+    },
+});
+
+/**
+ * Any non-terminal state → lost. Reason is optional; if you want to
+ * persist it, extend the schema with `lostReason` (not in this PR).
+ */
+export const markLost = mutation({
+    args: {
+        prospectId: v.id('prospects'),
+        reason: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const { prospect } = await assertOwnedByCaller(ctx, args.prospectId);
+        if (prospect.state === 'converted' || prospect.state === 'lost') {
+            throw new Error(
+                `Cannot mark lost from terminal state "${prospect.state}"`,
+            );
+        }
+        await ctx.db.patch(args.prospectId, {
+            state: 'lost',
+            stateUpdatedAt: Date.now(),
+            reservationExpiresAt: undefined,
+        });
+        await ctx.runMutation(internal.prospects.adjustInventory, {
+            h3CellRes7: prospect.h3CellRes7,
+            categoryBucket: prospect.categoryBucket,
+            country: prospect.country,
+            from: prospect.state,
+            to: 'lost',
+        });
+    },
+});
+
+/**
+ * Voluntary release: reserved → available, clears the creator + expiry.
+ * Only the reserving creator can release their own claim.
+ */
+export const releaseReservation = mutation({
+    args: { prospectId: v.id('prospects') },
+    handler: async (ctx, args) => {
+        const { prospect } = await assertOwnedByCaller(ctx, args.prospectId);
+        if (prospect.state !== 'reserved') {
+            throw new Error(
+                `Cannot release a prospect in state "${prospect.state}"`,
+            );
+        }
+        await ctx.db.patch(args.prospectId, {
+            state: 'available',
+            stateUpdatedAt: Date.now(),
+            reservedByCreatorId: undefined,
+            reservedAt: undefined,
+            reservationExpiresAt: undefined,
+        });
+        await ctx.runMutation(internal.prospects.adjustInventory, {
+            h3CellRes7: prospect.h3CellRes7,
+            categoryBucket: prospect.categoryBucket,
+            country: prospect.country,
+            from: 'reserved',
+            to: 'available',
+        });
+    },
+});
+
+/**
+ * Shared guard for state-advance mutations. Loads the prospect, the
+ * caller's creator row, and verifies the caller owns the reservation.
+ * Mutations call this once at the top instead of duplicating the auth
+ * + ownership check inline.
+ */
+async function assertOwnedByCaller(
+    ctx: any,
+    prospectId: Id<'prospects'>,
+): Promise<{ prospect: Doc<'prospects'>; creator: Doc<'creators'> }> {
+    const identity = await requireAuth(ctx);
+    const prospect = await ctx.db.get(prospectId);
+    if (!prospect) throw new Error('Prospect not found');
+    const creator = await ctx.db
+        .query('creators')
+        .withIndex('by_clerk_id', (q: any) => q.eq('clerkId', identity.subject))
+        .first();
+    if (!creator) throw new Error('Creator profile not found');
+    if (
+        prospect.reservedByCreatorId &&
+        prospect.reservedByCreatorId !== creator._id
+    ) {
+        throw new Error(
+            'Only the reserving creator can advance this prospect.',
+        );
+    }
+    return { prospect, creator };
+}
+
+// ── Scrape history recorders (audit trail) ────────────────────────────
+
+/**
+ * Insert a `scrape_history` row at job start with status="pending".
+ */
+export const recordScrapeStart = internalMutation({
+    args: {
+        jobId: v.string(),
+        h3CellRes7: v.string(),
+        h3CellRes8: v.optional(v.string()),
+        categoryBucket: v.string(),
+        country: v.string(),
+        outscraperQuery: v.string(),
+        outscraperCoordinates: v.string(),
+        outscraperZoom: v.number(),
+        outscraperLimit: v.number(),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.insert('scrape_history', {
+            jobId: args.jobId,
+            h3CellRes7: args.h3CellRes7,
+            h3CellRes8: args.h3CellRes8,
+            categoryBucket: args.categoryBucket,
+            country: args.country,
+            outscraperQuery: args.outscraperQuery,
+            outscraperCoordinates: args.outscraperCoordinates,
+            outscraperZoom: args.outscraperZoom,
+            outscraperLimit: args.outscraperLimit,
+            status: 'pending',
+            startedAt: Date.now(),
+        });
+    },
+});
+
+/**
+ * Transition: pending → running, stamp Outscraper's async job ID.
+ */
+export const recordScrapeAsyncId = internalMutation({
+    args: {
+        jobId: v.string(),
+        outscraperJobId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const row = await ctx.db
+            .query('scrape_history')
+            .withIndex('by_job_id', (q) => q.eq('jobId', args.jobId))
+            .first();
+        if (!row) return;
+        await ctx.db.patch(row._id, {
+            status: 'running',
+            outscraperJobId: args.outscraperJobId,
+        });
+    },
+});
+
+/**
+ * Transition: running → completed. Stamps result counts + estimated cost
+ * (raw Outscraper rate: ~$0.001 per business). Also touches the matching
+ * `prospect_inventory.lastScrapedAt` so the next pool-sufficiency check
+ * has fresh telemetry.
+ */
+export const recordScrapeComplete = internalMutation({
+    args: {
+        jobId: v.string(),
+        rawResultCount: v.number(),
+        insertedCount: v.number(),
+        dedupedCount: v.optional(v.number()),
+        hitLimitCap: v.optional(v.boolean()),
+    },
+    handler: async (ctx, args) => {
+        const row = await ctx.db
+            .query('scrape_history')
+            .withIndex('by_job_id', (q) => q.eq('jobId', args.jobId))
+            .first();
+        if (!row) return;
+
+        const estimatedCost = Math.round(args.rawResultCount * 0.001 * 100) / 100;
+        await ctx.db.patch(row._id, {
+            status: 'completed',
+            rawResultCount: args.rawResultCount,
+            insertedCount: args.insertedCount,
+            dedupedCount: args.dedupedCount,
+            hitLimitCap: args.hitLimitCap,
+            estimatedCost,
+            completedAt: Date.now(),
+        });
+
+        // Bump inventory.lastScrapedAt so cell stays "fresh" for the
+        // pool-sufficiency heuristic.
+        const inv = await ctx.db
+            .query('prospect_inventory')
+            .withIndex('by_h3_and_category', (q) =>
+                q.eq('h3CellRes7', row.h3CellRes7).eq('categoryBucket', row.categoryBucket),
+            )
+            .first();
+        if (inv) {
+            await ctx.db.patch(inv._id, {
+                lastScrapedAt: Date.now(),
+                scrapesAttempted: inv.scrapesAttempted + 1,
+                lastScrapeJobId: args.jobId,
+                updatedAt: Date.now(),
+            });
+        }
+    },
+});
+
+/**
+ * Transition: any → failed. Logs the reason for debugging.
+ */
+export const recordScrapeFailed = internalMutation({
+    args: {
+        jobId: v.string(),
+        errorMessage: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const row = await ctx.db
+            .query('scrape_history')
+            .withIndex('by_job_id', (q) => q.eq('jobId', args.jobId))
+            .first();
+        if (!row) return;
+        await ctx.db.patch(row._id, {
+            status: 'failed',
+            errorMessage: args.errorMessage,
+            completedAt: Date.now(),
+        });
+    },
+});
+
+// ── ingestScrapeResults — THE BIG ONE ─────────────────────────────────
+
+/**
+ * Ingest a batch of scraped businesses into the prospects pool.
+ *
+ * Dedup layers (in order):
+ *   1. H3 cell coverage — implicit (the action only fires for cells that
+ *      were under-stocked; we don't re-check here).
+ *   2. Google place_id — the primary identity key. Existing row with
+ *      same googlePlaceId is updated (lastRefreshedAt + quality) rather
+ *      than duplicated.
+ *   3. Normalized E.164 phone — when place_id is missing on the incoming
+ *      record but phone matches an existing prospect, treat as same.
+ *   4. Normalized business name within ~150m — last-resort fuzzy match.
+ *
+ * Quality scoring (lib/quality.ts) uses the category locale's weights
+ * if seeded, else default weights.
+ *
+ * Inventory: for each NEW prospect, calls adjustInventory(from=available,
+ * to=available) — a same-state pair that nets to +0 on the `from` side
+ * and +1 on the `to` side, which is the right shape for fresh inserts.
+ *
+ * Returns the count of newly-inserted rows (not counting updates).
+ */
+export const ingestScrapeResults = internalMutation({
+    args: {
+        jobId: v.string(),
+        businesses: v.array(v.any()),
+        country: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const job = await ctx.db
+            .query('scrape_history')
+            .withIndex('by_job_id', (q) => q.eq('jobId', args.jobId))
+            .first();
+        const country = args.country ?? job?.country ?? 'PH';
+        const fallbackCategoryBucket = job?.categoryBucket ?? 'other';
+
+        // Cache scoring weights per (country, categoryBucket) — avoid
+        // re-querying for every business.
+        const localeCache = new Map<string, Doc<'category_locales'> | null>();
+        const getLocale = async (
+            categoryBucket: string,
+        ): Promise<Doc<'category_locales'> | null> => {
+            const key = `${country}:${categoryBucket}`;
+            if (localeCache.has(key)) return localeCache.get(key)!;
+            const row = await ctx.db
+                .query('category_locales')
+                .withIndex('by_country_and_bucket', (q) =>
+                    q.eq('country', country).eq('categoryBucket', categoryBucket),
+                )
+                .first();
+            localeCache.set(key, row);
+            return row;
+        };
+
+        let inserted = 0;
+        let updated = 0;
+        let skipped = 0;
+        // Per-batch in-memory dedup so two source rows with the same
+        // place_id in the same payload don't both insert.
+        const seenPlaceIds = new Set<string>();
+
+        for (const raw of args.businesses) {
+            const placeId: string | undefined =
+                raw.placeId ??
+                raw.place_id ??
+                raw.google_id ??
+                raw.businessGooglePlaceId ??
+                undefined;
+            const businessName: string | undefined =
+                raw.businessName ?? raw.name ?? undefined;
+            const lat: number | undefined =
+                typeof raw.businessLatitude === 'number'
+                    ? raw.businessLatitude
+                    : typeof raw.latitude === 'number'
+                        ? raw.latitude
+                        : undefined;
+            const lng: number | undefined =
+                typeof raw.businessLongitude === 'number'
+                    ? raw.businessLongitude
+                    : typeof raw.longitude === 'number'
+                        ? raw.longitude
+                        : undefined;
+            if (!businessName || lat == null || lng == null) {
+                skipped += 1;
+                continue;
+            }
+
+            // Layer 2 — place_id dedup (in-batch + against existing rows)
+            let existing: Doc<'prospects'> | null = null;
+            if (placeId) {
+                if (seenPlaceIds.has(placeId)) {
+                    skipped += 1;
+                    continue;
+                }
+                seenPlaceIds.add(placeId);
+                existing = await ctx.db
+                    .query('prospects')
+                    .withIndex('by_place_id', (q) => q.eq('googlePlaceId', placeId))
+                    .first();
+            }
+
+            const phoneRaw: string | undefined =
+                raw.businessPhone ?? raw.phone ?? undefined;
+            const normalizedPhone = normalizePhoneE164(phoneRaw ?? null, 'PH');
+
+            // Layer 3 — phone dedup when place_id missed
+            if (!existing && normalizedPhone) {
+                existing = await ctx.db
+                    .query('prospects')
+                    .withIndex('by_normalized_phone', (q) =>
+                        q.eq('normalizedPhone', normalizedPhone),
+                    )
+                    .first();
+            }
+
+            const normalizedName = normalizeBusinessName(businessName);
+
+            // Layer 4 — name + proximity dedup (last resort).
+            // Bounded scan: we only check prospects in the same res-9
+            // cell (~400m) with the same normalizedName. Convex doesn't
+            // index normalizedName directly, so we filter post-pull.
+            if (!existing) {
+                const cells = latLngToH3Cells(lat, lng);
+                const sameCellRows = await ctx.db
+                    .query('prospects')
+                    .withIndex('by_h3_res7', (q) => q.eq('h3CellRes7', cells.res7))
+                    .filter((q) => q.eq(q.field('h3CellRes9'), cells.res9))
+                    .take(20);
+                for (const row of sameCellRows) {
+                    if (row.normalizedName === normalizedName) {
+                        existing = row;
+                        break;
+                    }
+                }
+            }
+
+            const rawCategory: string =
+                raw.businessCategory ??
+                raw.category ??
+                raw.type ??
+                raw.subtypes ??
+                '';
+            const categoryBucket =
+                bucketCategory(rawCategory) || fallbackCategoryBucket;
+            const locale = await getLocale(categoryBucket);
+
+            const website: string | undefined =
+                raw.businessWebsite ?? raw.site ?? raw.website ?? undefined;
+            const rating: number | null =
+                typeof raw.businessRating === 'number'
+                    ? raw.businessRating
+                    : typeof raw.rating === 'number'
+                        ? raw.rating
+                        : null;
+            const reviewCount: number | null =
+                typeof raw.businessReviewCount === 'number'
+                    ? raw.businessReviewCount
+                    : typeof raw.reviews === 'number'
+                        ? raw.reviews
+                        : typeof raw.user_ratings_total === 'number'
+                            ? raw.user_ratings_total
+                            : null;
+
+            const qualityScore = computeQualityScore(
+                {
+                    hasWebsite: !!website,
+                    hasPhone: !!phoneRaw,
+                    rating,
+                    reviewCount,
+                },
+                locale?.scoringWeights,
+            );
+
+            const now = Date.now();
+
+            if (existing) {
+                // Refresh — bump lastRefreshedAt + recompute quality, keep
+                // identity + state untouched.
+                await ctx.db.patch(existing._id, {
+                    lastRefreshedAt: now,
+                    qualityScore,
+                    rating: rating ?? existing.rating,
+                    reviewCount: reviewCount ?? existing.reviewCount,
+                    website: website ?? existing.website,
+                    phone: phoneRaw ?? existing.phone,
+                    normalizedPhone: normalizedPhone ?? existing.normalizedPhone,
+                });
+                updated += 1;
+                continue;
+            }
+
+            // Fresh insert
+            const cells = latLngToH3Cells(lat, lng);
+            await ctx.db.insert('prospects', {
+                googlePlaceId:
+                    placeId ?? `synthetic:${normalizedName}:${lat},${lng}`,
+                businessName,
+                normalizedName,
+                category: rawCategory,
+                categoryBucket,
+                address:
+                    raw.businessAddress ?? raw.full_address ?? raw.address ?? undefined,
+                phone: phoneRaw ?? undefined,
+                normalizedPhone: normalizedPhone ?? undefined,
+                website: website ?? undefined,
+                latitude: lat,
+                longitude: lng,
+                city: raw.businessCity ?? raw.city ?? undefined,
+                country,
+                h3CellRes7: cells.res7,
+                h3CellRes8: cells.res8,
+                h3CellRes9: cells.res9,
+                rating: rating ?? undefined,
+                reviewCount: reviewCount ?? undefined,
+                state: 'available',
+                stateUpdatedAt: now,
+                qualityScore,
+                scrapedAt: now,
+                lastRefreshedAt: now,
+                scrapeJobId: args.jobId,
+            });
+            // Inventory bookkeeping — fresh available row.
+            await ctx.runMutation(internal.prospects.adjustInventory, {
+                h3CellRes7: cells.res7,
+                categoryBucket,
+                country,
+                from: 'available',
+                to: 'available',
+            });
+            inserted += 1;
+        }
+
+        console.log(
+            `[ingestScrapeResults] jobId=${args.jobId} inserted=${inserted} updated=${updated} skipped=${skipped}`,
+        );
+        return { inserted, updated, skipped };
+    },
+});
+
+// ── Inventory bookkeeping (unchanged from P1) ─────────────────────────
+
+/**
+ * Single source of truth for `prospect_inventory` counter updates.
  *
  * On first insert for a (cell, category): creates the inventory row,
  * seeded with the locale's `minAvailableThreshold` (falls back to 100).
- * On subsequent calls: atomically -1 from `<from>Count`, +1 to `<to>Count`.
- *
- * Idempotency note: callers should NOT call this twice for the same state
- * transition. The mutation isn't keyed on idempotency tokens; double-call
- * = double-count. The migration's `backfillBatch` guards against this by
- * skipping rows whose `migratedToProspectId` is already set.
+ * On subsequent calls: atomically -1 from `<from>Count` (clamped at 0),
+ * +1 to `<to>Count`. Same-state pairs (from === to) net to a fresh +1.
  */
 export const adjustInventory = internalMutation({
     args: {
@@ -141,10 +898,6 @@ export const adjustInventory = internalMutation({
         const now = Date.now();
 
         if (!existing) {
-            // Fresh inventory row — seed counts with 1 in the target state.
-            // For new inserts (from === to or from === "available" path of
-            // a brand-new row), this is the right shape. Inventory row
-            // never exists before the first prospect lands.
             const locale = await ctx.db
                 .query('category_locales')
                 .withIndex('by_country_and_bucket', (q) =>
@@ -168,14 +921,8 @@ export const adjustInventory = internalMutation({
             return;
         }
 
-        // Decrement the `from` bucket (clamped at 0 — don't go negative)
-        // and increment the `to` bucket. Same-state transitions are a no-op
-        // pair that nets to zero — safe.
         const fromKey = `${args.from}Count` as const;
         const toKey = `${args.to}Count` as const;
-
-        // TS can't narrow Doc<...>[key] for dynamic keys here; the cast is
-        // safe because every `<state>Count` field is a v.number().
         const fromCount = (existing as any)[fromKey] as number;
         const toCount = (existing as any)[toKey] as number;
 

--- a/convex/scrape.ts
+++ b/convex/scrape.ts
@@ -1,0 +1,335 @@
+/**
+ * On-demand scrape orchestration (per docs/changes/WEB-PROPECT-POOL.md
+ * revised 2026-06 — on-demand only, NO crons).
+ *
+ * Single entry point: `scrapeOnDemandSync` is called by
+ * `outscraper.scrapeNearby` when its pool-sufficiency check finds the
+ * area under-stocked. The action submits a 400-result Outscraper async
+ * job and polls inline every 5 seconds for up to 5 minutes. When the
+ * job completes, results flow into `prospects.ingestScrapeResults`.
+ *
+ * `subdivideAndScrape` handles the P5 adaptive-subdivision case: when a
+ * res-7 scrape hits the 400-result cap (densely populated cell), it
+ * spawns 7 child res-8 scrapes to cover the same area at finer
+ * granularity. Still on-demand — only fires when the parent action
+ * triggers it.
+ *
+ * `getJob` is a tiny audit helper.
+ *
+ * What this file deliberately does NOT contain (per the revision):
+ *   - ❌ `replenishLowInventoryCells` — was the cron handler. Gone.
+ *   - ❌ `countScrapesLast24h` — was the cron's budget guard. Gone.
+ *   - ❌ `pollAndIngest` as a separate scheduled action — polling is
+ *      INLINE inside `scrapeOnDemandSync`.
+ *   - ❌ `scrapeAndStore` (cron-mode) — replaced by `scrapeOnDemandSync`.
+ */
+import {
+    internalAction,
+    internalQuery,
+} from './_generated/server';
+import { v } from 'convex/values';
+import { Doc } from './_generated/dataModel';
+import { internal } from './_generated/api';
+import {
+    cellCentroid,
+    cellChildrenRes8,
+} from './lib/h3';
+
+// ── Constants (per spec §"Async batch mode" lines 207-217) ────────────
+const ASYNC_POLL_INTERVAL_MS = 5000;
+const ASYNC_POLL_MAX_ATTEMPTS = 60; // 5 minutes total
+const ASYNC_SCRAPE_LIMIT = 400;
+const ASYNC_SCRAPE_ZOOM = 14;
+const OUTSCRAPER_SEARCH_URL = 'https://api.outscraper.com/maps/search';
+const OUTSCRAPER_REQUESTS_URL = 'https://api.outscraper.com/requests';
+
+/**
+ * On-demand scrape with inline polling.
+ *
+ * Called from `outscraper.scrapeNearby` when the pool check finds the
+ * area's pool insufficient. Submits one Outscraper async job (up to
+ * 400 results), polls inline, ingests results into the pool, and
+ * triggers adaptive subdivision if the cap is hit.
+ *
+ * The action's wall-clock budget is ~30-90s typical, capped at 5min by
+ * the poll loop. Convex's 10-min action timeout leaves comfortable
+ * headroom for ingest + subdivision scheduling.
+ *
+ * NOTE: name is "scrapeOnDemandSync" for historical continuity with
+ * mobile's port. Despite "Sync" in the name, this uses Outscraper's
+ * ASYNC batch mode internally (with inline polling) — see the revised
+ * spec §"Async batch mode" for the rationale.
+ *
+ * Returns the count of newly-inserted prospects (per
+ * `ingestScrapeResults`'s return shape).
+ */
+export const scrapeOnDemandSync = internalAction({
+    args: {
+        h3CellRes7: v.string(),
+        h3CellRes8: v.optional(v.string()),
+        categoryBucket: v.string(),
+        country: v.string(),
+    },
+    handler: async (ctx, args): Promise<{
+        inserted: number;
+        updated: number;
+        skipped: number;
+        rawResultCount: number;
+        hitLimitCap: boolean;
+    }> => {
+        const apiKey = process.env.OUTSCRAPER_API_KEY;
+        if (!apiKey) {
+            throw new Error('OUTSCRAPER_API_KEY is not set');
+        }
+
+        // Resolve locale → outscraper query terms + scoring weights.
+        const locale = await ctx.runQuery(internal.prospects.getLocaleConfig, {
+            country: args.country,
+            categoryBucket: args.categoryBucket,
+        });
+        if (!locale || !locale.enabled) {
+            console.warn(
+                `[scrape] no enabled locale for (${args.country}, ${args.categoryBucket}) — skipping`,
+            );
+            return { inserted: 0, updated: 0, skipped: 0, rawResultCount: 0, hitLimitCap: false };
+        }
+
+        // Cell centroid drives the search location. Subdivision passes
+        // the res-8 cell; default uses res-7.
+        const targetCell = args.h3CellRes8 ?? args.h3CellRes7;
+        const [lat, lng] = cellCentroid(targetCell);
+        const jobId = `ondemand-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+        await ctx.runMutation(internal.prospects.recordScrapeStart, {
+            jobId,
+            h3CellRes7: args.h3CellRes7,
+            h3CellRes8: args.h3CellRes8,
+            categoryBucket: args.categoryBucket,
+            country: args.country,
+            outscraperQuery: locale.outscraperQueries.join(', '),
+            outscraperCoordinates: `${lat},${lng}`,
+            outscraperZoom: ASYNC_SCRAPE_ZOOM,
+            outscraperLimit: ASYNC_SCRAPE_LIMIT,
+        });
+
+        // Submit async job.
+        const submitParams = new URLSearchParams({
+            query: locale.outscraperQueries.join(','),
+            coordinates: `${lat},${lng}`,
+            zoom: String(ASYNC_SCRAPE_ZOOM),
+            limit: String(ASYNC_SCRAPE_LIMIT),
+            async: 'true',
+            language: 'en',
+            region: args.country,
+        });
+
+        let outscraperJobId: string;
+        try {
+            const submitRes = await fetch(
+                `${OUTSCRAPER_SEARCH_URL}?${submitParams}`,
+                {
+                    method: 'GET',
+                    headers: { 'X-API-KEY': apiKey, Accept: 'application/json' },
+                },
+            );
+            if (!submitRes.ok) {
+                const body = await submitRes.text();
+                throw new Error(
+                    `Outscraper submit HTTP ${submitRes.status}: ${body.slice(0, 200)}`,
+                );
+            }
+            const submitPayload = (await submitRes.json()) as {
+                id?: string;
+                status?: string;
+            };
+            if (!submitPayload.id) {
+                throw new Error(
+                    `Outscraper submit returned no job id: ${JSON.stringify(submitPayload).slice(0, 200)}`,
+                );
+            }
+            outscraperJobId = submitPayload.id;
+        } catch (err: any) {
+            await ctx.runMutation(internal.prospects.recordScrapeFailed, {
+                jobId,
+                errorMessage: `submit failed: ${err?.message ?? err}`,
+            });
+            throw err;
+        }
+
+        await ctx.runMutation(internal.prospects.recordScrapeAsyncId, {
+            jobId,
+            outscraperJobId,
+        });
+        console.log(
+            `[scrape] async job submitted → outscraperJobId=${outscraperJobId} (jobId=${jobId})`,
+        );
+
+        // Inline poll loop. Per spec §"Async batch mode" lines 222-232.
+        let businesses: any[] = [];
+        let pollSuccess = false;
+        for (let attempt = 1; attempt <= ASYNC_POLL_MAX_ATTEMPTS; attempt++) {
+            await new Promise((resolve) =>
+                setTimeout(resolve, ASYNC_POLL_INTERVAL_MS),
+            );
+            let pollPayload: any;
+            try {
+                const pollRes = await fetch(
+                    `${OUTSCRAPER_REQUESTS_URL}/${outscraperJobId}`,
+                    {
+                        headers: {
+                            'X-API-KEY': apiKey,
+                            Accept: 'application/json',
+                        },
+                    },
+                );
+                if (!pollRes.ok) {
+                    // HTTP failure is transient — keep polling.
+                    console.warn(
+                        `[scrape] poll HTTP ${pollRes.status} (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}) — retrying`,
+                    );
+                    continue;
+                }
+                pollPayload = await pollRes.json();
+            } catch (err: any) {
+                console.warn(
+                    `[scrape] poll fetch failed (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}): ${err?.message ?? err}`,
+                );
+                continue;
+            }
+
+            const status = String(pollPayload?.status ?? '').toLowerCase();
+            if (status === 'success') {
+                // Outscraper async result wraps results in a nested array.
+                const data = pollPayload?.data;
+                businesses = Array.isArray(data?.[0])
+                    ? data[0]
+                    : Array.isArray(data)
+                        ? data
+                        : [];
+                console.log(
+                    `[scrape] async job complete after ${attempt} poll(s) (~${attempt * 5}s) — ${businesses.length} results`,
+                );
+                pollSuccess = true;
+                break;
+            }
+            if (status === 'failed' || status === 'error') {
+                const errMsg = pollPayload?.error_message ?? pollPayload?.message ?? status;
+                await ctx.runMutation(internal.prospects.recordScrapeFailed, {
+                    jobId,
+                    errorMessage: `Outscraper reported ${status}: ${errMsg}`,
+                });
+                throw new Error(`Outscraper async job ${outscraperJobId} ${status}: ${errMsg}`);
+            }
+            // status was "pending"/"inprogress"/empty — keep polling
+            if (attempt % 6 === 0) {
+                console.log(
+                    `[scrape] async still pending (attempt ${attempt}/${ASYNC_POLL_MAX_ATTEMPTS}, status=${pollPayload?.status ?? 'unknown'})`,
+                );
+            }
+        }
+
+        if (!pollSuccess) {
+            await ctx.runMutation(internal.prospects.recordScrapeFailed, {
+                jobId,
+                errorMessage: `Outscraper async job timed out after ${ASYNC_POLL_MAX_ATTEMPTS * ASYNC_POLL_INTERVAL_MS / 1000}s`,
+            });
+            throw new Error(
+                `Outscraper async job ${outscraperJobId} timed out`,
+            );
+        }
+
+        // Ingest into pool.
+        const ingest = (await ctx.runMutation(
+            internal.prospects.ingestScrapeResults,
+            { jobId, businesses, country: args.country },
+        )) as { inserted: number; updated: number; skipped: number };
+
+        const hitLimitCap = businesses.length >= ASYNC_SCRAPE_LIMIT;
+        await ctx.runMutation(internal.prospects.recordScrapeComplete, {
+            jobId,
+            rawResultCount: businesses.length,
+            insertedCount: ingest.inserted,
+            dedupedCount: ingest.updated + ingest.skipped,
+            hitLimitCap,
+        });
+
+        // Adaptive subdivision: if we hit the 400-cap on a res-7 scrape,
+        // schedule child res-8 scrapes so dense urban cores stay covered.
+        // Don't subdivide further if we're already at res-8 (avoids
+        // infinite recursion on Makati CBD etc).
+        if (hitLimitCap && !args.h3CellRes8) {
+            console.log(
+                `[scrape] hit cap of ${ASYNC_SCRAPE_LIMIT}, scheduling on-demand subdivision for jobId=${jobId}`,
+            );
+            await ctx.scheduler.runAfter(0, internal.scrape.subdivideAndScrape, {
+                parentJobId: jobId,
+                parentCellRes7: args.h3CellRes7,
+                categoryBucket: args.categoryBucket,
+                country: args.country,
+            });
+        }
+
+        return {
+            inserted: ingest.inserted,
+            updated: ingest.updated,
+            skipped: ingest.skipped,
+            rawResultCount: businesses.length,
+            hitLimitCap,
+        };
+    },
+});
+
+/**
+ * Adaptive subdivision (P5): when a res-7 scrape hits the 400-result
+ * cap, the cell is denser than one scrape can cover. Spawn 7 child
+ * res-8 scrapes to fill in the gaps. Each child runs as its own
+ * `scrapeOnDemandSync` invocation via the scheduler — they fire
+ * sequentially (one after the other) to avoid hammering Outscraper.
+ *
+ * Cost: worst case 8 × $0.40 = $3.20 for one super-dense area, in
+ * exchange for ~3,200 prospects added to the pool. Amortizes well over
+ * future creator requests in the area.
+ */
+export const subdivideAndScrape = internalAction({
+    args: {
+        parentJobId: v.string(),
+        parentCellRes7: v.string(),
+        categoryBucket: v.string(),
+        country: v.string(),
+    },
+    handler: async (ctx, args): Promise<void> => {
+        const children = cellChildrenRes8(args.parentCellRes7);
+        console.log(
+            `[scrape] subdividing parentJobId=${args.parentJobId} into ${children.length} res-8 children`,
+        );
+        // Stagger the children — schedule each 10s after the previous so
+        // we don't fire 7 parallel Outscraper async jobs. Each child runs
+        // its own poll loop independently.
+        for (let i = 0; i < children.length; i++) {
+            await ctx.scheduler.runAfter(
+                i * 10_000,
+                internal.scrape.scrapeOnDemandSync,
+                {
+                    h3CellRes7: args.parentCellRes7,
+                    h3CellRes8: children[i],
+                    categoryBucket: args.categoryBucket,
+                    country: args.country,
+                },
+            );
+        }
+    },
+});
+
+/**
+ * Tiny audit helper — fetches a scrape_history row by jobId. Used by
+ * dashboard ad-hoc queries / debugging.
+ */
+export const getJob = internalQuery({
+    args: { jobId: v.string() },
+    handler: async (ctx, args): Promise<Doc<'scrape_history'> | null> => {
+        return ctx.db
+            .query('scrape_history')
+            .withIndex('by_job_id', (q) => q.eq('jobId', args.jobId))
+            .first();
+    },
+});

--- a/docs/changes/WEB-PROPECT-POOL.md
+++ b/docs/changes/WEB-PROPECT-POOL.md
@@ -157,6 +157,398 @@
 > - ❌ Fetching business phone/website via Places Details API (extra cost ~$0.017/call × 20 results = $0.34/scrape — only do if creators report missing phone/website on hyper-local businesses)
 > - ❌ Pagination beyond the first 20 Places results (Places caps at 60 total, but each extra page costs and adds latency)
 > - ❌ Separate `source: 'outscraper' | 'places'` field on returned businesses (proposed for P-B.5 if web UI wants to badge them differently)
+>
+> ---
+>
+> ## ⚡ REVISED 2026-06 — On-demand only, NO crons
+>
+> **Project owner revised the architecture.** Per the updated spec, the platform must operate on a purely on-demand model — NO scheduled jobs, NO background replenishment, NO time-based refresh. Mobile has reworked the spec to match. **Web agent: deploy this revision instead of the original P4 cron-driven design.**
+>
+> ### What changed vs the pre-revision spec
+>
+> | Component | Pre-revision (cron-driven) | Revised (on-demand) |
+> |---|---|---|
+> | Scrape trigger | `replenishLowInventoryCells` cron every 30 min | Triggered only by creator's tap on Find Local Business, only if pool is insufficient |
+> | Reservation expiry | `releaseExpiredReservations` cron every 60 min | Lazy filter in `searchNearby` + reclaim-on-reserve in `reserve` mutation |
+> | Outscraper mode | Async (queue + poll, cron-driven) | Async BATCH MODE with inline polling — user waits 30-90s for a 400-result scrape (8× more results per call than sync) |
+> | Cost model | Predictable daily budget | Zero scrapes when pool serves the request, scrape only when needed |
+> | `crons.ts` entries added | 2 | **0** |
+>
+> ### Explicit restrictions (per the revised spec, do NOT implement)
+>
+> - ❌ Cron jobs
+> - ❌ Scheduled jobs
+> - ❌ Nightly / hourly scraping
+> - ❌ Automatic inventory replenishment
+> - ❌ Time-based refresh logic
+> - ❌ Background scraping without a creator request
+>
+> ### 🔥 Async batch mode (2026-06, later revision)
+>
+> Earlier revision used Outscraper's **sync mode** (`async=false`, ~50 results per call, 5-30s response). After review, the project owner requested **async batch mode** (per spec item #4: "Use async batch requests") to minimize total Outscraper API calls.
+>
+> **The change in one paragraph:** scrapeNearby and scrapeOnDemandSync now submit jobs to Outscraper's async endpoint (`async=true`), then poll the `/requests/{jobId}` endpoint every 5 seconds inside the same action for up to 5 minutes. When the job completes (typically 30-90s), results are parsed and ingested as before. The action stays within Convex's 10-minute budget. The user IS waiting — they see a 30-90s loading state instead of 5-30s — but the trade-off is worth it because **one async call returns up to 400 results (vs ~50 in sync mode)**, so the pool grows 8× faster per scrape.
+>
+> **Why this is cheaper at steady state:**
+>
+> Per-result cost from Outscraper is identical between sync and async (~$0.001 per business). But the unit economics are different:
+>
+> | Mode | Results / call | Cost / call | Pool growth | Future creators served by one scrape |
+> |---|---|---|---|---|
+> | Sync (prior) | ~50 | ~$0.05 | +50 prospects | ~5-10 |
+> | Async batch (current) | ~400 | ~$0.40 | +400 prospects | ~50-100 |
+>
+> The cost-per-future-creator drops by ~5×. One async-batch scrape stocks the area's pool for 10× longer than a sync scrape would.
+>
+> **What the code change looks like (porting checklist):**
+>
+> When porting `ndm/convex/scrape.ts` (Step 3 below) and `ndm/convex/outscraper.ts` (Step 4 below), port these exact additions:
+>
+> 1. **Constants** — both files declare:
+>    ```typescript
+>    const ASYNC_POLL_INTERVAL_MS = 5000;
+>    const ASYNC_POLL_MAX_ATTEMPTS = 60;  // 5 minutes total
+>    // scrape.ts also has:
+>    const ASYNC_SCRAPE_LIMIT = 400;       // was SYNC_SCRAPE_LIMIT = 50
+>    const ASYNC_SCRAPE_ZOOM = 14;
+>    // outscraper.ts has:
+>    const MAX_LIMIT = 400;                 // was 50
+>    const DEFAULT_LIMIT = 400;             // was 20
+>    ```
+>
+> 2. **Submit params** — `async: "true"` (was `"false"`)
+>
+> 3. **Poll loop** — added INLINE inside the action, runs after the submit POST:
+>    ```typescript
+>    for (let attempt = 1; attempt <= ASYNC_POLL_MAX_ATTEMPTS; attempt++) {
+>      await new Promise((resolve) => setTimeout(resolve, ASYNC_POLL_INTERVAL_MS));
+>      const pollRes = await fetch(`https://api.outscraper.com/requests/${outscraperJobId}`, ...);
+>      const pollPayload = await pollRes.json();
+>      const status = (pollPayload.status ?? "").toLowerCase();
+>      if (status === "success") { /* parse data, break */ }
+>      if (status === "failed" || status === "error") { /* throw */ }
+>      // else still pending — keep looping
+>    }
+>    ```
+>
+> 4. **Error handling** — distinguish HTTP failure (transient, keep retrying) from Outscraper-reported failure (terminal, abort with recordScrapeFailed)
+>
+> 5. **Convex action timeout headroom** — keep the poll budget at 5 minutes (60 × 5s). Convex actions have a 10-minute hard timeout. Leave 5 minutes of headroom for the ingestScrapeResults mutation + adaptive subdivision scheduling.
+>
+> **UX implication for mobile:**
+>
+> The 3-stage scrape loader on `discover.tsx` now shows for 30-90s instead of 5-30s. Mobile DID NOT change loader copy in this revision — the existing copy ("Finding businesses nearby…" etc.) is still accurate. If creators complain about the longer wait, consider adding a "Stocking the local database…" stage. For now, mobile considers it acceptable because:
+> - Creators tap once and walk to a business — the wait happens while they're moving
+> - Subsequent taps in the same area serve from the pool **instantly** (no Outscraper call)
+> - The pool grows enough on first scrape that the wait usually only happens once per area
+>
+> ### What you'll do (high level)
+>
+> 1. Port `ndm/convex/prospects.ts` — 6 reservation mutations + 6 internal helpers (no cron handler, no findLowInventoryCells)
+> 2. Port `ndm/convex/scrape.ts` — **async-batch-mode** `scrapeOnDemandSync` action with inline polling + adaptive subdivision (no cron, polling is INLINE inside the action)
+> 3. Port `ndm/convex/outscraper.ts` — `scrapeNearby` is now POOL-AWARE: pool check first, async batch scrape if insufficient (400-result limit), inserts results to prospects table
+> 4. `convex/crons.ts` — add NO new crons. The 2 entries from the pre-revision spec must NOT be added.
+> 5. `npx convex deploy --prod`
+> 6. Verify end-to-end
+>
+> ### Step-by-step
+>
+> **Step 1 — Port reservation mutations to web's `convex/prospects.ts`**
+>
+> Mobile added these exports to `ndm/convex/prospects.ts`. Copy verbatim:
+>
+> - `reserve(prospectId)` — available → reserved; **also accepts lazy-expired reservations** (state=reserved, expiry passed) and reclaims them. This replaces the cron-based release.
+> - `markContacted(prospectId)` — reserved → contacted
+> - `markQualified(prospectId)` — contacted → qualified
+> - `markConverted(prospectId, submissionId)` — any → converted, links submission
+> - `markLost(prospectId, reason?)` — any non-terminal → lost
+> - `releaseReservation(prospectId)` — reserved → available (voluntary)
+>
+> **Step 2 — Port the read-side helpers to `convex/prospects.ts`**
+>
+> - `searchNearby` (public query) — same as P1 but now **lazy-filters expired reservations** in the result set so they appear as available without writing state back
+> - `searchNearbyInternal` (internal query) — same logic, callable from actions. Used by `outscraper.scrapeNearby` for the pool check.
+> - `countAvailableInCell` (internal query) — counts available prospects in a single (cell, category) pair
+> - `getLocaleConfig` (internal query) — fetches category_locales row
+> - `recordScrapeStart`, `recordScrapeAsyncId`, `recordScrapeComplete`, `recordScrapeFailed` — scrape_history tracking (kept for audit even though scrape is now on-demand)
+> - `ingestScrapeResults` — the 4-layer dedup + quality scoring + inventory aggregation mutation (unchanged from pre-revision)
+> - `adjustInventory` — atomic inventory counter (unchanged)
+>
+> **What you will NOT see in mobile's `prospects.ts` (and must NOT port):**
+> - ❌ `releaseExpiredReservations` — was the cron handler. Lazy filter replaces it.
+> - ❌ `findLowInventoryCells` — was for the cron. The pool-aware `scrapeNearby` doesn't need it.
+>
+> **Step 3 — Port `convex/scrape.ts`** (NEW FILE — replaces the pre-revision version)
+>
+> Port verbatim from `ndm/convex/scrape.ts`. Contains:
+>
+> - `scrapeOnDemandSync` (internal action) — **NOTE: name is legacy. Implementation is now async-batch mode with inline polling.** Submits a 400-result Outscraper async job, polls every 5s for up to 5 min, ingests into prospects. Called only from on-demand flows.
+> - `subdivideAndScrape` (internal action) — P5 adaptive subdivision when an async scrape hits the 400-result cap. Still on-demand (parent action triggered it).
+> - `getJob` (internal query) — fetches scrape_history rows for traceability
+>
+> **What was REMOVED from scrape.ts in the revision (must NOT port):**
+> - ❌ `replenishLowInventoryCells` — was the cron handler. Gone.
+> - ❌ `countScrapesLast24h` — was for the cron's daily budget guard. Gone.
+> - ❌ `pollAndIngest` as a separate scheduled action — polling is now INLINE inside `scrapeOnDemandSync` since the user is waiting. Don't port `pollAndIngest` as a free-standing action.
+> - ❌ `scrapeAndStore` (cron-mode async version) — replaced by `scrapeOnDemandSync`
+>
+> **Step 4 — Port `convex/outscraper.ts` `scrapeNearby` (POOL-AWARE + ASYNC BATCH)**
+>
+> The existing `scrapeNearby` action now has THREE blocks bolted on (one of them new in this revision):
+>
+> 1. **Pool check at the top.** Before any Outscraper call, it queries `prospects.searchNearbyInternal` for the user's area + category. If pool has ≥ 10 available prospects, it converts them to the businesses array shape and returns immediately — **zero API cost, instant response.**
+>
+> 2. **🔥 NEW — Async-batch Outscraper submission + inline polling.** When the pool is insufficient, the action:
+>    - Submits a 400-result Outscraper job with `async=true`
+>    - Polls the `/requests/{jobId}` endpoint every 5s for up to 5 min
+>    - When the job reaches "Success" status, parses the data
+>    - This replaces the prior sync-mode single-shot fetch
+>    - **The function's external return signature is unchanged** — mobile callers see the same businesses array shape, just with up to 400 items instead of ~50, after a 30-90s wait instead of 5-30s
+>
+> 3. **Pool ingest at the bottom.** After the async results + Places merge produce the final `businesses` array, ALL of those businesses are inserted into the `prospects` table via `ingestScrapeResults`. Subsequent requests to the same area get served from the pool for free.
+>
+> The function's external signature is unchanged. Mobile callers continue to use it. The behavior shift is internal: pool-first, async-batch-scrape-as-fallback, always-archive.
+>
+> **Step 5 — `convex/crons.ts` should have NO new entries**
+>
+> If your `convex/crons.ts` has any of these, DELETE them now:
+>
+> ```typescript
+> // ❌ DELETE — these were from the pre-revision spec
+> crons.interval("replenish low inventory cells", { minutes: 30 }, internal.scrape.replenishLowInventoryCells);
+> crons.interval("release expired prospect reservations", { minutes: 60 }, internal.prospects.releaseExpiredReservations);
+> ```
+>
+> The only cron in `crons.ts` should be the existing `aggregate monthly stats` daily entry. Nothing else from this architecture.
+>
+> **Step 6 — Convex env vars**
+>
+> NO new env vars are required by the revision. Specifically, these from the pre-revision spec are NOT needed:
+>
+> - ❌ `MAX_SCRAPES_PER_CRON_TICK` — no cron
+> - ❌ `MAX_SCRAPES_PER_DAY` — no cron
+> - ❌ `MONTHLY_SCRAPE_BUDGET_USD` — no scheduled spend to cap
+>
+> Existing env vars stay:
+> - ✅ `OUTSCRAPER_API_KEY`
+> - ✅ `GOOGLE_PLACES_API_KEY` (for Path B hyper-local merge)
+> - ✅ `ADMIN_CLERK_IDS`
+>
+> **Step 7 — Deploy**
+>
+> ```bash
+> npx convex deploy --prod
+> ```
+>
+> **Step 8 — Verify (after deploy)**
+>
+> | Check | How |
+> |---|---|
+> | No new crons appear | Convex dashboard → Schedules tab — should show ONLY the pre-existing `aggregate monthly stats` |
+> | First Find Local Business tap triggers Outscraper async | Watch Convex logs for `[outscraper] pool check: found 0 existing prospects` followed by `[outscraper] scrapeNearby (async batch) → query=...` then `[outscraper] async job submitted → outscraperJobId=...` |
+> | Inline polling progresses | Logs show `[outscraper] async still pending (attempt 6/60, status=Pending)` lines every ~30s while waiting |
+> | Async completes within budget | Logs show `[outscraper] async job complete after N poll(s) (~Xs)` typically within 30-90s |
+> | Second tap in the same area serves from pool | Tap Find Local Business again with the same location/category → logs show `[outscraper] pool sufficient — skipping Outscraper, serving from pool` (instant response, no async polling) |
+> | Prospects accumulate in pool | After each scrape, watch `prospects` table grow — async mode means ~400 new rows per fresh scrape (vs ~50 in the prior sync version) + `[outscraper] pool ingest: N new prospects added to global pool` |
+> | Cap-hit triggers subdivision | If a single area returns 400 results (cap hit), logs show `[scrape] hit cap of 400, scheduling on-demand subdivision for jobId=...` followed by 7 child scrapes |
+> | Lazy reservation release works | Reserve a prospect, manually patch `reservationExpiresAt` to past in Convex Data tab. Next searchNearby surfaces it; next reserve call from a different creator succeeds. |
+>
+> **Step 9 — Mobile UI is ready to consume immediately**
+>
+> Mobile's `discover.tsx` already has the **"I'll interview this"** Door from the P2 work and consumes `prospects.reserve`. No further mobile UI changes for the revision. Just rebuild the APK after web deploys.
+>
+> **Files in the revised spec (already written, ready to port):**
+> - `ndm/convex/prospects.ts` — reservation mutations + lazy-release in searchNearby + countAvailableInCell + ingestScrapeResults + helpers (NO cron handler)
+> - `ndm/convex/scrape.ts` — `scrapeOnDemandSync` + `subdivideAndScrape` + `getJob` (NO cron, NO async polling)
+> - `ndm/convex/outscraper.ts` — `scrapeNearby` now pool-aware (pool check + pool ingest blocks)
+> - `ndm/convex/crons.ts` — pristine, only the pre-existing `aggregate monthly stats` cron
+> - `ndm/app/(app)/leads/discover.tsx` — already has the reserve button from P2 work
+>
+> ### Cost outlook under the revised on-demand + async-batch model
+>
+> Outscraper cost is bounded by **actual creator demand**, not a scheduled job. Each creator request either:
+>
+> - Hits the pool → **$0**
+> - Pool is empty for that area/category → triggers one Outscraper **async batch** call → ~$0.40 per call (up to 400 results × $0.001)
+>
+> The pool only grows. The first creator in a new area pays the async-batch cost. Every subsequent creator in that area gets free pool results (the data is permanent — no refresh schedule).
+>
+> **Why async batch is cheaper at steady state despite higher per-call cost:**
+>
+> One 400-result async call costs $0.40 and stocks the pool for ~50-100 future creator requests in that area. Compare to the prior sync mode where one 50-result call cost $0.05 and stocked the pool for only ~5-10 future requests.
+>
+> | Mode | Cost / call | Pool growth / call | Future creators served / scrape | Effective cost / creator served |
+> |---|---|---|---|---|
+> | Sync (prior) | $0.05 | +50 | 5-10 | ~$0.005-$0.010 |
+> | Async batch (current) | $0.40 | +400 | 50-100 | ~$0.004-$0.008 |
+>
+> Async batch is **20-50% cheaper per creator served** because the larger batch defrays the cost across more pool hits.
+>
+> At 100 creators each making 5 unique-area scrapes/week:
+> - First week: ~500 area-touches; ~80% hit the pool after week 1's bootstrap. Bootstrap ~30 fresh scrapes × $0.40 = $12 → covered by $30 AppSumo → **$0**
+> - Week 2+: most requests hit the pool, maybe 10-20 fresh scrapes/week × $0.40 = $4-8/week → **$15-30/month, mostly covered by AppSumo**
+>
+> At 1,000 creators: similar steady-state cost because creators search overlapping areas already in the pool.
+>
+> At 10K-50K creators: cost stays roughly flat because the pool saturates after ~30 days of activity. Estimated $30-80/month, mostly covered by AppSumo.
+>
+> **Adaptive subdivision cost:** if a 400-result scrape hits the cap, the action schedules 7 child scrapes (one per H3 res-8 hex). Worst case: 8 × $0.40 = $3.20 for one super-dense area. The pool gain is correspondingly large (~3,200 prospects), so it still amortizes well. Only triggers on truly dense urban cores (Makati CBD, BGC, etc.).
+>
+> ### Hard rules — what you MUST NOT do (still)
+>
+> - ❌ Mobile must not run `npx convex deploy`. Same rule, every deploy.
+> - ❌ Do NOT add ANY crons under this architecture. Spec is explicit.
+> - ❌ Do NOT remove the existing `outscraper.scrapeNearby`. It's the on-demand entry point now.
+> - ❌ Do NOT touch `migratedToProspectId` on leads until P8 cleanup (deferred).
+> - ❌ Do NOT seed prospects manually via dashboard — let the on-demand flow populate them through `ingestScrapeResults`.
+>
+> ---
+>
+> <details>
+> <summary><strong>📦 ARCHIVED — Pre-revision cron-driven architecture (do NOT implement)</strong></summary>
+>
+> The original P2-P8 spec called for `replenishLowInventoryCells` and `releaseExpiredReservations` crons running every 30 and 60 minutes respectively. The project owner revised the spec on 2026-06 to remove all scheduled scraping. The cron-driven design is preserved below for context but should NOT be deployed.
+>
+> ### What you'll do (high level)
+>
+> 1. Port `ndm/convex/prospects.ts` additions (6 new mutations + 1 cron handler + 5 P4 helpers + ingestScrapeResults with dedup layers)
+> 2. Port `ndm/convex/scrape.ts` verbatim (NEW FILE — 4 actions + 1 internal query)
+> 3. Register 2 new crons in `convex/crons.ts`
+> 4. Set 3 new env vars
+> 5. `npx convex deploy --prod`
+> 6. Verify end-to-end
+>
+> ### Step-by-step
+>
+> **Step 1 — Port reservation mutations to web's `convex/prospects.ts`**
+>
+> Mobile added these exports to `ndm/convex/prospects.ts`. Copy verbatim:
+>
+> - `reserve(prospectId)` — available → reserved, sets 24h expiry, updates inventory
+> - `markContacted(prospectId)` — reserved → contacted, clears expiry
+> - `markQualified(prospectId)` — contacted → qualified
+> - `markConverted(prospectId, submissionId)` — any → converted, links submission
+> - `markLost(prospectId, reason?)` — any non-terminal → lost
+> - `releaseReservation(prospectId)` — reserved → available (voluntary)
+> - `releaseExpiredReservations` — internal mutation, called by cron
+>
+> All state-change mutations enforce "only the reserving creator can advance state" (admin bypass not implemented — add if needed via `requireAdmin` check). Inventory deltas use the existing `adjustInventory` internal mutation from P1.
+>
+> **Step 2 — Port P4 helpers to `convex/prospects.ts`**
+>
+> Mobile added these supporting functions for the background scrape flow:
+>
+> - `getLocaleConfig(country, categoryBucket)` — fetches category_locales row
+> - `findLowInventoryCells(maxResults)` — returns neediest (cell, category) pairs, throttled to 2h since last scrape
+> - `recordScrapeStart(jobId, ...)` — inserts scrape_history row, status="pending"
+> - `recordScrapeAsyncId(jobId, outscraperJobId)` — updates to status="running" + saves Outscraper's async job ID
+> - `recordScrapeComplete(jobId, rawResultCount, insertedCount, dedupedCount?, hitLimitCap)` — finalizes, computes estimatedCost, updates prospect_inventory.lastScrapedAt
+> - `recordScrapeFailed(jobId, errorMessage)` — status="failed", logs reason
+> - `ingestScrapeResults(jobId, businesses, country?)` — **THE BIG ONE**: dedup layers 2/3/4, quality scoring, inventory aggregation, atomic batch insert
+>
+> **Step 3 — Create `convex/scrape.ts`** (NEW FILE)
+>
+> Port verbatim from `ndm/convex/scrape.ts`. Contains:
+>
+> - `replenishLowInventoryCells` (cron handler) — reads daily budget from env, calls findLowInventoryCells, schedules scrapeAndStore for each
+> - `countScrapesLast24h` (internal query) — used by the budget guard
+> - `scrapeAndStore` (internal action) — fires Outscraper async mode, schedules pollAndIngest 30s later
+> - `pollAndIngest` (internal action) — polls Outscraper requests endpoint, reschedules every 30s up to 20 attempts (10 min), ingests results, triggers subdivision if cap hit
+> - `subdivideAndScrape` (internal action) — P5: when res-7 scrape hits 400-result cap, splits into 7 res-8 children
+> - `getJob` (internal query) — fetches scrape_history row by jobId
+>
+> **Step 4 — Update `convex/crons.ts`** with two new entries:
+>
+> ```typescript
+> crons.interval(
+>   "replenish low inventory cells",
+>   { minutes: 30 },
+>   internal.scrape.replenishLowInventoryCells,
+> );
+>
+> crons.interval(
+>   "release expired prospect reservations",
+>   { minutes: 60 },
+>   internal.prospects.releaseExpiredReservations,
+> );
+> ```
+>
+> Don't touch the existing `aggregate monthly stats` cron.
+>
+> **Step 5 — Set Convex env vars (defaults are conservative — adjust as you observe usage)**
+>
+> ```bash
+> npx convex env set MAX_SCRAPES_PER_CRON_TICK 5 --prod
+> npx convex env set MAX_SCRAPES_PER_DAY 50 --prod
+> npx convex env set MONTHLY_SCRAPE_BUDGET_USD 300 --prod
+> ```
+>
+> The cron's daily-budget guard reads `MAX_SCRAPES_PER_DAY` and stops scheduling jobs once today's `scrape_history` count (completed + failed) hits the cap. The `MONTHLY_SCRAPE_BUDGET_USD` is informational for now — server-side enforcement comes in a follow-up if needed.
+>
+> **Step 6 — Deploy**
+>
+> ```bash
+> npx convex deploy --prod
+> ```
+>
+> **Step 7 — Verify (after deploy)**
+>
+> | Check | How |
+> |---|---|
+> | Crons scheduled | Convex dashboard → Schedules tab — should see both new crons with next-run time |
+> | First replenishment fires | Wait up to 30 min OR manually invoke `internal.scrape.replenishLowInventoryCells` from dashboard "Run function" panel |
+> | Scrape job recorded | Open `scrape_history` table — should see new row with status="pending" → "running" → "completed" over ~30-90 seconds |
+> | Prospects inserted | `prospects` table grows; check `ingestScrapeResults` log line: `inserted=N dedupedByPlaceId=X dedupedByPhone=Y dedupedByName=Z` |
+> | Inventory updates | `prospect_inventory` rows for that cell show updated `availableCount` and `lastScrapedAt` |
+> | Subdivision triggers (if applicable) | If a scrape returns 400 results, watch for child scrapes spawned with `h3CellRes8` populated |
+> | Reservation cron fires hourly | Reserve a prospect manually, wait until expiry passes (`Date.now() + 24h`), confirm it flips back to available |
+>
+> **Step 8 — Mobile UI is ready to consume immediately**
+>
+> Mobile's `discover.tsx` now renders an **"I'll interview this"** accent Door under the Directions/Call buttons when a card is active. Tapping it calls `prospects.reserve` and shows a confirmation alert. The button gracefully handles:
+> - Already reserved (someone else just took it)
+> - Auth expired
+> - URL-data businesses (not yet in pool — shown a hint to retry from main Leads tab)
+>
+> After your deploy, the button works for any prospect with a Convex `_id` (pool-backed). URL-data businesses (fresh scrape results) still don't have prospect rows — they'll get them once the next replenishment cron sweeps the area.
+>
+> **Files in mobile's P2-P8 spec (already written, ready to port):**
+> - `ndm/convex/prospects.ts` — 6 mutations, 1 cron handler, 7 internal helpers (added below the existing P1 code)
+> - `ndm/convex/scrape.ts` — NEW file, ~250 lines, full P4+P5 implementation
+> - `ndm/convex/crons.ts` — 2 new cron registrations
+> - `ndm/app/(app)/leads/discover.tsx` — reserve button + handler
+>
+> ### What's intentionally deferred (P-future, not in this batch)
+>
+> - **P3 admin inventory dashboard** — query exists (`findLowInventoryCells`), UI is web's call. Recommended: add a simple admin route showing inventory health per (cell, category) with a "manually trigger replenishment" button.
+> - **P6 stale-contact release cron** — 7-day idle release of contacted prospects. Add to `convex/crons.ts` later: `crons.interval("release stale prospect contacts", { hours: 24 }, internal.prospects.releaseStaleContacts);` Mutation can be modeled on `releaseExpiredReservations`.
+> - **P6 weekly refresh cron** — re-pull existing prospects from Outscraper monthly to keep `rating` / `reviewCount` / `website` fresh. Add when launching country #2.
+> - **P7 quality badges on prospect cards** — render the `qualityScore` field as a small badge on the discover map and detail pages. Pure web/mobile UI work.
+> - **P8 cutover + cleanup** — after 2 weeks of stable operation:
+>   1. Delete `leads` rows where `migratedToProspectId` is set
+>   2. Remove the deprecated `outscraper.scrapeNearby` action (mobile's discover map no longer needs it once the pool is fully populated)
+>   3. Remove the `migratedToProspectId` field from `leads` schema
+>   4. Remove the dual-read fallback in mobile's `discover.tsx`
+>
+> ### Cost outlook with full P2-P8 live
+>
+> | Coverage | Monthly Outscraper calls (replenishment only) | Monthly cost |
+> |---|---|---|
+> | Metro Manila (50 cells × 10 categories, ~30-day refresh) | ~500 | ~$100 |
+> | All major PH cities (5 cities × 50 cells × 10 categories) | ~2,500 | ~$500 |
+> | PH + ID + VN at full coverage | ~7,500 | ~$1,500 |
+>
+> Compare to current per-tap model at 5K creators: $2K+/month. The pool model is ~75% cheaper at small scale, ~95% cheaper at 50K creators.
+>
+> ### Hard rules — what you MUST NOT do (still)
+>
+> - ❌ Mobile must not run `npx convex deploy`. Same rule, every deploy.
+> - ❌ Do NOT remove the existing `outscraper.scrapeNearby` until P8 cleanup. The dual-read window keeps the discover map working during migration.
+> - ❌ Do NOT touch `migratedToProspectId` on leads until P8.
+> - ❌ Do NOT seed prospects manually via dashboard — let the backfill (P1) + replenishment (P4) populate them through the proper code paths.
+> - ❌ Do NOT raise `MAX_SCRAPES_PER_DAY` past 100 without checking the Outscraper bill first.
+>
+> </details>
 
 ---
 


### PR DESCRIPTION
# Latest Changes 

**Frontend enhancements:**

- Added a "Reserve" button for pool-sourced leads in the `CategoryPins` component, allowing users to claim prospects directly from the pool. This replaces the old read-only hint and wires up the new `prospects.reserve` mutation for reserving leads. [[1]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R750-R753) [[2]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L842-R869)

**Backend improvements:**

*Prospect Pool Integration:*
- The `scrapeNearby` action now checks the prospect pool for sufficient leads (≥10) in the requested area and category before triggering a new scrape. If enough are available, it serves them instantly at zero API cost; otherwise, it proceeds to scrape and replenish the pool.

*Async-Batch Scraping:*
- Switched the scraping flow to use Outscraper's async-batch API: submits a job, polls for completion (up to 5 minutes), and retrieves up to 400 results per call (previously ~50). This change greatly increases pool growth per scrape and reduces cost per future lead.

*Pool Ingest and Category Mapping:*
- After a successful scrape, all results are archived into the prospects pool for future reuse, including proper category bucketing and scrape history tracking. Also, introduced a utility to map free-text categories to known pool buckets, avoiding unnecessary scrapes for rarely-seeded "other" categories. [[1]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R21-R41) [[2]](diffhunk://#diff-5dd98b864ea7ee4500d9c784629f12ea5ca4ecae8c6414e3e43c7e420ca94b68R652-R701)