### PR TITLE
feat: Fix blank phone Number show Directions Button for Leads

### DIFF
--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -250,14 +250,6 @@ function DiscoverInner() {
         return arr.map((p: any) => ({ ...p, __source: "legacy" as const }));
     }, [fallbackProspects]);
 
-    // Per-source counts for the DEBUG strip — matches mobile's debug
-    // string so cross-platform support reads the same numbers.
-    const sourceCounts = useMemo(() => ({
-        url: urlBusinesses?.length ?? 0,
-        pool: poolArray.length,
-        legacy: fallbackArray?.length ?? 0,
-    }), [urlBusinesses, poolArray, fallbackArray]);
-
     // Merge sources with place_id dedup. Priority: url > pool > legacy.
     // Falls back to the legacy-only path when URL data is present (post-
     // scrape happy path) — pool + legacy still ride along so a partial
@@ -629,31 +621,10 @@ function DiscoverInner() {
                             Tap Find Local Business again with a wider radius or a different category to add more pins here.
                         </p>
 
-                        {/* DEBUG strip — per-source breakdown matching mobile's
-                            discover.tsx format for cross-platform support.
-                              direct=N      → pins from the URL ?data= param (post-scrape)
-                              pool=N        → pins from prospects.searchNearby (P1 pool)
-                              legacy=N      → pins from outscraper.listScrapedLeads (pre-P1)
-                              with-coords=N → final pin count after coord filtering */}
-                        <div
-                            className="rounded-md px-3 py-2 mb-4 text-[10px] inline-block"
-                            style={{
-                                background: "var(--ed-paper-2)",
-                                color: "var(--ed-ink-3)",
-                                border: "1px solid var(--ed-rule)",
-                                fontFamily: "var(--ed-mono)",
-                                letterSpacing: "0.08em",
-                            }}
-                        >
-                            DEBUG · direct={sourceCounts.url} · pool={sourceCounts.pool} · legacy={sourceCounts.legacy} · with-coords={
-                                (prospects ?? []).filter(
-                                    (p: any) =>
-                                        !p.submissionId &&
-                                        p.businessLatitude != null &&
-                                        p.businessLongitude != null,
-                                ).length
-                            }
-                        </div>
+                        {/* Field-test fix #5 (2026-06-04): debug strip removed.
+                            Dual-read fallback is stable; per-source counts no
+                            longer carry diagnostic value and were visible to
+                            creators. Matches mobile discover.tsx. */}
                         <Link
                             href="/leads"
                             className="inline-flex items-center justify-center gap-1.5 text-[12px] px-4 py-2.5 rounded-xl w-full"

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -42,6 +42,30 @@ const STATUS_PILL_STYLES: Record<string, { bg: string; ink: string }> = {
     lost:      { bg: "var(--ed-status-lost-bg, #F3D7CF)",      ink: "var(--ed-status-lost-ink, #B43A1F)" },
 };
 
+/**
+ * Per WEB-PROPECT-POOL.md §"Field-test fixes 2026-06-04" Fix #4:
+ * builds a Google Maps directions URL for a phoneless+emailless lead so
+ * the card can render a "Show direction" inline button as a fallback CTA.
+ *
+ * Returns null when the lead has neither coords nor a real business name —
+ * the card UI should render "no contact on file" italic in that case.
+ */
+function buildDirectionsUrl(lead: any): string | null {
+    if (lead.businessLatitude != null && lead.businessLongitude != null) {
+        const placeQuery = lead.businessGooglePlaceId
+            ? `&query_place_id=${encodeURIComponent(lead.businessGooglePlaceId)}`
+            : '';
+        return `https://www.google.com/maps/search/?api=1&query=${lead.businessLatitude},${lead.businessLongitude}${placeQuery}`;
+    }
+    if (lead.businessName && lead.businessName !== '(business unavailable)') {
+        const q = encodeURIComponent(
+            lead.businessCity ? `${lead.businessName} ${lead.businessCity}` : lead.businessName,
+        );
+        return `https://www.google.com/maps/search/?api=1&query=${q}`;
+    }
+    return null;
+}
+
 function timeAgo(ts: number | null | undefined): string {
     if (!ts) return "—";
     const diff = Date.now() - ts;
@@ -816,6 +840,44 @@ function LeadStandardCard({ lead }: { lead: any }) {
                     </div>
                 </div>
             )}
+
+            {/* Field-test fix #4 (2026-06-04): Show direction fallback CTA for
+                phoneless+emailless leads (common with scraped informal businesses).
+                Renders the directions button when we have coords/place_id/name;
+                falls through to "no contact on file" italic when even the
+                business name is missing. */}
+            {!lead.phone && !lead.email && (() => {
+                const directionsUrl = buildDirectionsUrl(lead);
+                if (!directionsUrl) {
+                    return (
+                        <div
+                            className="text-[11px] italic mb-3"
+                            style={{ color: "var(--ed-ink-3)", fontFamily: "var(--ed-serif)" }}
+                        >
+                            no contact on file
+                        </div>
+                    );
+                }
+                return (
+                    <a
+                        href={directionsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="inline-flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-3 py-1.5 mb-3 transition-colors"
+                        style={{
+                            background: "var(--ed-accent, #10B981)",
+                            color: "#fff",
+                            textDecoration: "none",
+                            fontFamily: "var(--ed-mono)",
+                            letterSpacing: "0.08em",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        <MapPin className="w-3 h-3" /> Show direction
+                    </a>
+                );
+            })()}
 
             <hr className="border-t" style={{ borderColor: "var(--ed-rule)" }} />
 

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -406,6 +406,14 @@ export const listForMobileCRM = query({
                     businessType: submission?.businessType ?? lead.businessCategory ?? null,
                     businessCity: submission?.city ?? lead.businessCity ?? null,
                     businessAddress: submission?.address ?? lead.businessAddress ?? null,
+                    // Per WEB-PROPECT-POOL.md §"Field-test fixes 2026-06-04" Fix #4:
+                    // expose coords + place_id so the card UI can render a
+                    // "Show direction" fallback CTA for phoneless leads.
+                    // These already exist on the leads table schema — the
+                    // query just wasn't returning them.
+                    businessLatitude: lead.businessLatitude ?? null,
+                    businessLongitude: lead.businessLongitude ?? null,
+                    businessGooglePlaceId: lead.businessGooglePlaceId ?? null,
                     ownerName: submission?.ownerName ?? null,
                     ownerPhone: submission?.ownerPhone ?? null,
                     interviewerCount,

--- a/docs/changes/WEB-PROPECT-POOL.md
+++ b/docs/changes/WEB-PROPECT-POOL.md
@@ -494,12 +494,53 @@
 >
 > Mobile also bumped the default `scrapeRadiusKm` from 5km to **1km** so out-of-the-box behavior is hyper-local. Web should do the same on its discover page default.
 >
+> **Fix #4 — "Show direction" fallback CTA for phoneless leads**
+>
+> Many scraped leads (especially informal Filipino businesses) have no phone number on Google Maps. The team feed cards previously rendered an empty mono line where the phone would be, leaving creators with no obvious next action. The fix:
+>
+> - **Add three new fields to `listForMobileCRM`'s return shape** (web's `convex/leads.ts`):
+>
+>   ```typescript
+>   // Add to the existing return object inside the enrichment .map block:
+>   businessLatitude: lead.businessLatitude ?? null,
+>   businessLongitude: lead.businessLongitude ?? null,
+>   businessGooglePlaceId: lead.businessGooglePlaceId ?? null,
+>   ```
+>
+>   These already exist on the `leads` table schema; the query just wasn't returning them. No schema change required.
+>
+> - **Web's lead card UI should render a "Show direction" inline button** whenever `lead.phone` and `lead.email` are both empty AND any of (lat+lng, googlePlaceId, businessName) are present. Tapping it opens a Google Maps directions URL:
+>
+>   ```typescript
+>   function buildDirectionsUrl(lead) {
+>     if (lead.businessLatitude != null && lead.businessLongitude != null) {
+>       const placeQuery = lead.businessGooglePlaceId
+>         ? `&query_place_id=${encodeURIComponent(lead.businessGooglePlaceId)}`
+>         : '';
+>       return `https://www.google.com/maps/search/?api=1&query=${lead.businessLatitude},${lead.businessLongitude}${placeQuery}`;
+>     }
+>     if (lead.businessName && lead.businessName !== '(business unavailable)') {
+>       const q = encodeURIComponent(
+>         lead.businessCity ? `${lead.businessName} ${lead.businessCity}` : lead.businessName,
+>       );
+>       return `https://www.google.com/maps/search/?api=1&query=${q}`;
+>     }
+>     return null;
+>   }
+>   ```
+>
+>   When even the business name is missing (`"(business unavailable)"`), render "no contact on file" italic as a final fallback. Mobile uses the green accent pill style for the Show direction button; web can use its own equivalent.
+>
+> **Fix #5 — Removed debug strip from discover map empty state**
+>
+> The discover map's empty state previously rendered `DEBUG · direct=N · pool=M · legacy=K · with-coords=X` as a tiny mono line. The dual-read fallback is stable now, the per-source counts no longer carry diagnostic value, and it was visible to creators. Removed mobile-side; web's equivalent discover empty state should drop any similar debug line if present.
+>
 > **Files in this revision (already written mobile-side, ready to port):**
-> - `ndm/convex/leads.ts` — `listForMobileCRM` enrichment block (Fix #1)
+> - `ndm/convex/leads.ts` — `listForMobileCRM` enrichment block (Fix #1 + Fix #4 new fields)
 > - `ndm/convex/prospects.ts` — new `listMyReservations` query (Fix #2)
 > - `ndm/convex/outscraper.ts` — zoom 16 for 0.5km radius (Fix #3)
-> - `ndm/app/(app)/leads/index.tsx` — Reserved chip + ReservedCard + 0.5km radius pill + default radius 1km (mobile-only, no web port)
-> - `ndm/app/(app)/leads/discover.tsx` — hard distance filter + 500m header label (mobile-only, web should mirror the filter in its own discover map)
+> - `ndm/app/(app)/leads/index.tsx` — Reserved chip + ReservedCard + 0.5km radius pill + default radius 1km + Show direction fallback in CompactCard (mobile-only, web should mirror Fix #4 CTA on its own card component)
+> - `ndm/app/(app)/leads/discover.tsx` — hard distance filter + 500m header label + debug strip removed (Fix #5) (mobile-only, web should mirror)
 >
 > ### Hard rules — what you MUST NOT do (still)
 >


### PR DESCRIPTION
# Latest Changes ✨

refactor: replace nodemailer with Resend for transactional email

Swaps the email transport inside lib/email/service.ts only. All 8 public
named functions (sendApprovalEmail, sendPaymentLinkEmail, etc.) keep
their original signatures + return shape so the 7 consumer API routes
and convex/domains.ts callers need no changes. Templates and preview
route untouched.

New env vars (added to .env.local; must also be set on Vercel prod):
  - RESEND_API_KEY     — required
  - RESEND_FROM_EMAIL  — optional, defaults to onboarding@resend.dev
  - RESEND_REPLY_TO    — optional, set to frmwrkd.media@gmail.com so
                         customer replies land in the existing Gmail
                         inbox without needing to set up a new mailbox

Nodemailer + @types/nodemailer + GMAIL_USER/GMAIL_APP_PASSWORD kept as
rollback insurance — remove in a follow-up PR after a week of stable
Resend usage in prod.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
