### PR TITLE
Devpatch7

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -356,11 +356,14 @@ function DiscoverInner() {
         );
     }, [allMappableProspects, userLoc, radiusKm]);
 
-    // Fallback: when the radius filter rules everything out but we DO have
-    // mappable prospects elsewhere, show them all rather than blank canvas.
-    // Surface a banner so the creator understands the relaxation.
+    // Field-test fix #3 (2026-06-04): hard distance filter. The previous
+    // behaviour silently relaxed to "show all" when the radius excluded
+    // every prospect; creators reported confusing pins 2-3km away on a
+    // "1km" search. Now we strictly honor radiusKm. The banner below still
+    // shows when there are out-of-radius prospects so creators understand
+    // why the map looks empty — but the pin set itself is no longer relaxed.
     const usingRadiusFallback = withinRadius.length === 0 && allMappableProspects.length > 0;
-    const pinsUnsorted = usingRadiusFallback ? allMappableProspects : withinRadius;
+    const pinsUnsorted = withinRadius;
 
     const pins = useMemo(() => {
         const arr = [...pinsUnsorted];

--- a/components/leads/FindLocalBusinessModal.tsx
+++ b/components/leads/FindLocalBusinessModal.tsx
@@ -28,7 +28,10 @@ import {
 
 type Phase = "idle" | "locating" | "searching" | "saving";
 
-const RADIUS_OPTIONS = [1, 3, 5, 10] as const;
+// Field-test fix #3 (2026-06-04): added 0.5km (rendered as "500 m") for
+// hyper-local searches. Mobile defaults to 1km so that's the new web
+// default too — see useState below.
+const RADIUS_OPTIONS = [0.5, 1, 3, 5, 10] as const;
 
 const PHASE_META: Record<Exclude<Phase, "idle">, { caption: string; doorLabel: string; hint: string }> = {
     locating: {
@@ -80,7 +83,7 @@ export default function FindLocalBusinessModal({
     const scrapeNearby = useAction(api.outscraper.scrapeNearby);
 
     const [category, setCategory] = useState("");
-    const [radius, setRadius] = useState<number>(5);
+    const [radius, setRadius] = useState<number>(1);
     const [phase, setPhase] = useState<Phase>("idle");
     const [permissionError, setPermissionError] = useState<string | null>(null);
     const activeRef = useRef(false);
@@ -294,9 +297,14 @@ export default function FindLocalBusinessModal({
 
                             {/* Radius */}
                             <div className="mb-4">
-                                <div className="grid grid-cols-4 gap-2">
+                                <div className="grid grid-cols-5 gap-2">
                                     {RADIUS_OPTIONS.map((r) => {
                                         const isActive = radius === r;
+                                        // Sub-1km options render as "500 m" rather than "0.5 km"
+                                        // for readability — matches mobile's label.
+                                        const isSubKm = r < 1;
+                                        const label = isSubKm ? String(Math.round(r * 1000)) : String(r);
+                                        const unit = isSubKm ? 'm' : 'km';
                                         return (
                                             <button
                                                 key={r}
@@ -310,7 +318,7 @@ export default function FindLocalBusinessModal({
                                                 }}
                                             >
                                                 <div style={{ fontFamily: "var(--ed-serif)", fontSize: 22, lineHeight: 1.05 }}>
-                                                    {r}
+                                                    {label}
                                                 </div>
                                                 <div
                                                     className="text-[9px] mt-0.5"
@@ -321,7 +329,7 @@ export default function FindLocalBusinessModal({
                                                         opacity: 0.7,
                                                     }}
                                                 >
-                                                    km
+                                                    {unit}
                                                 </div>
                                             </button>
                                         );

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -395,10 +395,17 @@ export const listForMobileCRM = query({
                     source: lead.source,
                     status: lead.status,
                     createdAt: lead.createdAt,
-                    businessName: submission?.businessName ?? '(business unavailable)',
-                    businessType: submission?.businessType ?? null,
-                    businessCity: submission?.city ?? null,
-                    businessAddress: submission?.address ?? null,
+                    // Per WEB-PROPECT-POOL.md §"Field-test fixes 2026-06-04" Fix #1:
+                    // when there's no submission linked, fall back to the lead
+                    // row's own business fields (populated by Outscraper-source
+                    // leads + by markConverted from a reserved prospect).
+                    businessName:
+                        submission?.businessName ??
+                        lead.businessName ??
+                        '(business unavailable)',
+                    businessType: submission?.businessType ?? lead.businessCategory ?? null,
+                    businessCity: submission?.city ?? lead.businessCity ?? null,
+                    businessAddress: submission?.address ?? lead.businessAddress ?? null,
                     ownerName: submission?.ownerName ?? null,
                     ownerPhone: submission?.ownerPhone ?? null,
                     interviewerCount,

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -237,7 +237,13 @@ export const scrapeNearby = action({
         //     → Matches Outscraper's documented API.
         //
         // Zoom derivation per the spec's radius→zoom mapping for PH latitudes:
+        // Field-test fix #3 (2026-06-04): added zoom 16 case for ≤0.5km.
+        // Zoom 16 forces Outscraper to favor block-level results, which
+        // surfaces informal businesses ("PARES SA GARAHE" class) ahead
+        // of the popular far-away places Google's relevance ranking
+        // otherwise pushes to the top.
         const zoom =
+            radiusKm <= 0.5 ? 16 :
             radiusKm <= 1 ? 15 :
             radiusKm <= 3 ? 14 :
             radiusKm <= 5 ? 13 :

--- a/convex/prospects.ts
+++ b/convex/prospects.ts
@@ -178,6 +178,45 @@ export const searchNearbyInternal = internalQuery({
 });
 
 /**
+ * Field-test fix #2 (2026-06-04) — list the calling creator's active
+ * reservations, newest first. Powers the mobile "Reserved" filter chip
+ * and the web equivalent on /creators/leads.
+ *
+ * Filters lazy-expired reservations (state=reserved, expiry past) — those
+ * are claimable by anyone now and don't belong in this creator's view.
+ * Uses the existing `by_reserved_creator` index — no new index needed.
+ */
+export const listMyReservations = query({
+    args: {},
+    handler: async (ctx) => {
+        const identity = await requireAuth(ctx);
+        const creator = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!creator) return [];
+
+        const now = Date.now();
+        const all = await ctx.db
+            .query('prospects')
+            .withIndex('by_reserved_creator', (q) =>
+                q.eq('reservedByCreatorId', creator._id),
+            )
+            .collect();
+
+        const active = all.filter(
+            (p) =>
+                p.state === 'reserved' &&
+                typeof p.reservationExpiresAt === 'number' &&
+                p.reservationExpiresAt > now,
+        );
+
+        active.sort((a, b) => (b.reservedAt ?? 0) - (a.reservedAt ?? 0));
+        return active;
+    },
+});
+
+/**
  * Count available prospects in a single (cell, category, country) bucket.
  * Used by `outscraper.scrapeNearby` for a coarse pool-sufficiency check
  * (≥ 10 → skip Outscraper). Cheap — caps at 20 reads.

--- a/docs/changes/WEB-PROPECT-POOL.md
+++ b/docs/changes/WEB-PROPECT-POOL.md
@@ -394,6 +394,113 @@
 >
 > **Adaptive subdivision cost:** if a 400-result scrape hits the cap, the action schedules 7 child scrapes (one per H3 res-8 hex). Worst case: 8 × $0.40 = $3.20 for one super-dense area. The pool gain is correspondingly large (~3,200 prospects), so it still amortizes well. Only triggers on truly dense urban cores (Makati CBD, BGC, etc.).
 >
+> ### 🛠 Field-test fixes (2026-06-04)
+>
+> After the first APK rebuild against the revised architecture, three issues surfaced in real use. All three were fixed mobile-side; **the fixes below need to be ported to web for parity.**
+>
+> **Fix #1 — "(business unavailable)" labels on team feed cards**
+>
+> The `leads.listForMobileCRM` query was rendering "(business unavailable)" for every lead that didn't have a linked submission. The lead row itself carries `lead.businessName` (populated by Outscraper-source leads and by `markConverted` from a reserved prospect), but the query was only checking `submission?.businessName`.
+>
+> Port this change to web's `convex/leads.ts` `listForMobileCRM` query, in the enrichment map block:
+>
+> ```typescript
+> // BEFORE — only checked submission
+> businessName: submission?.businessName ?? "(business unavailable)",
+> businessType: submission?.businessType ?? null,
+> businessCity: submission?.city ?? null,
+> businessAddress: submission?.address ?? null,
+>
+> // AFTER — fall back to the lead row's own fields
+> businessName:
+>   submission?.businessName ??
+>   lead.businessName ??
+>   "(business unavailable)",
+> businessType: submission?.businessType ?? lead.businessCategory ?? null,
+> businessCity: submission?.city ?? lead.businessCity ?? null,
+> businessAddress: submission?.address ?? lead.businessAddress ?? null,
+> ```
+>
+> Existing leads in production with the bug will display their real business names after the web redeploy. No data migration needed — the data was always there, the query just wasn't reading it.
+>
+> **Fix #2 — New `listMyReservations` query (powers the "Reserved" filter chip)**
+>
+> Mobile's leads page now has a `Reserved` filter chip between `All` and `New`. Selecting it shows the creator their active reservations — prospects they've reserved but haven't yet interviewed, with a countdown timer until the 24h expiry.
+>
+> Port this new public query to web's `convex/prospects.ts`, right after `searchNearbyInternal`:
+>
+> ```typescript
+> export const listMyReservations = query({
+>   args: {},
+>   handler: async (ctx) => {
+>     const identity = await requireAuth(ctx);
+>     const creator = await ctx.db
+>       .query("creators")
+>       .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+>       .first();
+>     if (!creator) return [];
+>
+>     const now = Date.now();
+>     const all = await ctx.db
+>       .query("prospects")
+>       .withIndex("by_reserved_creator", (q) => q.eq("reservedByCreatorId", creator._id))
+>       .collect();
+>
+>     // Filter expired reservations — lazy release means they're claimable
+>     // again by anyone, so they shouldn't show in the creator's "yours" view
+>     const active = all.filter(
+>       (p) =>
+>         p.state === "reserved" &&
+>         typeof p.reservationExpiresAt === "number" &&
+>         p.reservationExpiresAt > now,
+>     );
+>
+>     active.sort((a, b) => (b.reservedAt ?? 0) - (a.reservedAt ?? 0));
+>     return active;
+>   },
+> });
+> ```
+>
+> Uses the existing `by_reserved_creator` index from the prospects table schema — no new index needed. Returns the full prospect rows; mobile renders timer + business name + tap-to-open-in-Maps button.
+>
+> The web Creators page should also surface this query in its own equivalent UI — recommended: a "Reserved" tab/filter on the web `/creators/leads` page showing the same data. Web's existing lead list already groups by status; just add a new group/filter "Reserved" that calls `prospects.listMyReservations` and renders the prospect data shape instead of the lead data shape.
+>
+> **Fix #3 — Hyper-local distance tightening**
+>
+> Creators reported the scrape returning businesses 1-1.5km away even when they asked for a 1km radius. Three changes land:
+>
+> 1. **Mobile-side hard distance filter** — `discover.tsx` now drops any business where `haversineKm(userGps, business) > radiusKm`. **Web's equivalent discover map should do the same.** The merge response from `outscraper.scrapeNearby` can include businesses slightly beyond the requested radius (Outscraper's relevance ranking + Places returning 20 nearest regardless of distance hint). Filter client-side so the header copy stays honest.
+>
+> 2. **New 0.5km radius option** — added a "500 m" pill alongside the existing 1/3/5/10 km options. Web's equivalent radius picker should add the same option.
+>
+> 3. **Outscraper zoom bump for sub-1km radii** — port this change to web's `convex/outscraper.ts` `scrapeNearby`:
+>
+>    ```typescript
+>    // BEFORE
+>    let zoom = 13;
+>    if (radiusKm <= 1) zoom = 15;
+>    else if (radiusKm <= 3) zoom = 14;
+>    // ...
+>
+>    // AFTER — added 0.5km → zoom 16 (block-level)
+>    let zoom = 13;
+>    if (radiusKm <= 0.5) zoom = 16;
+>    else if (radiusKm <= 1) zoom = 15;
+>    else if (radiusKm <= 3) zoom = 14;
+>    // ...
+>    ```
+>
+> Zoom 16 forces Outscraper to favor block-level results, which is how informal businesses (the "PARES SA GARAHE" class of leads) surface ahead of the popular far-away restaurants Google's relevance ranking otherwise pushes to the top.
+>
+> Mobile also bumped the default `scrapeRadiusKm` from 5km to **1km** so out-of-the-box behavior is hyper-local. Web should do the same on its discover page default.
+>
+> **Files in this revision (already written mobile-side, ready to port):**
+> - `ndm/convex/leads.ts` — `listForMobileCRM` enrichment block (Fix #1)
+> - `ndm/convex/prospects.ts` — new `listMyReservations` query (Fix #2)
+> - `ndm/convex/outscraper.ts` — zoom 16 for 0.5km radius (Fix #3)
+> - `ndm/app/(app)/leads/index.tsx` — Reserved chip + ReservedCard + 0.5km radius pill + default radius 1km (mobile-only, no web port)
+> - `ndm/app/(app)/leads/discover.tsx` — hard distance filter + 500m header label (mobile-only, web should mirror the filter in its own discover map)
+>
 > ### Hard rules — what you MUST NOT do (still)
 >
 > - ❌ Mobile must not run `npx convex deploy`. Same rule, every deploy.


### PR DESCRIPTION
# Latest Changes 

**Discover Map and Radius Handling Improvements:**

* The discovery map now strictly filters businesses by the selected radius, preventing out-of-radius prospects from appearing as pins. The UI still surfaces a banner when no results are found within the radius, but the pin set is no longer relaxed to "show all."
* Added a 0.5km ("500 m") option to the radius picker for hyper-local searches, updated the UI to display sub-1km options in meters, and changed the default search radius from 5km to 1km for a more local experience. [[1]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL31-R34) [[2]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL83-R86) [[3]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL297-R307) [[4]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL313-R321) [[5]](diffhunk://#diff-b2b32fb3ecc46a0a39baaad217371f997c6a9f8e4b1070f83f4536fc236c62feL324-R332)
* The `scrapeNearby` action now uses zoom level 16 for searches with a radius of 0.5km or less, improving the discovery of block-level and informal businesses.

**Lead and Prospect Data Quality:**

* The `listForMobileCRM` query now falls back to the lead's own business fields if no submission is linked, ensuring that business names and addresses are shown wherever possible instead of "(business unavailable)."

**Reservations and Filtering:**

* Added a new `listMyReservations` query to surface the creator's active reservations, filtering out expired ones and sorting by newest first. This enables a "Reserved" filter/tab in the UI, matching mobile functionality.

