### PR TITLE
Pricing overhaul (₱999→₱4,999, 50% commission) + field-agent recruitment page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -20,7 +20,7 @@ const PHONE_TEL = "tel:+639671455245";
 export const metadata = {
   title: "About — Tendso",
   description:
-    "Tendso pays Filipinos to digitize local businesses. We use AI to build real coded websites in 48 hours. Local businesses get online for ₱1,000. Creators earn ₱300–₱500 per submission.",
+    "Tendso pays Filipinos to digitize local businesses. We use AI to build real coded websites in 48 hours. Local businesses get online for ₱999. Creators earn ₱500 per submission (50% of every sale).",
 };
 
 const businessSteps = [
@@ -37,7 +37,7 @@ const businessSteps = [
   {
     icon: Globe,
     title: "Live in 24–48 hours",
-    desc: "AI builds your real coded website on a free subdomain. You pay ₱1,000 only when it's live.",
+    desc: "AI builds your real coded website on a free subdomain. You pay ₱999 only when it's live.",
   },
 ];
 
@@ -60,7 +60,7 @@ const creatorSteps = [
   {
     icon: Wallet,
     title: "You get paid",
-    desc: "₱300 for audio · ₱500 for video. Direct to your Wise wallet. ₱1,000 referral bonus for inviting other creators.",
+    desc: "₱500 per submission (50% of every sale). Direct to your Wise wallet. ₱1,000 referral bonus for inviting other creators.",
   },
 ];
 
@@ -87,8 +87,8 @@ export default function AboutPage() {
               <span className="italic text-amber-700">online.</span>
             </h1>
             <p className="text-base sm:text-lg md:text-xl text-neutral-700 leading-relaxed">
-              Two sides, one platform. Local businesses get a real coded website in 48 hours for ₱1,000.
-              Creators earn ₱300–₱500 per submission for finding businesses and capturing their story.
+              Two sides, one platform. Local businesses get a real coded website in 48 hours for ₱999.
+              Creators earn 50% of every website they sell — ₱500 to start, up to ₱2,500 as they unlock higher pricing.
               AI does the building in between.
             </p>
           </div>
@@ -109,7 +109,7 @@ export default function AboutPage() {
               </h2>
               <p className="text-neutral-700 leading-relaxed mb-5">
                 Real coded website (not Wix or template), mobile-optimized, hosted on a free subdomain.
-                One-time ₱1,000. No monthly fees. You only pay when it&apos;s live.
+                One-time ₱999. No monthly fees. You only pay when it&apos;s live.
               </p>
               <a
                 href={PHONE_TEL}
@@ -131,7 +131,7 @@ export default function AboutPage() {
                 Get paid to digitize businesses.
               </h2>
               <p className="text-white/75 leading-relaxed mb-5">
-                Students, content creators, anyone with a smartphone and hustle. Earn ₱300–₱500 per submission.
+                Students, content creators, anyone with a smartphone and hustle. Earn 50% of every website you sell — ₱500 to start, up to ₱2,500 as you unlock higher pricing.
                 Direct payouts via Wise. ₱1,000 referral bonus for inviting other creators.
               </p>
               <Link
@@ -269,7 +269,7 @@ export default function AboutPage() {
         <section className="w-full py-16 sm:py-20 px-6 max-w-7xl mx-auto">
           <div className="max-w-2xl mx-auto text-center mb-12">
             <p className="text-xs uppercase tracking-widest font-bold text-amber-700 mb-3">
-              What ₱1,000 gets you
+              What ₱999 gets you
             </p>
             <h2
               style={{ fontFamily: "var(--font-fraunces)" }}
@@ -289,7 +289,7 @@ export default function AboutPage() {
               "Hosted with SSL · Fast loading",
               "Free edits within 7 days of launch",
               "Live in 24–48 hours",
-              "One-time ₱1,000 — no monthly fees",
+              "One-time ₱999 — no monthly fees",
             ].map((item) => (
               <li
                 key={item}

--- a/app/api/send-payment-followup-email/route.ts
+++ b/app/api/send-payment-followup-email/route.ts
@@ -4,6 +4,7 @@ import { fetchQuery, fetchMutation } from 'convex/nextjs'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { sendPaymentFollowUpEmail } from '@/lib/email/service'
+import { BASE_PRICE } from '@/lib/pricing'
 
 /**
  * Send the payment follow-up email to a business owner.
@@ -82,7 +83,7 @@ export async function POST(request: NextRequest) {
         const deadline = (submission.sentEmailAt || submission._creationTime) + THREE_DAYS_MS
         const hoursLeft = Math.max(1, Math.round((deadline - Date.now()) / (60 * 60 * 1000)))
 
-        const amount = (submission as any).amount || 1000
+        const amount = (submission as any).amount || BASE_PRICE
         const referenceCode = (submission as any).paymentReference
 
         await sendPaymentFollowUpEmail({

--- a/app/creators/page.tsx
+++ b/app/creators/page.tsx
@@ -8,7 +8,7 @@ import { Camera, Sparkles, Users, ArrowRight } from "lucide-react";
 
 export const metadata = {
   title: "Earn as a Creator — Tendso",
-  description: "Get paid to digitize local Filipino businesses. ₱300–₱500 per submission, plus ₱1,000 referral bonus. Direct payouts via Wise.",
+  description: "Get paid to digitize local Filipino businesses. ₱500 per submission (50% of every sale), plus ₱1,000 referral bonus. Direct payouts via Wise.",
 };
 
 const flow = [
@@ -19,7 +19,7 @@ const flow = [
   },
   {
     icon: Sparkles,
-    title: "Pitch ₱1,000 service",
+    title: "Pitch ₱999 service",
     desc: "Collect business info, take photos, record a short audio or video interview using the app.",
   },
   {
@@ -52,7 +52,7 @@ export default function CreatorsPage() {
               <span className="italic text-amber-700">full.</span>
             </h1>
             <p className="text-base sm:text-lg md:text-xl text-neutral-700 max-w-2xl mx-auto mb-9 leading-relaxed">
-              Visit a shop where someone is already working. Photograph the work. Ask a few questions. Submit through the Tendso app. Earn <span className="font-semibold text-neutral-900">₱300–₱500 per submission</span> — straight to your Wise account.
+              Visit a shop where someone is already working. Photograph the work. Ask a few questions. Submit through the Tendso app. Earn <span className="font-semibold text-neutral-900">₱500 per submission (50% of every sale)</span> — straight to your Wise account.
             </p>
             <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3">
               <Link

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useUser } from "@clerk/nextjs"
 import { useQuery, useMutation } from "convex/react"
+import { PRICE_CEILING, formatPHP } from "@/lib/pricing"
 import { api } from "@/convex/_generated/api"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
@@ -22,6 +23,12 @@ export default function DashboardPage() {
     // Get submissions from Convex
     const submissions = useQuery(
         api.submissions.getByCreatorId,
+        creator?._id ? { creatorId: creator._id } : "skip"
+    )
+
+    // Price-tier progress: approved-submission count + whether higher pricing is unlocked
+    const pricing = useQuery(
+        api.submissions.getPricingContext,
         creator?._id ? { creatorId: creator._id } : "skip"
     )
 
@@ -183,6 +190,46 @@ export default function DashboardPage() {
             </header>
 
             <main className="px-4 space-y-5">
+                {/* Price-tier progress — unlock higher pricing (see lib/pricing.ts) */}
+                {pricing && !pricing.unlocked && (
+                    <div
+                        className="rounded-2xl p-4"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <div className="flex items-center justify-between mb-2">
+                            <span className="ed-label">Unlock higher pricing</span>
+                            <span className="text-sm font-bold" style={{ color: "var(--ed-accent)" }}>
+                                {pricing.approvedCount}/{pricing.threshold}
+                            </span>
+                        </div>
+                        <div className="w-full h-2 rounded-full overflow-hidden" style={{ background: "var(--ed-rule)" }}>
+                            <div
+                                className="h-full rounded-full transition-all"
+                                style={{
+                                    width: `${Math.min(100, Math.round((pricing.approvedCount / pricing.threshold) * 100))}%`,
+                                    background: "var(--ed-accent)",
+                                }}
+                            />
+                        </div>
+                        <p className="text-xs mt-2" style={{ color: "var(--ed-ink-3)" }}>
+                            {pricing.threshold - pricing.approvedCount > 0
+                                ? `${pricing.threshold - pricing.approvedCount} more approved ${pricing.threshold - pricing.approvedCount === 1 ? "submission" : "submissions"} to set your own price up to ${formatPHP(PRICE_CEILING)}.`
+                                : `You can now set your own price up to ${formatPHP(PRICE_CEILING)}.`}
+                        </p>
+                    </div>
+                )}
+                {pricing && pricing.unlocked && (
+                    <div
+                        className="rounded-2xl p-4 flex items-center justify-between"
+                        style={{ background: "var(--ed-paper-3)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <span className="ed-label">Pricing unlocked</span>
+                        <span className="text-sm font-bold" style={{ color: "var(--ed-accent)" }}>
+                            Set up to {formatPHP(pricing.priceCeiling)}
+                        </span>
+                    </div>
+                )}
+
                 {/* Balance Card — ink surface with serif amount */}
                 <div
                     className="rounded-3xl p-6 relative overflow-hidden"

--- a/app/for-field-agents/page.tsx
+++ b/app/for-field-agents/page.tsx
@@ -1,5 +1,4 @@
-"use client";
-
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import Navbar from "@/components/landing/Navbar";
@@ -7,23 +6,86 @@ import Footer from "@/components/landing/Footer";
 import ScrollToTop from "@/components/landing/ScrollToTop";
 
 import EarningsSection from "@/components/landing/EarningsSection";
-import ProcessSection from "@/components/landing/ProcessSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaSection from "@/components/landing/CtaSection";
 import ChatBot from "@/components/landing/ChatBot";
 
 import { ArrowUpRightIcon } from "@/components/landing/landingPrimitives";
+import { BASE_PRICE, PRICE_CEILING, commissionFor, formatPHP } from "@/lib/pricing";
 
-const APPLY_STEPS = [
-    { n: "01", h: "Tap \"I want to earn\"", sub: "Sign up from this page. The full flow lives in the app.", meta: "30 seconds" },
-    { n: "02", h: "Verify your phone & ID", sub: "Bank-grade KYC inside the app. Selfie + a valid ID. We hold your data for payouts only.", meta: "5 minutes" },
-    { n: "03", h: "Take the certification", sub: "Twelve short videos. A photo quiz. An interview rehearsal with a fake shop owner. You can retry as many times as you need.", meta: "20 minutes" },
-    { n: "04", h: "Pin yourself on the map", sub: "You show up on the landing page, in front of every business owner in your area looking for a creator.", meta: "instant" },
-    { n: "05", h: "Accept your first booking", sub: "Either a business taps you, or you pick one from your queue. Bring a phone, bring patience. The app guides every step.", meta: "same day" },
-    { n: "06", h: "Deliver. Get paid.", sub: "₱500 lands in your wallet within 48 hours of the business approving the site. Refer a friend, earn another ₱1,000 when their first paid submission lands.", meta: "48 hours" },
+export const metadata: Metadata = {
+    title: "Become a Tendso Field Agent — Get Paid to Put Local Shops Online",
+    description:
+        "We're hiring field agents. Visit local businesses, run a short interview, and earn 50% of every website you sell — ₱500 to start, up to ₱2,500 as you grow. Part-time, free to apply, paid via Wise. A real Philippine company (VONAS, OPC).",
+    alternates: { canonical: "/for-field-agents" },
+    openGraph: {
+        title: "Become a Tendso Field Agent",
+        description:
+            "Get paid to put local shops online. Earn 50% of every sale — ₱500 to start, up to ₱2,500. Part-time, paid via Wise.",
+        url: "/for-field-agents",
+    },
+};
+
+// The Discord onboarding/coaching server invite. NEXT_PUBLIC_DISCORD_INVITE_URL
+// overrides this in any environment; the default is the live field-agent server.
+const DISCORD_INVITE_URL = process.env.NEXT_PUBLIC_DISCORD_INVITE_URL || "https://discord.gg/Dxjt9HV5B";
+
+const STARTER_PAYOUT = commissionFor(BASE_PRICE); // ₱500 (50% of ₱999)
+const TOP_PAYOUT = commissionFor(PRICE_CEILING); // ₱2,500 (50% of ₱4,999)
+
+const FIELD_STEPS = [
+    {
+        n: "01",
+        h: "Apply & get certified",
+        sub: "Sign up free. Verify your phone and ID, then take a short certification — twelve quick videos, a photo quiz, and an interview rehearsal. Retry as many times as you need.",
+        meta: "~20 min",
+    },
+    {
+        n: "02",
+        h: "Walk into a local shop",
+        sub: "A barber, a carinderia, a salon, an auto-repair — anyone already working but not online. The app gives you the script, the questions, and the photo checklist.",
+        meta: "your area",
+    },
+    {
+        n: "03",
+        h: "Run a 30-minute interview",
+        sub: "Record a short video or audio while the owner keeps working, snap 3–5 photos, and submit. Tendso's AI builds a real coded website from it in 48 hours.",
+        meta: "30 min",
+    },
+    {
+        n: "04",
+        h: "Owner approves & pays",
+        sub: "The owner only pays once the site is live and they've approved it — so you're never selling vapor. The price starts at ₱999 and you set it higher as you build a track record.",
+        meta: "48 hr",
+    },
+    {
+        n: "05",
+        h: "Get paid — 50% of the sale",
+        sub: `${formatPHP(STARTER_PAYOUT)} lands in your Wise wallet on your first sales. Close five and you unlock higher pricing — up to ${formatPHP(PRICE_CEILING)} a site, ${formatPHP(TOP_PAYOUT)} to you.`,
+        meta: "via Wise",
+    },
 ];
 
-function CreatorHero() {
+const TRUST_POINTS = [
+    {
+        h: "A registered Philippine company",
+        b: "Tendso is operated by VONAS, OPC. Payouts go straight to your own Wise account — we never ask you for money to start.",
+    },
+    {
+        h: "The owner pays only when it's live",
+        b: "No upfront fee, no deposit. The business owner reviews the finished website and pays only after they approve it. Nothing to pay, nothing to lose.",
+    },
+    {
+        h: "You keep what you earn",
+        b: `Half of every sale is yours — ${formatPHP(STARTER_PAYOUT)} at the ₱999 starter price, up to ${formatPHP(TOP_PAYOUT)} as you unlock higher pricing. Plus ₱1,000 for every creator you refer.`,
+    },
+    {
+        h: "Part-time, on your schedule",
+        b: "Keep your day job. There's no quota and no minimum. Pick the shops you visit and the pace you work at.",
+    },
+];
+
+function FieldAgentHero() {
     return (
         <section style={{ paddingTop: 56, paddingBottom: 48 }}>
             <div className="container-wide">
@@ -77,13 +139,15 @@ function CreatorHero() {
                                     background: "var(--neo-creator)",
                                 }}
                             />
-                            For creators
+                            We&apos;re hiring field agents
                         </div>
-                        <h1 className="display" style={{ fontSize: "clamp(56px, 7.5vw, 120px)" }}>
-                            Get paid to <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>build websites</em> for shops near you.
+                        <h1 className="display" style={{ fontSize: "clamp(52px, 7vw, 112px)" }}>
+                            Get paid to put <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>local shops</em> online.
                         </h1>
-                        <p className="lede" style={{ marginTop: 28, fontSize: 19, maxWidth: "56ch" }}>
-                            Bring a phone, bring patience, follow the in-app checklist. We do the editing, the writing, the deploying. You collect the cheque.
+                        <p className="lede" style={{ marginTop: 28, fontSize: 19, maxWidth: "58ch" }}>
+                            Walk into a business near you, run a short interview, and earn <strong>50% of every website you sell</strong> —
+                            {" "}{formatPHP(STARTER_PAYOUT)} to start, up to {formatPHP(TOP_PAYOUT)} as you grow. We handle the building, the
+                            hosting, and the payouts. You bring the hustle.
                         </p>
 
                         <div style={{ marginTop: 32, display: "flex", gap: 12, flexWrap: "wrap" }}>
@@ -92,22 +156,26 @@ function CreatorHero() {
                                 className="door door-creator"
                                 style={{ textDecoration: "none", display: "inline-flex" }}
                             >
-                                Start the certification <span className="arrow"><ArrowUpRightIcon /></span>
+                                Apply now <span className="arrow"><ArrowUpRightIcon /></span>
                             </Link>
                             <Link
-                                href="/#for-creators"
+                                href={DISCORD_INVITE_URL}
                                 className="door door-ghost"
                                 style={{ textDecoration: "none", display: "inline-flex" }}
                             >
-                                See the numbers
+                                Join the Discord
                             </Link>
                         </div>
+                        <p className="label" style={{ marginTop: 16, color: "var(--neo-ink-3)" }}>
+                            Free to apply · No experience needed · Paid via Wise
+                        </p>
                     </div>
 
                     <div className="surface" style={{ padding: 24 }}>
                         <div className="label" style={{ marginBottom: 16 }}>What you earn</div>
                         {[
-                            ["Per submission (50% of sale)", "₱500"],
+                            ["Per sale (50% of price)", formatPHP(STARTER_PAYOUT)],
+                            ["Once you unlock higher pricing", `up to ${formatPHP(TOP_PAYOUT)}`],
                             ["Referral bonus", "₱1,000"],
                             ["Payout via Wise", "—"],
                             ["Time to first payout", "48 hr"],
@@ -121,14 +189,16 @@ function CreatorHero() {
                                     padding: "12px 0",
                                     borderTop: "1px solid var(--neo-rule)",
                                     fontSize: 14,
+                                    gap: 12,
                                 }}
                             >
                                 <span>{label}</span>
                                 <span
                                     className="counter-num"
                                     style={{
-                                        fontSize: 22,
-                                        color: v.startsWith("₱") ? "var(--neo-creator)" : "var(--neo-ink-3)",
+                                        fontSize: 20,
+                                        textAlign: "right",
+                                        color: v.startsWith("₱") || v.startsWith("up to ₱") ? "var(--neo-creator)" : "var(--neo-ink-3)",
                                     }}
                                 >
                                     {v}
@@ -142,29 +212,64 @@ function CreatorHero() {
     );
 }
 
-function HowToApplySection() {
+function TrustSection() {
     return (
         <section style={{ background: "var(--neo-paper-2)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ How to apply</div>
+                    <div className="eyebrow">§ Is this legit?</div>
                     <div>
                         <h2 className="display-2">
-                            From this page <em>to your first payout</em>.
+                            A real job, <em>not a scam</em>.
                         </h2>
                         <p className="lede" style={{ marginTop: 12 }}>
-                            The full apply-and-certify flow lives inside the app. Here&apos;s what it looks like, with the time each step actually takes.
+                            Fair question — anyone can promise easy money online. Here&apos;s exactly how Tendso works, so you can
+                            decide for yourself before you knock on a single door.
+                        </p>
+                    </div>
+                </div>
+
+                <div
+                    className="grid grid-cols-1 md:grid-cols-2 gap-4"
+                    style={{ maxWidth: 1080, margin: "0 auto" }}
+                >
+                    {TRUST_POINTS.map((p) => (
+                        <div key={p.h} className="card" style={{ padding: "28px 28px 24px" }}>
+                            <h3 className="serif" style={{ fontSize: 22, lineHeight: 1.2, marginBottom: 10 }}>
+                                {p.h}
+                            </h3>
+                            <p style={{ fontSize: 15, color: "var(--neo-ink-2)", lineHeight: 1.6 }}>{p.b}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}
+
+function FieldStepsSection() {
+    return (
+        <section>
+            <div className="container-wide">
+                <div className="sect-h">
+                    <div className="eyebrow">§ How it works</div>
+                    <div>
+                        <h2 className="display-2">
+                            From the street <em>to your wallet</em>.
+                        </h2>
+                        <p className="lede" style={{ marginTop: 12 }}>
+                            Five steps. The app guides every one of them, with the time each actually takes.
                         </p>
                     </div>
                 </div>
 
                 <div className="surface" style={{ padding: 0 }}>
-                    {APPLY_STEPS.map((s, i) => (
+                    {FIELD_STEPS.map((s, i) => (
                         <div
                             key={s.n}
                             style={{
                                 display: "grid",
-                                gridTemplateColumns: "80px 1fr 1fr 160px",
+                                gridTemplateColumns: "80px 1fr 1fr 140px",
                                 gap: 32,
                                 padding: "28px 32px",
                                 borderTop: i === 0 ? "none" : "1px solid var(--neo-rule)",
@@ -172,24 +277,10 @@ function HowToApplySection() {
                             }}
                         >
                             <div className="counter-num" style={{ fontSize: 32, color: "var(--neo-creator)" }}>{s.n}</div>
-                            <div
-                                className="serif"
-                                style={{
-                                    fontSize: 24,
-                                    lineHeight: 1.15,
-                                    letterSpacing: "-.015em",
-                                }}
-                            >
+                            <div className="serif" style={{ fontSize: 24, lineHeight: 1.15, letterSpacing: "-.015em" }}>
                                 {s.h}
                             </div>
-                            <div
-                                style={{
-                                    fontSize: 14,
-                                    color: "var(--neo-ink-2)",
-                                    lineHeight: 1.55,
-                                    maxWidth: "42ch",
-                                }}
-                            >
+                            <div style={{ fontSize: 14, color: "var(--neo-ink-2)", lineHeight: 1.55, maxWidth: "44ch" }}>
                                 {s.sub}
                             </div>
                             <div style={{ textAlign: "right" }}>
@@ -219,7 +310,7 @@ function HowToApplySection() {
                         className="door door-creator"
                         style={{ padding: "16px 24px", textDecoration: "none", display: "inline-flex" }}
                     >
-                        <span>Start the certification</span>
+                        <span>Apply now</span>
                         <span className="arrow"><ArrowUpRightIcon /></span>
                     </Link>
                 </div>
@@ -228,15 +319,15 @@ function HowToApplySection() {
     );
 }
 
-export default function ForCreatorsPage() {
+export default function ForFieldAgentsPage() {
     return (
         <div className="neo min-h-screen overflow-x-hidden">
             <Navbar />
             <main>
-                <CreatorHero />
+                <FieldAgentHero />
+                <TrustSection />
+                <FieldStepsSection />
                 <EarningsSection />
-                <HowToApplySection />
-                <ProcessSection />
                 <FaqSection />
                 <CtaSection />
             </main>

--- a/app/help-faq/page.tsx
+++ b/app/help-faq/page.tsx
@@ -59,7 +59,7 @@ const GROUPS: FaqGroup[] = [
         items: [
             {
                 q: "How much do I earn per submission?",
-                a: "You earn ₱500 for video submissions and ₱300 for audio-only submissions once the business owner pays.",
+                a: "You earn ₱500 per submission (50% of the sale price) once the business owner pays.",
             },
             {
                 q: "How do referral bonuses work?",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ const onest = Onest({
 
 export const metadata: Metadata = {
   title: "Tendso — The Thinking Ends Here. So the work doesn't.",
-  description: "A business page built around the work, not the other way around. A creator visits, asks a few questions, photographs your shop, and your page goes live in 48 hours. No template, no blank screen. ₱1,000 one-time. For Filipino local businesses whose hands are full.",
+  description: "A business page built around the work, not the other way around. A creator visits, asks a few questions, photographs your shop, and your page goes live in 48 hours. No template, no blank screen. ₱999 one-time. For Filipino local businesses whose hands are full.",
 };
 
 export default function RootLayout({

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -73,7 +73,7 @@ export default function SignupPage() {
                             fontSize: "1.05rem",
                         }}
                     >
-                        Earn ₱300–₱500 per submission. Direct payouts via Wise.
+                        Earn ₱500 per submission (50% of every sale). Direct payouts via Wise.
                     </p>
                 </div>
 

--- a/app/submit/interview/page.tsx
+++ b/app/submit/interview/page.tsx
@@ -8,6 +8,7 @@ import { api } from "@/convex/_generated/api"
 import { Id } from "@/convex/_generated/dataModel"
 import { Button } from "@/components/ui/button"
 import { Loader2 } from "lucide-react"
+import { BASE_PRICE, commissionFor } from "@/lib/pricing"
 
 const INTERVIEW_QUESTIONS = [
     "What does your business do and who are your customers?",
@@ -485,12 +486,14 @@ export default function InterviewUploadPage() {
                 throw new Error('Failed to upload interview')
             }
 
-            // Update submission with R2 URL and payout
+            // Update submission with R2 URL. Payout is 50% of the website sell
+            // price (set when the price is finalized on the review page); we no
+            // longer hardcode a per-capture-type rate here. See lib/pricing.ts.
             await updateSubmission({
                 id: submissionId as Id<"submissions">,
                 ...(interviewType === 'video'
-                    ? { videoUrl: publicUrl, creatorPayout: 500 }
-                    : { audioUrl: publicUrl, creatorPayout: 300 }
+                    ? { videoUrl: publicUrl, creatorPayout: commissionFor(BASE_PRICE) }
+                    : { audioUrl: publicUrl, creatorPayout: commissionFor(BASE_PRICE) }
                 ),
             })
 
@@ -648,7 +651,7 @@ export default function InterviewUploadPage() {
                                     </div>
                                     <div>
                                         <p className="font-bold text-gray-900">Audio</p>
-                                        <p className="text-sm text-amber-600 font-bold">₱300</p>
+                                        <p className="text-sm text-amber-600 font-bold">₱500</p>
                                     </div>
                                 </div>
                                 {interviewType === 'audio' && (

--- a/app/submit/review/page.tsx
+++ b/app/submit/review/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Loader2, Globe, CheckCircle2, XCircle, Search } from "lucide-react"
+import { BASE_PRICE, STANDARD_PRICE, CUSTOM_DOMAIN_PRICE, CUSTOM_DOMAIN_ADDON, PRICE_CEILING, UNLOCK_THRESHOLD, ownerTotal, commissionFor, formatPHP } from "@/lib/pricing"
 
 interface DomainCheckResult {
     valid: boolean
@@ -35,12 +36,14 @@ export default function ReviewSubmissionPage() {
 
     // Custom domain state — tier is auto-derived from whether the input has content
     const [domainInput, setDomainInput] = useState('')
+    // Creator-set sell price, clamped to the creator's band (see lib/pricing.ts)
+    const [sellPrice, setSellPrice] = useState<number>(BASE_PRICE)
     const [domainCheck, setDomainCheck] = useState<DomainCheckResult | null>(null)
     const [checkingDomain, setCheckingDomain] = useState(false)
     // Auto-derived: if user typed something, tier is "with_custom_domain"
     const wantsCustomDomain = domainInput.trim().length > 0
     const tier: 'standard' | 'with_custom_domain' = wantsCustomDomain ? 'with_custom_domain' : 'standard'
-    const totalAmount = wantsCustomDomain ? 1500 : 1000
+    const totalAmount = ownerTotal(sellPrice, tier)
 
     // Get creator from Convex
     const creator = useQuery(
@@ -104,7 +107,7 @@ export default function ReviewSubmissionPage() {
                 const response = await fetch('/api/check-domain', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ domain: domainInput.trim().toLowerCase(), maxBudgetPHP: 500 }),
+                    body: JSON.stringify({ domain: domainInput.trim().toLowerCase(), maxBudgetPHP: CUSTOM_DOMAIN_ADDON }),
                 })
                 const data = await response.json()
                 setDomainCheck(data)
@@ -122,6 +125,12 @@ export default function ReviewSubmissionPage() {
         if (submission) {
             const subAny = submission as any
             if (subAny.requestedDomain) setDomainInput(subAny.requestedDomain)
+            // Re-derive the saved website sell price (amount = sellPrice + domain
+            // add-on when a custom domain was chosen).
+            if (typeof subAny.amount === 'number' && subAny.amount > 0) {
+                const addon = subAny.submissionType === 'with_custom_domain' ? CUSTOM_DOMAIN_ADDON : 0
+                setSellPrice(Math.max(subAny.amount - addon, BASE_PRICE))
+            }
         }
     }, [submission])
 
@@ -148,7 +157,7 @@ export default function ReviewSubmissionPage() {
         // If user typed a domain, it must be valid + within budget
         if (wantsCustomDomain) {
             if (!domainCheck?.available || !domainCheck?.withinBudget) {
-                setError('The custom domain you typed is not available or exceeds the ₱500 budget. Either pick a different domain or clear the field to submit without a custom domain.')
+                setError(`The custom domain you typed is not available or exceeds the ${formatPHP(CUSTOM_DOMAIN_ADDON)} budget. Either pick a different domain or clear the field to submit without a custom domain.`)
                 return
             }
         }
@@ -162,6 +171,7 @@ export default function ReviewSubmissionPage() {
                 id: submissionId as Id<"submissions">,
                 submissionType: tier,
                 requestedDomain: wantsCustomDomain ? domainInput.trim().toLowerCase() : undefined,
+                sellPrice,
             })
 
             // Update status to submitted
@@ -187,11 +197,16 @@ export default function ReviewSubmissionPage() {
 
     if (!submission) return null
 
-    // Determine interview type and payout
+    // Creator's allowed price band — priceCeiling unlocks from BASE_PRICE to
+    // PRICE_CEILING after UNLOCK_THRESHOLD approved submissions (see lib/pricing.ts).
+    const priceCeiling = ((creator as any)?.priceCeiling as number | undefined) ?? BASE_PRICE
+    const canSetPrice = priceCeiling > BASE_PRICE
+
+    // Determine interview type and payout (50% of the chosen sell price)
     // Check both R2 URLs (new) and storage IDs (legacy)
     const hasVideo = !!submission.videoUrl || !!submission.videoStorageId
     const hasAudio = !!submission.audioUrl || !!submission.audioStorageId
-    const payout = hasVideo ? 500 : (hasAudio ? 300 : 0)
+    const payout = (hasVideo || hasAudio) ? commissionFor(sellPrice) : 0
 
     return (
         <div
@@ -384,7 +399,7 @@ export default function ReviewSubmissionPage() {
                         </div>
                     </div>
 
-                    {/* Custom Domain (optional) — typing here auto-flags submission as ₱1,500 */}
+                    {/* Custom Domain (optional) — typing here auto-flags the custom-domain tier (₱1,499) */}
                     <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
                         <div className="p-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between">
                             <h3 className="font-semibold text-gray-900 flex items-center gap-2">
@@ -392,12 +407,12 @@ export default function ReviewSubmissionPage() {
                                 Custom Domain (Optional)
                             </h3>
                             <span className={`text-xs font-bold px-2 py-1 rounded-full ${wantsCustomDomain ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-500'}`}>
-                                {wantsCustomDomain ? '₱1,500 total' : 'Not included'}
+                                {wantsCustomDomain ? `${formatPHP(CUSTOM_DOMAIN_PRICE)} total` : 'Not included'}
                             </span>
                         </div>
                         <div className="p-4 space-y-3">
                             <p className="text-xs text-gray-500">
-                                Leave this blank for the standard package (₱1,000, free subdomain). Type a domain to add a custom domain — your fee automatically becomes ₱1,500 and includes year 1 of the domain.
+                                Leave this blank for the standard package ({formatPHP(STANDARD_PRICE)}, free subdomain). Type a domain to add a custom domain — your fee automatically becomes {formatPHP(CUSTOM_DOMAIN_PRICE)} and includes year 1 of the domain.
                             </p>
 
                             <div>
@@ -428,7 +443,7 @@ export default function ReviewSubmissionPage() {
                                 <div className="text-xs">
                                     {domainCheck.available && domainCheck.withinBudget && (
                                         <p className="text-amber-700 font-semibold">
-                                            ✓ Available — included in the ₱1,500 business-owner fee.
+                                            ✓ Available — included in the {formatPHP(CUSTOM_DOMAIN_PRICE)} business-owner fee.
                                         </p>
                                     )}
                                     {domainCheck.available && !domainCheck.withinBudget && (
@@ -518,6 +533,41 @@ export default function ReviewSubmissionPage() {
                                         30 days before expiry.
                                     </p>
                                 </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Your price — creator-set band (see lib/pricing.ts) */}
+                    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                        <div className="p-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between">
+                            <h3 className="font-semibold text-gray-900">Your price</h3>
+                            <span className="text-xs font-bold px-2 py-1 rounded-full bg-amber-100 text-amber-700">
+                                You earn {formatPHP(payout)}
+                            </span>
+                        </div>
+                        <div className="p-4 space-y-3">
+                            {canSetPrice ? (
+                                <>
+                                    <p className="text-xs text-gray-500">
+                                        You&apos;ve unlocked higher pricing. Set the website price between {formatPHP(BASE_PRICE)} and {formatPHP(priceCeiling)} — you keep 50%.
+                                    </p>
+                                    <div className="flex items-center gap-3">
+                                        <input
+                                            type="range"
+                                            min={BASE_PRICE}
+                                            max={priceCeiling}
+                                            step={100}
+                                            value={sellPrice}
+                                            onChange={(e) => setSellPrice(Math.min(Math.max(Number(e.target.value), BASE_PRICE), priceCeiling))}
+                                            className="flex-1 accent-amber-600"
+                                        />
+                                        <span className="text-lg font-black text-amber-700 w-24 text-right">{formatPHP(sellPrice)}</span>
+                                    </div>
+                                </>
+                            ) : (
+                                <p className="text-xs text-gray-500">
+                                    The website price is {formatPHP(BASE_PRICE)}. Land {UNLOCK_THRESHOLD} approved submissions to unlock setting your own price up to {formatPHP(PRICE_CEILING)}.
+                                </p>
                             )}
                         </div>
                     </div>

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -34,7 +34,7 @@ const termsSections = [
         icon: Banknote,
         title: "Payouts & Economics",
         content:
-            "Creators earn PHP 500 for a successful video interview submission, and PHP 300 for audio-only submissions. Referral bonuses of PHP 1,000 are credited when a referred Creator completes their first paid submission. The minimum withdrawal threshold is PHP 100, processed securely via Wise API direct to local Philippine bank accounts.",
+            "Creators earn 50% of the website sale price (₱500 at the ₱999 base price, scaling up to ₱2,500 as higher price tiers unlock). Referral bonuses of PHP 1,000 are credited when a referred Creator completes their first paid submission. The minimum withdrawal threshold is PHP 100, processed securely via Wise API direct to local Philippine bank accounts.",
     },
     {
         marker: "§ 05",

--- a/components/landing/BusinessPricingSection.tsx
+++ b/components/landing/BusinessPricingSection.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { BUSINESS_TIERS } from "./landingData";
 import { ArrowUpRightIcon } from "./landingPrimitives";
+import { BASE_PRICE, formatPHP } from "@/lib/pricing";
 
 export default function BusinessPricingSection() {
     return (
@@ -12,7 +13,7 @@ export default function BusinessPricingSection() {
                     <div className="eyebrow">§ 04 — The price</div>
                     <div>
                         <h2 className="display-2">
-                            ₱1,000 once. <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>Live forever.</em>
+                            {formatPHP(BASE_PRICE)} once. <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>Live forever.</em>
                         </h2>
                         <p className="lede" style={{ marginTop: 12 }}>
                             One-time payment. No monthly fees. No contracts. You only pay once your website is live and you&apos;ve approved it.

--- a/components/landing/CreatorEarningFlow.tsx
+++ b/components/landing/CreatorEarningFlow.tsx
@@ -7,7 +7,7 @@ const flowSteps = [
   {
     icon: Search,
     label: "Find a business",
-    desc: "Walk into a local barber shop, restaurant, salon, or auto repair. Pitch the ₱1,000 website.",
+    desc: "Walk into a local barber shop, restaurant, salon, or auto repair. Pitch the ₱999 website.",
   },
   {
     icon: Send,
@@ -22,12 +22,12 @@ const flowSteps = [
   {
     icon: BadgeCheck,
     label: "Client approves & pays",
-    desc: "Owner reviews the live website. They pay ₱1,000 only when they accept it.",
+    desc: "Owner reviews the live website. They pay ₱999 only when they accept it.",
   },
   {
     icon: Wallet,
     label: "You get paid",
-    desc: "₱300 for audio · ₱500 for video. Direct to your Wise wallet, usually within 24 hours.",
+    desc: "₱500 per submission (50% of every sale). Direct to your Wise wallet, usually within 24 hours.",
   },
 ];
 
@@ -139,7 +139,7 @@ export default function CreatorEarningFlow() {
       {/* Money breakdown panel */}
       <div className="mt-14 sm:mt-16 max-w-3xl mx-auto rounded-3xl bg-neutral-900 text-white p-7 sm:p-10 border border-neutral-800 shadow-xl shadow-neutral-900/15">
         <p className="text-xs uppercase tracking-widest font-bold text-amber-400 mb-3">
-          Where the ₱1,000 goes
+          Where the ₱999 goes
         </p>
         <h3
           style={{ fontFamily: "var(--font-fraunces)" }}
@@ -150,13 +150,8 @@ export default function CreatorEarningFlow() {
 
         <ul className="space-y-3">
           <li className="flex items-center gap-4 py-3 border-b border-white/10">
-            <span className="text-amber-400 font-bold text-sm w-12 shrink-0">₱300</span>
-            <span className="flex-1 text-white/85 text-sm sm:text-base">You earn — audio interview submission</span>
-            <ArrowRight className="w-4 h-4 text-white/40" aria-hidden />
-          </li>
-          <li className="flex items-center gap-4 py-3 border-b border-white/10">
             <span className="text-amber-400 font-bold text-sm w-12 shrink-0">₱500</span>
-            <span className="flex-1 text-white/85 text-sm sm:text-base">You earn — video interview submission</span>
+            <span className="flex-1 text-white/85 text-sm sm:text-base">You earn — 50% of every website you sell (₱500 at the starter price, up to ₱2,500 as you unlock higher pricing)</span>
             <ArrowRight className="w-4 h-4 text-white/40" aria-hidden />
           </li>
           <li className="flex items-center gap-4 py-3 border-b border-white/10">
@@ -165,8 +160,8 @@ export default function CreatorEarningFlow() {
             <ArrowRight className="w-4 h-4 text-white/40" aria-hidden />
           </li>
           <li className="flex items-center gap-4 py-3">
-            <span className="text-white/50 font-bold text-sm w-12 shrink-0">Rest</span>
-            <span className="flex-1 text-white/65 text-sm sm:text-base">AI build cost, hosting, and platform — keeps the system running</span>
+            <span className="text-white/50 font-bold text-sm w-12 shrink-0">50%</span>
+            <span className="flex-1 text-white/65 text-sm sm:text-base">Platform share — AI build cost, hosting, and platform keeps the system running</span>
           </li>
         </ul>
       </div>

--- a/components/landing/EarningsSection.tsx
+++ b/components/landing/EarningsSection.tsx
@@ -31,9 +31,9 @@ export default function EarningsSection() {
                     </div>
                 </div>
 
-                {/* Payout rates — current marketing values */}
+                {/* Payout rates — 50%-of-sale model + referral bonus (see lib/pricing.ts) */}
                 <div
-                    className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12"
+                    className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12"
                     style={{}}
                 >
                     {CREATOR_EARNINGS.map((rate) => {

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -73,7 +73,7 @@ export default function HowItWorks({ door = null }: { door?: "business" | "creat
         "Sign up — no card required until your site is live.",
         "Pick a creator nearby. Or let one find you.",
         "Sit for a short interview. 30 minutes, your shop.",
-        "Approve your site. Pay only once it's live (₱1,000 or ₱1,500).",
+        "Approve your site. Pay only once it's live (₱999 or ₱1,499).",
     ];
     const creator = [
         "Download the app and verify your phone.",

--- a/components/landing/landingData.ts
+++ b/components/landing/landingData.ts
@@ -23,9 +23,10 @@
  *  │  Counter seed values              │  COUNTERS_GROWTH                    │
  *  └──────────────────────────────────────────────────────────────────────────┘
  *
- *  Pricing values mirror the existing landing page (NOT NEO LAB's mock data):
- *    - Business website: ₱1,000 (Standard) / ₱1,500 (With Custom Domain)
- *    - Creator earnings: ₱500 video / ₱300 audio / ₱1,000 referral bonus
+ *  Pricing values mirror the canonical model in lib/pricing.ts (imported below):
+ *    - Business website: ₱999 (Standard) / ₱1,499 (With Custom Domain)
+ *    - Creator earnings: 50% of every sale — ₱500 at the ₱999 base price,
+ *      up to ₱2,500 as higher pricing unlocks · ₱1,000 referral bonus
  *
  *  ADD A NEW LIVE WEBSITE = paste one object into SHOWCASE_SITES below.
  *    - Required: slug, name, tag, category, lat, lng, city
@@ -36,6 +37,8 @@
  *    - Counter increments only when src+url are present (live sites only).
  *    - Drop the screenshot at /public/Pages/<slug>.png.
  */
+
+import { BASE_PRICE, CUSTOM_DOMAIN_PRICE, REFERRAL_BONUS, commissionFor } from "@/lib/pricing";
 
 export type Creator = {
     id: string;
@@ -95,7 +98,7 @@ export const BUSINESS_TIERS = [
     {
         slug: "standard",
         name: "Standard",
-        price: 1000,
+        price: BASE_PRICE,
         tagline: "A page built around the work, not the other way around.",
         ctaLabel: "Get Started",
         ctaHref: "/login",
@@ -112,7 +115,7 @@ export const BUSINESS_TIERS = [
     {
         slug: "custom-domain",
         name: "With Custom Domain",
-        price: 1500,
+        price: CUSTOM_DOMAIN_PRICE,
         tagline: "Your own .com — fully owned, never tied to us.",
         ctaLabel: "Get a Custom Domain",
         ctaHref: "/login",
@@ -130,23 +133,16 @@ export const BUSINESS_TIERS = [
 
 export const CREATOR_EARNINGS = [
     {
-        slug: "video",
-        title: "Video Interview",
-        amount: 500,
-        desc: "Earn directly to your Wise wallet for a successful video interview and 3–5 location photos.",
-        featured: false,
-    },
-    {
-        slug: "audio",
-        title: "Audio Only",
-        amount: 300,
-        desc: "Perfect for camera-shy owners. Record high-quality audio plus 3–5 photos to earn.",
+        slug: "per-submission",
+        title: "Per Submission",
+        amount: commissionFor(BASE_PRICE),
+        desc: "Earn 50% of every website you sell, paid straight to your Wise wallet — ₱500 at the starter price, up to ₱2,500 as you unlock higher pricing. Video or audio capture, same rate.",
         featured: false,
     },
     {
         slug: "referral",
         title: "Referral Bonus",
-        amount: 1000,
+        amount: REFERRAL_BONUS,
         desc: "Invite another creator. When they complete their first paid submission, you get the bonus.",
         featured: true,
     },
@@ -381,7 +377,7 @@ export const FAQ_BUSINESS: FaqEntry[] = [
     { q: "What if I don't like it?", a: "You don't pay until the site is live and you've approved it. If you reject the draft, the creator revises it once for free." },
     { q: "Can I update it later?", a: "Yes — message your creator through the app. Small edits are included for the first year. After that, a flat fee per change." },
     { q: "Who owns the website?", a: "You do. The domain, the photos, the copy — all yours. You can take it elsewhere any time, no penalty." },
-    { q: "How much does it cost?", a: "₱1,000 for a Tendso subdomain site, ₱1,500 if you want a custom domain (.com included for year 1). One-time fee — no monthly hosting bills." },
+    { q: "How much does it cost?", a: "₱999 for a Tendso subdomain site, ₱1,499 if you want a custom domain (.com included for year 1). One-time fee — no monthly hosting bills." },
 ];
 
 // ── Knowledge base seed ────────────────────────────────────────────────────

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -1,6 +1,13 @@
 import { v } from 'convex/values';
 import { query, mutation } from './_generated/server';
 import { internal } from './_generated/api';
+import { PRICE_CEILING, UNLOCK_THRESHOLD } from '../lib/pricing';
+
+// Submission statuses that count as "approved or beyond" for the price-tier
+// unlock — i.e. the creator proved out a real, accepted submission.
+const APPROVED_OR_LATER = new Set<string>([
+    'approved', 'deployed', 'pending_payment', 'paid', 'completed', 'website_generated', 'unpublished',
+]);
 
 // ==================== QUERIES ====================
 
@@ -155,6 +162,28 @@ export const approveSubmission = mutation({
             reviewedBy: args.adminId,
             reviewedAt: Date.now(),
         });
+
+        // Creator-set pricing: unlock the higher price ceiling once the creator
+        // reaches UNLOCK_THRESHOLD approved submissions. Idempotent (only fires
+        // once, guarded by priceUnlockedAt) and additive. See lib/pricing.ts.
+        // `as any`: priceCeiling/priceUnlockedAt are new schema fields; the
+        // committed _generated types lag until `npx convex dev` re-codegens.
+        // This matches the repo's existing cross-deploy `as any` idiom.
+        const creator: any = await ctx.db.get(submission.creatorId);
+        if (creator && !creator.priceUnlockedAt) {
+            const creatorSubs = await ctx.db
+                .query('submissions')
+                .withIndex('by_creator_id', (q) => q.eq('creatorId', submission.creatorId))
+                .collect();
+            const approvedCount = creatorSubs.filter((s) => APPROVED_OR_LATER.has(s.status as string)).length;
+            if (approvedCount >= UNLOCK_THRESHOLD) {
+                await ctx.db.patch(submission.creatorId, {
+                    priceCeiling: PRICE_CEILING,
+                    priceUnlockedAt: Date.now(),
+                    tierChangedBy: args.adminId,
+                } as any);
+            }
+        }
 
         // Audit log
         await ctx.scheduler.runAfter(0, internal.auditLogs.log, {

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -3,6 +3,7 @@ import { internalAction, internalMutation } from './_generated/server'
 import { internal } from './_generated/api'
 import { extractReferenceFromText } from '../lib/payments/referenceCode'
 import { determinePaymentStatus } from '../lib/payments/webhookParser'
+import { REFERRAL_BONUS } from '../lib/pricing'
 
 // ==================== SHARED CREDIT LOGIC ====================
 // Used by both admin.markPaid (manual) and auto-payment (webhook)
@@ -113,7 +114,7 @@ export const creditCreatorForPayment = internalMutation({
             if (paidSubmissions.length <= 1) {
                 await ctx.scheduler.runAfter(0, internal.referrals.qualifyByCreator, {
                     referredId: submission.creatorId,
-                    bonusAmount: 1000,
+                    bonusAmount: REFERRAL_BONUS,
                 })
             }
         }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,21 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+// ==================== KNOWLEDGE BASE ====================
+// Article body is a sequence of typed blocks (mirrors the Claude Design
+// handoff content model in app/knowledge). Keep this in sync with the
+// <Block> renderer in app/knowledge/_components/views.tsx.
+const kbBlock = v.union(
+    v.object({ t: v.literal('p'), text: v.string() }),
+    v.object({ t: v.literal('h2'), text: v.string() }),
+    v.object({ t: v.literal('ul'), items: v.array(v.string()) }),
+    v.object({ t: v.literal('ol'), items: v.array(v.string()) }),
+    v.object({ t: v.literal('callout'), kind: v.string(), text: v.string() }), // kind: "note" | "warn"
+    v.object({ t: v.literal('code'), lang: v.string(), text: v.string() }),
+    v.object({ t: v.literal('quote'), text: v.string(), who: v.string() }),
+    v.object({ t: v.literal('image'), caption: v.string() }),
+);
+
 export default defineSchema({
     // Creators table (users - both creators and admins)
     creators: defineTable({
@@ -14,6 +29,13 @@ export default defineSchema({
         totalEarnings: v.optional(v.number()),
         totalWithdrawn: v.optional(v.number()),
         submissionCount: v.optional(v.number()),
+        // Creator-set pricing band (see lib/pricing.ts). priceCeiling is the max
+        // sell price this creator may charge; it starts at BASE_PRICE and unlocks
+        // to PRICE_CEILING after UNLOCK_THRESHOLD approved submissions.
+        // priceUnlockedAt + tierChangedBy are for audit / admin override.
+        priceCeiling: v.optional(v.number()),
+        priceUnlockedAt: v.optional(v.number()),
+        tierChangedBy: v.optional(v.string()),
         createdAt: v.optional(v.number()),
         updatedAt: v.optional(v.number()),
         lastActiveAt: v.optional(v.number()),
@@ -826,4 +848,80 @@ export default defineSchema({
         windowStart: v.number(),
     })
         .index('by_key', ['key']),
+
+    // ==================== KNOWLEDGE BASE — CATEGORIES ====================
+    // Browse-by-topic groupings. `workspace` splits the public customer Help
+    // Center ("help") from the gated internal field-agent Wiki ("wiki").
+    // `icon` is an icon-name string resolved by app/knowledge Icon component;
+    // `hue` is one of clay|sage|indigo|slate|amber|plum (chip color).
+    knowledgeCategories: defineTable({
+        slug: v.string(),
+        title: v.string(),
+        description: v.string(),
+        icon: v.string(),
+        hue: v.string(),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        order: v.optional(v.number()),
+    })
+        .index('by_slug', ['slug'])
+        .index('by_workspace', ['workspace']),
+
+    // ==================== KNOWLEDGE BASE — ARTICLES ====================
+    knowledgeArticles: defineTable({
+        slug: v.string(),
+        title: v.string(),
+        summary: v.string(),
+        categoryId: v.id('knowledgeCategories'),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        body: v.array(kbBlock),
+        keywords: v.array(v.string()),
+        author: v.string(),
+        readMin: v.number(),
+        popular: v.optional(v.boolean()),
+        status: v.union(v.literal('draft'), v.literal('published')),
+        createdAt: v.number(),
+        updatedAt: v.number(),
+        // Article-helpfulness counters (incremented by recordFeedback)
+        helpfulYes: v.optional(v.number()),
+        helpfulNo: v.optional(v.number()),
+        // RAG: Gemini text-embedding-004 → 768-dim vector. Optional so articles
+        // are insertable before the embedding backfill runs.
+        embedding: v.optional(v.array(v.float64())),
+        embeddingUpdatedAt: v.optional(v.number()),
+    })
+        .index('by_slug', ['slug'])
+        .index('by_workspace_status', ['workspace', 'status'])
+        .index('by_category', ['categoryId'])
+        .index('by_workspace_popular', ['workspace', 'popular'])
+        .vectorIndex('by_embedding', {
+            vectorField: 'embedding',
+            dimensions: 768,
+            filterFields: ['workspace', 'status'],
+        }),
+
+    // ==================== KNOWLEDGE BASE — FAQS ====================
+    knowledgeFaqs: defineTable({
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        question: v.string(),
+        answer: v.string(),
+        linkArticleSlug: v.optional(v.string()),
+        order: v.optional(v.number()),
+    })
+        .index('by_workspace', ['workspace']),
+
+    // ==================== KNOWLEDGE BASE — AI QUERY LOG ====================
+    // Every grounded AI answer (web search box, landing ChatBot, Discord /ask)
+    // is logged here for analytics + content-gap discovery.
+    knowledgeQueries: defineTable({
+        source: v.union(v.literal('web'), v.literal('discord'), v.literal('chatbot')),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        query: v.string(),
+        answer: v.string(),
+        sourceArticleIds: v.array(v.id('knowledgeArticles')),
+        userId: v.optional(v.string()),        // Clerk subject, when signed in
+        discordUserId: v.optional(v.string()),
+        createdAt: v.number(),
+    })
+        .index('by_source', ['source'])
+        .index('by_createdAt', ['createdAt']),
 });

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 import { query, mutation, internalQuery, internalMutation, internalAction } from './_generated/server';
 import { internal } from './_generated/api';
+import { BASE_PRICE, STANDARD_PRICE, UNLOCK_THRESHOLD, commissionFor, ownerTotal } from '../lib/pricing';
 
 // ==================== QUERIES ====================
 
@@ -177,6 +178,33 @@ export const getByStatus = query({
     },
 });
 
+/**
+ * Pricing context for a creator: how many approved submissions they have, and
+ * whether that unlocks the higher price ceiling. Used by the dashboard progress
+ * meter and the review-page price picker. Keep the status set in sync with
+ * admin.ts APPROVED_OR_LATER.
+ */
+export const getPricingContext = query({
+    args: { creatorId: v.id('creators') },
+    handler: async (ctx, args) => {
+        const approvedStatuses = ['approved', 'deployed', 'pending_payment', 'paid', 'completed', 'website_generated', 'unpublished'];
+        const creator: any = await ctx.db.get(args.creatorId);
+        const subs = await ctx.db
+            .query('submissions')
+            .withIndex('by_creator_id', (q) => q.eq('creatorId', args.creatorId))
+            .collect();
+        const approvedCount = subs.filter((s) => approvedStatuses.includes(s.status)).length;
+        const ceiling = creator?.priceCeiling ?? BASE_PRICE;
+        return {
+            approvedCount,
+            priceCeiling: ceiling,
+            unlocked: !!creator?.priceUnlockedAt || ceiling > BASE_PRICE,
+            threshold: UNLOCK_THRESHOLD,
+            basePrice: BASE_PRICE,
+        };
+    },
+});
+
 // ==================== MUTATIONS ====================
 
 /**
@@ -239,8 +267,8 @@ export const create = mutation({
             audioStorageId: args.audioStorageId,
             transcript: args.transcript,
             status: args.status ?? 'draft',
-            amount: args.amount ?? 1000,
-            creatorPayout: args.creatorPayout ?? 500,
+            amount: args.amount ?? STANDARD_PRICE,
+            creatorPayout: args.creatorPayout ?? commissionFor(BASE_PRICE),
         });
 
         // Increment creator's submissionCount and lastActiveAt
@@ -348,6 +376,8 @@ export const setDomainTier = mutation({
         id: v.id('submissions'),
         submissionType: v.union(v.literal('standard'), v.literal('with_custom_domain')),
         requestedDomain: v.optional(v.string()),
+        // Creator-chosen sell price. Clamped server-side to the creator's band.
+        sellPrice: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
         const submission = await ctx.db.get(args.id);
@@ -359,9 +389,18 @@ export const setDomainTier = mutation({
             throw new Error('Custom domain is required for the with_custom_domain tier');
         }
 
+        // Clamp the creator-chosen sell price to their allowed band
+        // [BASE_PRICE, creator.priceCeiling]. Owner pays sellPrice + the domain
+        // add-on; creator commission is 50% of the sell price (the domain is a
+        // registrar pass-through, not commissioned). See lib/pricing.ts.
+        const creator: any = await ctx.db.get(submission.creatorId);
+        const ceiling = creator?.priceCeiling ?? BASE_PRICE;
+        const sellPrice = Math.min(Math.max(Math.round(args.sellPrice ?? BASE_PRICE), BASE_PRICE), ceiling);
+
         const updates: any = {
             submissionType: args.submissionType,
-            amount: isWithDomain ? 1500 : 1000,
+            amount: ownerTotal(sellPrice, args.submissionType),
+            creatorPayout: commissionFor(sellPrice),
             domainStatus: isWithDomain ? 'pending_payment' : 'not_requested',
         };
         if (isWithDomain) {
@@ -417,11 +456,16 @@ export const submit = mutation({
         }
 
         // 1. Update submission status
-        // Preserve tier-based amount set by setDomainTier (₱1,500 for with_custom_domain, ₱1,000 for standard).
-        const hasCustomDomain = (submission as any).submissionType === 'with_custom_domain';
+        // Preserve tier-based amount set by setDomainTier (base + domain add-on
+        // for with_custom_domain, base only for standard). See lib/pricing.ts.
+        const tier = (submission as any).submissionType === 'with_custom_domain'
+            ? 'with_custom_domain'
+            : 'standard';
         await ctx.db.patch(args.id, {
             status: 'submitted',
-            amount: hasCustomDomain ? 1500 : 1000,
+            // Preserve the creator-set amount (from setDomainTier / create);
+            // only fall back to the base tier price if it was never set.
+            amount: submission.amount ?? ownerTotal(BASE_PRICE, tier),
             airtableSyncStatus: 'pending_push',
         });
 

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -138,7 +138,7 @@ interface PaymentLinkEmailData {
     paymentLink: string;
     referenceCode: string;
     platformEmail?: string;
-    customDomain?: string; // If set, template shows breakdown (website ₱1,000 + domain ₱500)
+    customDomain?: string; // If set, template shows breakdown (website ₱999 + domain ₱500)
 }
 
 export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -4,6 +4,7 @@
  */
 
 import { getPaymentConfig } from '@/lib/payment/config'
+import { CUSTOM_DOMAIN_ADDON, formatPHP } from '@/lib/pricing'
 
 const paymentConfig = getPaymentConfig()
 
@@ -241,7 +242,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Website Package</td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">₱1,000</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(amount - CUSTOM_DOMAIN_ADDON)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>
@@ -251,7 +252,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Custom Domain: <strong style="color:#C89548;">${customDomain}</strong></td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">₱500</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(CUSTOM_DOMAIN_ADDON)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,0 +1,92 @@
+/**
+ * ════════════════════════════════════════════════════════════════════════════
+ *  PRICING — SINGLE SOURCE OF TRUTH  (all amounts in PHP ₱)
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ *  Confirmed 2026-06-15 (creator-compensation & pricing strategy call):
+ *
+ *    • Base website price ............ ₱999   (a creator's starting sell price)
+ *    • Creators set their OWN price within a band. The ceiling unlocks from
+ *      ₱999 → ₱4,999 after UNLOCK_THRESHOLD *approved* submissions.
+ *    • Creator commission ............ 50% of the website sell price.
+ *    • Custom domain ................. flat ₱500 add-on (registrar pass-through,
+ *                                      NOT subject to the 50% commission).
+ *    • Referral bonus ................ ₱1,000 on a referred creator's first
+ *                                      paid submission.
+ *
+ *  Change a number HERE and it propagates to the landing pages, the submit
+ *  flow, the payout math, and the transactional emails. Do NOT re-hardcode
+ *  any of these values anywhere else — import from this module instead.
+ *
+ *  Math sanity check (reconciles the meeting):
+ *    commissionFor(999)  = 500   (≈ the old flat video rate — continuous)
+ *    commissionFor(4999) = 2500  (the "₱2,500" that kept recurring in the call)
+ */
+
+/** Default / minimum website sell price. Every creator starts here. */
+export const BASE_PRICE = 999;
+
+/** Maximum a creator may charge once their price ceiling is unlocked. */
+export const PRICE_CEILING = 4999;
+
+/** Number of *approved* submissions that unlocks the full PRICE_CEILING. */
+export const UNLOCK_THRESHOLD = 5;
+
+/** Creator's share of the website sell price (domain add-on excluded). */
+export const COMMISSION_RATE = 0.5;
+
+/** Flat add-on charged to the owner for a custom domain (year 1 + setup). */
+export const CUSTOM_DOMAIN_ADDON = 500;
+
+/** One-time bonus when a referred creator lands their first paid submission. */
+export const REFERRAL_BONUS = 1000;
+
+export type SubmissionTier = 'standard' | 'with_custom_domain';
+
+/** Owner total for the standard tier (no custom domain). */
+export const STANDARD_PRICE = BASE_PRICE; // ₱999
+
+/** Owner total for the base price + a custom domain. */
+export const CUSTOM_DOMAIN_PRICE = BASE_PRICE + CUSTOM_DOMAIN_ADDON; // ₱1,499
+
+/**
+ * A creator's current maximum sell price, given how many *approved*
+ * submissions they have. Below the threshold they're capped at the base price.
+ */
+export function priceCeilingFor(approvedSubmissionCount: number): number {
+    return approvedSubmissionCount >= UNLOCK_THRESHOLD ? PRICE_CEILING : BASE_PRICE;
+}
+
+/** True once a creator has earned the right to charge above the base price. */
+export function isPriceUnlocked(approvedSubmissionCount: number): boolean {
+    return approvedSubmissionCount >= UNLOCK_THRESHOLD;
+}
+
+/**
+ * Clamp a desired sell price into the creator's allowed band:
+ * [BASE_PRICE, priceCeilingFor(approvedSubmissionCount)].
+ */
+export function clampSellPrice(desired: number, approvedSubmissionCount: number): number {
+    const ceiling = priceCeilingFor(approvedSubmissionCount);
+    if (!Number.isFinite(desired)) return BASE_PRICE;
+    return Math.min(Math.max(Math.round(desired), BASE_PRICE), ceiling);
+}
+
+/** Creator's payout = 50% of the website sell price (domain add-on excluded). */
+export function commissionFor(sellPrice: number): number {
+    return Math.round(sellPrice * COMMISSION_RATE);
+}
+
+/** Total the business owner pays = sell price + optional custom-domain add-on. */
+export function ownerTotal(sellPrice: number, tier: SubmissionTier): number {
+    return sellPrice + (tier === 'with_custom_domain' ? CUSTOM_DOMAIN_ADDON : 0);
+}
+
+/**
+ * Format a PHP amount for display, e.g. 999 → "₱999", 4999 → "₱4,999".
+ * Manual thousands-separator (no Intl) so it's safe in the Convex runtime too.
+ */
+export function formatPHP(amount: number): string {
+    const n = Math.round(amount).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return `₱${n}`;
+}


### PR DESCRIPTION
From the 2026-06-15 creator-compensation & pricing strategy meeting. ClickUp: https://app.clickup.com/t/86ca95y0q

## What changed
- **`lib/pricing.ts`** — single source of truth: base **₱999**, ceiling **₱4,999**, **50% commission**, ₱500 custom-domain add-on, unlock after **5 approved** submissions, ₱1,000 referral.
- **Payout model: flat ₱500/₱300 → 50% of the sale** (`convex/submissions.ts`, `convex/payments.ts`).
- **Creator-set price band** — new `creators.priceCeiling/priceUnlockedAt/tierChangedBy`, auto-unlock on the 5th approval (`convex/admin.ts`), `setDomainTier` takes the chosen `sellPrice`, new `getPricingContext` query.
- **Review-page price slider** (₱999–₱4,999 once unlocked) + **dashboard "X/5 to unlock" meter**.
- Price/earning copy updated across landing + email (~14 files).
- **New `/for-field-agents`** recruitment page — SEO, anti-"scam" trust section, 50% earning story, Discord CTA (defaults to discord.gg/Dxjt9HV5B, overridable via `NEXT_PUBLIC_DISCORD_INVITE_URL`).

## Deploy / review notes
- ⚠️ Run **`npx convex dev --once`** to push the new `creators` price-tier fields before the band works.
- ⚠️ **Audio submissions now earn 50% (₱500)** like video — old ₱300 rate removed. Revert is one constant if undesired.
- ⚠️ **`terms-of-service`** comp clause changed → **legal review**.
- `convex/schema.ts` also carries an unrelated knowledge-base block addition that was already in the working tree.

## Verification (local)
`tsc` clean (only pre-existing `tendso-logo.png` module-resolution noise in untouched files) · new files lint-clean, zero new lint errors · `jest` 48 pass / 6 pre-existing `crypto`-env failures in untouched `referenceCode.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)