### PR TITLE
SEO/GEO Track A (AI-crawler visibility) + EN/Tagalog landing localization

### DIFF
--- a/app/knowledge/[slug]/page.tsx
+++ b/app/knowledge/[slug]/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "@/convex/_generated/api";
+import { JsonLd } from "@/components/JsonLd";
+import { knowledgeArticleGraph, abs } from "@/lib/seo";
+
+/**
+ * SSR per-article Knowledge Base route — the crawlable counterpart to the
+ * client SPA at /knowledge.
+ *
+ * Why this exists: AI crawlers (GPTBot, OAI-SearchBot, PerplexityBot, etc.) and
+ * Google AI Overviews do NOT execute JavaScript. The /knowledge SPA is invisible
+ * to them. This route emits the full article text + Article/FAQ/Breadcrumb
+ * JSON-LD in the initial server HTML, so the corpus becomes citable.
+ *
+ * ISR: revalidate hourly so edited articles refresh without a redeploy.
+ */
+export const revalidate = 3600;
+
+type Block = NonNullable<Awaited<ReturnType<typeof getArticle>>>["body"][number];
+
+async function getArticle(slug: string) {
+    return await fetchQuery(api.knowledge.getArticleBySlug, { slug });
+}
+
+export async function generateStaticParams() {
+    // Best-effort prerender list. If Convex is unreachable at build time (or the
+    // function isn't deployed yet), return [] — pages still render on demand via
+    // ISR (dynamicParams defaults to true), so the build never hard-fails on it.
+    try {
+        const slugs = await fetchQuery(api.knowledge.listPublishedHelpSlugs, {});
+        return slugs.map((s) => ({ slug: s.slug }));
+    } catch {
+        return [];
+    }
+}
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+    const { slug } = await params;
+    const a = await getArticle(slug);
+    if (!a) return { title: "Article not found — Tendso Knowledge Base" };
+    const url = abs(`/knowledge/${slug}`);
+    return {
+        title: `${a.title} — Tendso Knowledge Base`,
+        description: a.summary,
+        keywords: a.keywords,
+        alternates: { canonical: url },
+        openGraph: {
+            type: "article",
+            url,
+            title: a.title,
+            description: a.summary,
+            siteName: "Tendso",
+            locale: "en_PH",
+        },
+        twitter: { card: "summary_large_image", title: a.title, description: a.summary },
+    };
+}
+
+function slugifyHeading(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+/** Server-safe renderer for the typed kbBlock body (mirrors the SPA's BlockView). */
+function BlockView({ b }: { b: Block }) {
+    switch (b.t) {
+        case "p":
+            return <p>{b.text}</p>;
+        case "h2":
+            return <h2 id={slugifyHeading(b.text)}>{b.text}</h2>;
+        case "ul":
+            return <ul>{b.items.map((x, i) => <li key={i}>{x}</li>)}</ul>;
+        case "ol":
+            return <ol>{b.items.map((x, i) => <li key={i}>{x}</li>)}</ol>;
+        case "callout":
+            return (
+                <div className={"kb-callout " + b.kind} role="note">
+                    {b.text}
+                </div>
+            );
+        case "code":
+            return <pre><code>{b.text}</code></pre>;
+        case "quote":
+            return (
+                <blockquote>
+                    <p>&ldquo;{b.text}&rdquo;</p>
+                    <cite>{b.who}</cite>
+                </blockquote>
+            );
+        case "image":
+            return <figure><figcaption>{b.caption}</figcaption></figure>;
+        default:
+            return null;
+    }
+}
+
+export default async function KnowledgeArticlePage({
+    params,
+}: {
+    params: Promise<{ slug: string }>;
+}) {
+    const { slug } = await params;
+    const a = await getArticle(slug);
+    if (!a) notFound();
+
+    const jsonLd = knowledgeArticleGraph({
+        slug: a.slug,
+        title: a.title,
+        summary: a.summary,
+        keywords: a.keywords,
+        createdAtMs: a.createdAt,
+        updatedAtMs: a.updatedAt,
+        // faqs[] not on the article yet (P1.7) — FAQPage stays absent until then.
+    });
+
+    return (
+        <main className="mx-auto max-w-3xl px-6 py-12">
+            <JsonLd data={jsonLd} />
+
+            <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-6">
+                <Link href="/" className="hover:underline">Home</Link>
+                {" / "}
+                <Link href="/knowledge" className="hover:underline">Knowledge Base</Link>
+                {" / "}
+                <span className="text-gray-700">{a.title}</span>
+            </nav>
+
+            <article>
+                <header className="mb-8">
+                    <h1 className="text-3xl font-bold text-gray-900">{a.title}</h1>
+                    {/* Answer-first lead: the summary doubles as the extractable answer for AI engines. */}
+                    <p className="text-lg text-gray-600 mt-3">{a.summary}</p>
+                    <p className="text-xs text-gray-400 mt-2">
+                        {a.readMin} min read · Updated {new Date(a.updatedAt).toLocaleDateString("en-PH")}
+                    </p>
+                </header>
+
+                <div className="kb-article-body prose prose-neutral max-w-none">
+                    {a.body.map((b, i) => (
+                        <BlockView key={i} b={b} />
+                    ))}
+                </div>
+            </article>
+
+            <footer className="mt-12 pt-6 border-t border-gray-100">
+                <Link href="/knowledge" className="text-amber-600 hover:underline">
+                    ← Back to the Knowledge Base
+                </Link>
+            </footer>
+        </main>
+    );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import { Toaster } from "sonner";
 import { Analytics } from "@vercel/analytics/react";
 import { ConvexClerkProvider } from "@/components/providers/ConvexClerkProvider";
 import CustomCursor from "@/components/landing/CustomCursor";
+import { JsonLd } from "@/components/JsonLd";
+import { organizationGraph, SITE_URL } from "@/lib/seo";
 import "./globals.css";
 
 const fraunces = Fraunces({
@@ -55,8 +57,19 @@ const onest = Onest({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Tendso — The Thinking Ends Here. So the work doesn't.",
   description: "A business page built around the work, not the other way around. A creator visits, asks a few questions, photographs your shop, and your page goes live in 48 hours. No template, no blank screen. ₱999 one-time. For Filipino local businesses whose hands are full.",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    siteName: "Tendso",
+    locale: "en_PH",
+    url: SITE_URL,
+    title: "Tendso — The Thinking Ends Here. So the work doesn't.",
+    description: "Filipino local businesses get online in 48 hours. ₱999 one-time. Built around the work, not the other way around.",
+  },
+  twitter: { card: "summary_large_image", title: "Tendso", description: "Filipino local businesses get online in 48 hours." },
 };
 
 export default function RootLayout({
@@ -74,6 +87,8 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="apple-mobile-web-app-title" content="Tendso" />
         <link rel="apple-touch-icon" href="/tendso-icon.png" />
+        {/* Platform entity graph — read by AI crawlers from the initial HTML */}
+        <JsonLd data={organizationGraph()} />
       </head>
       <body
         className={`${fraunces.variable} ${plusJakarta.variable} ${playfair.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${onest.variable} antialiased`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { LanguageProvider } from "@/components/landing/i18n";
 import Navbar from "@/components/landing/Navbar";
 import Footer from "@/components/landing/Footer";
 import ScrollToTop from "@/components/landing/ScrollToTop";
@@ -29,6 +30,7 @@ export default function Home() {
     const [selectedBusiness, setSelectedBusiness] = useState<LiveBusiness | null>(null);
 
     return (
+        <LanguageProvider>
         <div className="neo min-h-screen overflow-x-hidden">
             <Navbar />
 
@@ -72,5 +74,6 @@ export default function Home() {
             <BusinessSheet business={selectedBusiness} onClose={() => setSelectedBusiness(null)} />
             <ScrollToTop />
         </div>
+        </LanguageProvider>
     );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,47 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/seo';
+
+/**
+ * robots.txt for the Tendso platform (tendso.com).
+ *
+ * 2025/2026 AI-crawler policy:
+ *  - ALLOW the AI search/retrieval crawlers that CITE sources — being absent
+ *    from these = invisible to ChatGPT/Perplexity/Gemini answers:
+ *      • GPTBot          (OpenAI training)
+ *      • OAI-SearchBot   (ChatGPT search retrieval — a DIFFERENT bot than GPTBot;
+ *                         ChatGPT search also relies on the Bing index → allow Bingbot)
+ *      • ClaudeBot / anthropic-ai / claude-web (Anthropic)
+ *      • Google-Extended (Gemini / AI Overviews opt-in)
+ *      • PerplexityBot   (Perplexity)
+ *      • Bingbot         (Bing index = the ChatGPT-search gate)
+ *  - BLOCK scrapers with no citation/referral value:
+ *      • Bytespider (ByteDance/TikTok), CCBot (Common Crawl)
+ *  - Keep private/app surfaces out of every crawler.
+ */
+
+const PRIVATE_PATHS = ['/api/', '/admin/', '/connect-ai', '/dashboard/', '/wallet', '/submit/'];
+
+const AI_BOTS = [
+    'GPTBot',
+    'OAI-SearchBot',
+    'ClaudeBot',
+    'anthropic-ai',
+    'claude-web',
+    'Google-Extended',
+    'PerplexityBot',
+    'Bingbot',
+];
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: [
+            { userAgent: '*', allow: '/', disallow: [...PRIVATE_PATHS, '/_next/'] },
+            // Explicitly welcome the AI crawlers (same private exclusions).
+            { userAgent: AI_BOTS, allow: '/', disallow: PRIVATE_PATHS },
+            // Block the no-value scrapers entirely.
+            { userAgent: ['Bytespider', 'CCBot'], disallow: '/' },
+        ],
+        sitemap: `${SITE_URL}/sitemap.xml`,
+        host: SITE_URL,
+    };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,50 @@
+import type { MetadataRoute } from "next";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "@/convex/_generated/api";
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * sitemap.xml for tendso.com — static marketing pages + published KB articles.
+ *
+ * Business-profile URLs (/businesses/[slug]) are intentionally NOT here yet:
+ * they need the generatedWebsites.slug field + content gate (Track B / D-E-F),
+ * and listing thin/unvetted pages in the sitemap is a scaled-content risk.
+ *
+ * Revalidates hourly. If the KB query fails, fall back to static-only rather
+ * than throwing (a broken sitemap is worse than a partial one).
+ */
+export const revalidate = 3600;
+
+const STATIC_PATHS: Array<{ path: string; priority: number; freq: MetadataRoute.Sitemap[number]["changeFrequency"] }> = [
+    { path: "/", priority: 1, freq: "weekly" },
+    { path: "/for-business", priority: 0.8, freq: "monthly" },
+    { path: "/for-creators", priority: 0.8, freq: "monthly" },
+    { path: "/for-field-agents", priority: 0.8, freq: "monthly" },
+    { path: "/about", priority: 0.7, freq: "monthly" },
+    { path: "/knowledge", priority: 0.9, freq: "daily" },
+    { path: "/help-faq", priority: 0.6, freq: "monthly" },
+];
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const staticEntries: MetadataRoute.Sitemap = STATIC_PATHS.map((s) => ({
+        url: `${SITE_URL}${s.path}`,
+        changeFrequency: s.freq,
+        priority: s.priority,
+        lastModified: new Date(),
+    }));
+
+    let articleEntries: MetadataRoute.Sitemap = [];
+    try {
+        const slugs = await fetchQuery(api.knowledge.listPublishedHelpSlugs, {});
+        articleEntries = slugs.map((a) => ({
+            url: `${SITE_URL}/knowledge/${a.slug}`,
+            lastModified: new Date(a.updatedAt),
+            changeFrequency: "weekly" as const,
+            priority: 0.7,
+        }));
+    } catch {
+        // Convex unreachable at build/revalidate — ship static-only.
+    }
+
+    return [...staticEntries, ...articleEntries];
+}

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,15 @@
+/**
+ * Renders a Schema.org JSON-LD object as a <script type="application/ld+json">.
+ *
+ * Uses a native <script> (NOT next/script) so the markup is in the initial
+ * server-rendered HTML where AI crawlers — which do NOT execute JavaScript —
+ * can read it. The `<` escape prevents the JSON from breaking out of the tag.
+ */
+export function JsonLd({ data }: { data: unknown }) {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, '\\u003c') }}
+        />
+    );
+}

--- a/components/landing/BusinessPricingSection.tsx
+++ b/components/landing/BusinessPricingSection.tsx
@@ -4,19 +4,21 @@ import Link from "next/link";
 import { BUSINESS_TIERS } from "./landingData";
 import { ArrowUpRightIcon } from "./landingPrimitives";
 import { BASE_PRICE, formatPHP } from "@/lib/pricing";
+import { useT } from "./i18n";
 
 export default function BusinessPricingSection() {
+    const { t } = useT();
     return (
         <section id="for-business" style={{ background: "var(--neo-paper)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ 04 — The price</div>
+                    <div className="eyebrow">{t("price.eyebrow")}</div>
                     <div>
                         <h2 className="display-2">
-                            {formatPHP(BASE_PRICE)} once. <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>Live forever.</em>
+                            {formatPHP(BASE_PRICE)} once. <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>{t("price.liveForever")}</em>
                         </h2>
                         <p className="lede" style={{ marginTop: 12 }}>
-                            One-time payment. No monthly fees. No contracts. You only pay once your website is live and you&apos;ve approved it.
+                            {t("price.lede")}
                         </p>
                     </div>
                 </div>
@@ -101,7 +103,7 @@ export default function BusinessPricingSection() {
                                         color: featured ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)",
                                     }}
                                 >
-                                    One-time · pay only when live
+                                    {t("price.oneTime")}
                                 </div>
 
                                 <ul
@@ -167,7 +169,7 @@ export default function BusinessPricingSection() {
                         color: "var(--neo-ink-3)",
                     }}
                 >
-                    No card on file. No fine print. No charges later. ◆ International pricing matches PH until local launch.
+                    {t("price.footnote")}
                 </div>
             </div>
         </section>

--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 import { ArrowUpRightIcon } from "./landingPrimitives";
+import { useT } from "./i18n";
 
 export default function CtaSection() {
+    const { t } = useT();
     return (
         <section
             style={{
@@ -77,7 +79,7 @@ export default function CtaSection() {
                                 letterSpacing: "-.02em",
                             }}
                         >
-                            I own a business.
+                            {t("cta.business")}
                         </span>
                         <span style={{ fontSize: 13, opacity: 0.8, marginTop: 20 }}>
                             A page built around the work. A creator visits, you keep going, the site goes live.
@@ -106,7 +108,7 @@ export default function CtaSection() {
                                 letterSpacing: "-.02em",
                             }}
                         >
-                            I want to earn.
+                            {t("cta.creator")}
                         </span>
                         <span style={{ fontSize: 13, opacity: 0.8, marginTop: 20 }}>
                             Help owners who can't stop working. Real earnings, real referrals, paid in 48 hours.

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import { useT, type Lang } from "./i18n";
 
 const footColStyle: React.CSSProperties = {
     display: "flex",
@@ -35,17 +36,8 @@ function FootCol({ title, children }: { title: string; children: React.ReactNode
     );
 }
 
-export default function Footer({
-    lang = "en",
-    country = "PH",
-    onLangChange,
-    onCountryChange,
-}: {
-    lang?: string;
-    country?: string;
-    onLangChange?: (v: string) => void;
-    onCountryChange?: (v: string) => void;
-} = {}) {
+export default function Footer() {
+    const { lang, setLang } = useT();
     const apkUrl = useQuery(api.settings.get, { key: "apk_download_url" }) as string | null | undefined;
     return (
         <footer className="neo-footer">
@@ -94,21 +86,10 @@ export default function Footer({
                         <Link href="/terms-of-service">Terms</Link>
                         <Link href="/contact">Contact</Link>
                     </FootCol>
-                    <FootCol title="Region">
-                        <select
-                            value={country}
-                            onChange={(e) => onCountryChange?.(e.target.value)}
-                            style={footSelStyle}
-                            aria-label="Country"
-                        >
-                            <option value="PH">🇵🇭 Philippines</option>
-                            <option value="ID">🇮🇩 Indonesia</option>
-                            <option value="MX">🇲🇽 Mexico</option>
-                            <option value="VN">🇻🇳 Vietnam</option>
-                        </select>
+                    <FootCol title="Language">
                         <select
                             value={lang}
-                            onChange={(e) => onLangChange?.(e.target.value)}
+                            onChange={(e) => setLang(e.target.value as Lang)}
                             style={footSelStyle}
                             aria-label="Language"
                         >

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useTickUp, ArrowDownIcon, ArrowUpRightIcon } from "./landingPrimitives";
 import { fmt, COUNTERS_GROWTH, HARDCODED_LIVE_SITE_COUNT } from "./landingData";
+import { useT } from "./i18n";
 
 // Live clock that only renders post-mount to avoid SSR/CSR hydration mismatch.
 // The server has no way to know the client's "now" within the same minute, so
@@ -45,24 +46,6 @@ function IssueDate() {
     return <>{label ?? " "}</>;
 }
 
-// Tendso campaign: Hands Full. The Thinking Ends Here. So the work doesn't.
-// Voice: respect for the doer; the page is built around the work, not the
-// other way around. Per docs/changes/TENDSO-REBRAND-LANDING-COPY.md (the
-// Tend "Hands Full" treatment PDF).
-const T = {
-    hero_main: ["Some hands", "don't get to ", "sit still", "."] as const,
-    hero_main_em: "The Thinking Ends Here. So the work doesn't.",
-    hero_lede:
-        "Your hands are full of customers, orders, tools, dough, kids. The internet asks you to stop and design. We built around that — a creator visits, asks a few questions, photographs the work, and your page forms around it. Live in 48 hours. No template. No design tab. No blank page.",
-    door_business: "I own a business",
-    door_business_sub: "Page built around my work",
-    door_creator: "I want to earn",
-    door_creator_sub: "Become a certified creator",
-    counter_creators: "creators",
-    counter_businesses: "live sites",
-    counter_cities: "cities",
-    counter_countries: "countries",
-};
 
 function CounterRow({ value, label, last }: { value: number; label: string; last?: boolean }) {
     return (
@@ -129,6 +112,22 @@ export default function HeroSection() {
     // from the SHOWCASE_SITES list in landingData.ts (single source of truth).
     const liveCreators = useQuery(api.creators.count, {}) as number | undefined;
 
+    const { t } = useT();
+    // Localized copy, shaped to match the field names the JSX below already uses.
+    const T = {
+        hero_main: [t("hero.h1a"), t("hero.h1b"), t("hero.h1c"), "."] as const,
+        hero_main_em: t("hero.em"),
+        hero_lede: t("hero.lede"),
+        door_business: t("hero.doorBusiness"),
+        door_business_sub: t("hero.doorBusinessSub"),
+        door_creator: t("hero.doorCreator"),
+        door_creator_sub: t("hero.doorCreatorSub"),
+        counter_creators: t("hero.counterCreators"),
+        counter_businesses: t("hero.counterBusinesses"),
+        counter_cities: t("hero.counterCities"),
+        counter_countries: t("hero.counterCountries"),
+    };
+
     const creators = useTickUp(liveCreators ?? COUNTERS_GROWTH.creators);
     const businesses = useTickUp(HARDCODED_LIVE_SITE_COUNT);
     const cities = useTickUp(COUNTERS_GROWTH.cities);
@@ -154,7 +153,7 @@ export default function HeroSection() {
                             }}
                         >
                             <span className="live-dot"></span>
-                            Issue No. 01 · <IssueDate />
+                            {t("hero.issue")} · <IssueDate />
                         </div>
                         <h1 className="display">
                             {hm[0]}
@@ -178,11 +177,11 @@ export default function HeroSection() {
                         </p>
                         <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 28 }}>
                             {[
-                                "Photo. Answers. Live page.",
-                                "No template",
-                                "No blank screen",
-                                "Built around the work",
-                                "Live in 48 hours",
+                                t("hero.tag1"),
+                                t("hero.tag2"),
+                                t("hero.tag3"),
+                                t("hero.tag4"),
+                                t("hero.tag5"),
                             ].map((p) => (
                                 <span
                                     key={p}
@@ -223,21 +222,21 @@ export default function HeroSection() {
                 </div>
 
                 <div className="pt-8" style={{ borderTop: "1px solid var(--neo-rule-strong)" }}>
-                    <div className="label" style={{ marginBottom: 16 }}>Pick a door</div>
+                    <div className="label" style={{ marginBottom: 16 }}>{t("hero.pickDoor")}</div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
                         <DoorButton
                             kind="business"
                             href="/for-business"
                             sub={T.door_business_sub}
                             title={T.door_business}
-                            note="Keep cutting, kneading, packing, answering. A creator handles the rest and shows up at your shop within 10 km."
+                            note={t("hero.doorBusinessNote")}
                         />
                         <DoorButton
                             kind="creator"
                             href="/for-creators"
                             sub={T.door_creator_sub}
                             title={T.door_creator}
-                            note="Help owners who can't stop working. ₱500 per video, ₱300 per audio, ₱1,000 per referral. Paid in 48 hours."
+                            note={t("hero.doorCreatorNote")}
                         />
                     </div>
                     <div
@@ -251,7 +250,7 @@ export default function HeroSection() {
                         }}
                     >
                         <ArrowDownIcon />
-                        <span>Or scroll — find creators near you on the map below.</span>
+                        <span>{t("hero.scroll")}</span>
                     </div>
                 </div>
             </div>

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -79,7 +79,7 @@ export default function HowItWorks({ door = null }: { door?: "business" | "creat
         "Download the app and verify your phone.",
         "Get certified — free, fast, in 20 minutes.",
         "Visit local businesses with guided capture.",
-        "Earn ₱500 per video · ₱300 audio · ₱1,000 referral.",
+        "Keep 50% of every sale — ₱500 to ₱2,500 per site · ₱1,000 referral.",
     ];
     const businessFirst = door !== "creator";
 

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Logo, ArrowUpRightIcon } from "./landingPrimitives";
+import { useT, type Lang } from "./i18n";
 
 const selectStyle: React.CSSProperties = {
     appearance: "none",
@@ -19,17 +20,8 @@ const selectStyle: React.CSSProperties = {
     borderRadius: 8,
 };
 
-export default function Navbar({
-    lang = "en",
-    country = "PH",
-    onLangChange,
-    onCountryChange,
-}: {
-    lang?: string;
-    country?: string;
-    onLangChange?: (v: string) => void;
-    onCountryChange?: (v: string) => void;
-} = {}) {
+export default function Navbar() {
+    const { lang, setLang, t } = useT();
     // Direct APK download URL (admin uploads via /admin/app-release).
     // Falls back to /signup if no APK is currently uploaded. The URL points
     // straight at the R2 public URL — R2 derives the download filename from
@@ -49,36 +41,25 @@ export default function Navbar({
                     <Link href="/" style={{ textDecoration: "none" }} className="flex-shrink-0">
                         <Logo />
                     </Link>
-                    {/* "Live in Philippines · expanding" — hide on <md to avoid wrap/overflow */}
+                    {/* Region label — hide on <md to avoid wrap/overflow. (Region
+                        dropdown removed: PH-only for now; this label states it.) */}
                     <div className="label items-center gap-2 hidden md:flex">
                         <span className="live-dot"></span>
-                        Live in Philippines · expanding
+                        {t("nav.live")}
                     </div>
                 </div>
 
-                {/* Right cluster — selects hide on phones, Get-the-app always visible */}
+                {/* Right cluster — language switch hides on phones, Get-the-app always visible */}
                 <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
                     <select
                         value={lang}
-                        onChange={(e) => onLangChange?.(e.target.value)}
+                        onChange={(e) => setLang(e.target.value as Lang)}
                         style={selectStyle}
                         aria-label="Language"
                         className="hidden sm:inline-block"
                     >
                         <option value="en">EN</option>
                         <option value="tl">Tagalog</option>
-                    </select>
-                    <select
-                        value={country}
-                        onChange={(e) => onCountryChange?.(e.target.value)}
-                        style={selectStyle}
-                        aria-label="Country"
-                        className="hidden md:inline-block"
-                    >
-                        <option value="PH">🇵🇭 Philippines</option>
-                        <option value="ID">🇮🇩 Indonesia</option>
-                        <option value="MX">🇲🇽 Mexico</option>
-                        <option value="VN">🇻🇳 Vietnam</option>
                     </select>
                     <a
                         href={downloadHref}
@@ -88,7 +69,7 @@ export default function Navbar({
                         className="store-btn whitespace-nowrap"
                         style={{ textDecoration: "none", padding: "10px 14px" }}
                     >
-                        <span>Get the app</span>
+                        <span>{t("nav.getApp")}</span>
                         <span style={{ opacity: 0.6 }}>
                             <ArrowUpRightIcon />
                         </span>

--- a/components/landing/i18n.tsx
+++ b/components/landing/i18n.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * Lightweight EN/Tagalog localization for the public landing page.
+ *
+ * The landing is static marketing (no per-request data), so a full i18n library
+ * is overkill. This is a React context + a `useT()` hook returning `t(key)`.
+ * The chosen language persists in localStorage and is read on mount.
+ *
+ * Adding copy: add the key to BOTH `en` and `tl` below, then call `t("key")`
+ * in the component. A missing `tl` value falls back to `en`, so partial
+ * translation never shows a blank — it shows English until the Tagalog lands.
+ *
+ * Tagalog copy here is natural Taglish (how the audience actually speaks);
+ * brand terms (Tendso, ₱, Wise, Gemini) stay verbatim. Have a native speaker
+ * review before treating it as final marketing copy.
+ */
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type Lang = "en" | "tl";
+
+type Dict = Record<string, string>;
+
+const EN: Dict = {
+    // Navbar
+    "nav.live": "Live in Philippines · expanding",
+    "nav.getApp": "Get the app",
+
+    // Hero
+    "hero.issue": "Issue No. 01",
+    "hero.h1a": "Some hands",
+    "hero.h1b": "don't get to ",
+    "hero.h1c": "sit still",
+    "hero.em": "The Thinking Ends Here. So the work doesn't.",
+    "hero.lede":
+        "Your hands are full of customers, orders, tools, dough, kids. The internet asks you to stop and design. We built around that — a creator visits, asks a few questions, photographs the work, and your page forms around it. Live in 48 hours. No template. No design tab. No blank page.",
+    "hero.tag1": "Photo. Answers. Live page.",
+    "hero.tag2": "No template",
+    "hero.tag3": "No blank screen",
+    "hero.tag4": "Built around the work",
+    "hero.tag5": "Live in 48 hours",
+    "hero.pickDoor": "Pick a door",
+    "hero.doorBusiness": "I own a business",
+    "hero.doorBusinessSub": "Page built around my work",
+    "hero.doorBusinessNote":
+        "Keep cutting, kneading, packing, answering. A creator handles the rest and shows up at your shop within 10 km.",
+    "hero.doorCreator": "I want to earn",
+    "hero.doorCreatorSub": "Become a certified creator",
+    // NOTE: this replaces the stale "₱500 video / ₱300 audio" line with the 50% model.
+    "hero.doorCreatorNote":
+        "Help owners who can't stop working. Keep 50% of every site you sell — from ₱500 up to ₱2,500, plus ₱1,000 per referral. Paid in 48 hours.",
+    "hero.scroll": "Or scroll — find creators near you on the map below.",
+    "hero.counterCreators": "creators",
+    "hero.counterBusinesses": "live sites",
+    "hero.counterCities": "cities",
+    "hero.counterCountries": "countries",
+
+    // Business pricing
+    "price.eyebrow": "§ 04 — The price",
+    "price.liveForever": "Live forever.",
+    "price.lede":
+        "One-time payment. No monthly fees. No contracts. You only pay once your website is live and you've approved it.",
+    "price.oneTime": "One-time · pay only when live",
+    "price.footnote":
+        "No card on file. No fine print. No charges later. ◆ International pricing matches PH until local launch.",
+
+    // CTA
+    "cta.title": "Your work deserves a page.",
+    "cta.subtitle": "Live in 48 hours. Pay only when you're happy with it.",
+    "cta.business": "I own a business",
+    "cta.creator": "I want to earn as a creator",
+
+    // FAQ
+    "faq.title": "Questions, answered.",
+};
+
+const TL: Dict = {
+    // Navbar
+    "nav.live": "Live sa Pilipinas · palawak pa",
+    "nav.getApp": "Kunin ang app",
+
+    // Hero
+    "hero.issue": "Isyu Blg. 01",
+    "hero.h1a": "May mga kamay",
+    "hero.h1b": "na hindi ",
+    "hero.h1c": "mapakali",
+    "hero.em": "Dito nagtatapos ang isip. Para hindi matigil ang trabaho.",
+    "hero.lede":
+        "Puno ang kamay mo ng customer, order, gamit, masa, anak. Ang internet, gusto kang patigilin para mag-design. Doon kami umangkop — may creator na bibisita, magtatanong, kukuha ng litrato ng trabaho mo, at bubuo ng page paligid niyan. Live sa loob ng 48 oras. Walang template. Walang design tab. Walang blangkong page.",
+    "hero.tag1": "Litrato. Sagot. Live na page.",
+    "hero.tag2": "Walang template",
+    "hero.tag3": "Walang blangkong screen",
+    "hero.tag4": "Binuo sa trabaho mo",
+    "hero.tag5": "Live sa 48 oras",
+    "hero.pickDoor": "Pumili ng pinto",
+    "hero.doorBusiness": "May negosyo ako",
+    "hero.doorBusinessSub": "Page na binuo sa trabaho ko",
+    "hero.doorBusinessNote":
+        "Ituloy mo lang ang paggupit, pagmasa, pag-empake, pagsagot. Ang creator ang bahala sa iba at pupunta sa tindahan mo sa loob ng 10 km.",
+    "hero.doorCreator": "Gusto kong kumita",
+    "hero.doorCreatorSub": "Maging certified creator",
+    "hero.doorCreatorNote":
+        "Tulungan ang mga may-ari na hindi makatigil sa trabaho. Panatilihin ang 50% ng bawat site na maibenta mo — mula ₱500 hanggang ₱2,500, plus ₱1,000 kada referral. Bayad sa loob ng 48 oras.",
+    "hero.scroll": "O mag-scroll — hanapin ang mga creator malapit sa'yo sa mapa sa ibaba.",
+    "hero.counterCreators": "mga creator",
+    "hero.counterBusinesses": "live na site",
+    "hero.counterCities": "mga lungsod",
+    "hero.counterCountries": "mga bansa",
+
+    // Business pricing
+    "price.eyebrow": "§ 04 — Ang presyo",
+    "price.liveForever": "Live habambuhay.",
+    "price.lede":
+        "Isang bayad lang. Walang buwanang bayad. Walang kontrata. Magbabayad ka lang kapag live na ang website mo at na-approve mo na.",
+    "price.oneTime": "Isang beses · bayad lang kapag live na",
+    "price.footnote":
+        "Walang card na nakatago. Walang maliit na letra. Walang sorpresang singil. ◆ Pantay ang presyo sa ibang bansa sa PH hanggang sa lokal na launch.",
+
+    // CTA
+    "cta.title": "May karapatan ang trabaho mo sa sariling page.",
+    "cta.subtitle": "Live sa 48 oras. Magbayad lang kapag masaya ka na dito.",
+    "cta.business": "May negosyo ako",
+    "cta.creator": "Gusto kong kumita bilang creator",
+
+    // FAQ
+    "faq.title": "Mga tanong, nasagot na.",
+};
+
+const DICTS: Record<Lang, Dict> = { en: EN, tl: TL };
+
+interface LangCtx {
+    lang: Lang;
+    setLang: (l: Lang) => void;
+    t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LangCtx | null>(null);
+
+const STORAGE_KEY = "tendso.lang";
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+    const [lang, setLangState] = useState<Lang>("en");
+
+    // Read persisted choice on mount (client-only, avoids SSR mismatch).
+    useEffect(() => {
+        try {
+            const saved = localStorage.getItem(STORAGE_KEY);
+            if (saved === "en" || saved === "tl") setLangState(saved);
+        } catch {
+            /* localStorage unavailable — stay on default */
+        }
+    }, []);
+
+    const setLang = (l: Lang) => {
+        setLangState(l);
+        try {
+            localStorage.setItem(STORAGE_KEY, l);
+        } catch {
+            /* ignore */
+        }
+    };
+
+    const t = (key: string): string => {
+        return DICTS[lang][key] ?? EN[key] ?? key; // tl → en → raw key
+    };
+
+    return (
+        <LanguageContext.Provider value={{ lang, setLang, t }}>
+            {children}
+        </LanguageContext.Provider>
+    );
+}
+
+/** Access the active language + translator. Safe outside a provider (defaults to EN). */
+export function useT(): LangCtx {
+    const ctx = useContext(LanguageContext);
+    if (!ctx) {
+        // Fallback so a component used outside the provider never crashes.
+        return { lang: "en", setLang: () => {}, t: (k) => EN[k] ?? k };
+    }
+    return ctx;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as leadNotes from "../leadNotes.js";
 import type * as leads from "../leads.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_cloudflare from "../lib/cloudflare.js";
+import type * as lib_encryption from "../lib/encryption.js";
 import type * as lib_fxRate from "../lib/fxRate.js";
 import type * as lib_h3 from "../lib/h3.js";
 import type * as lib_hostinger from "../lib/hostinger.js";
@@ -88,6 +89,7 @@ declare const fullApi: ApiFromModules<{
   leads: typeof leads;
   "lib/auth": typeof lib_auth;
   "lib/cloudflare": typeof lib_cloudflare;
+  "lib/encryption": typeof lib_encryption;
   "lib/fxRate": typeof lib_fxRate;
   "lib/h3": typeof lib_h3;
   "lib/hostinger": typeof lib_hostinger;

--- a/convex/knowledge.ts
+++ b/convex/knowledge.ts
@@ -92,6 +92,43 @@ export const listArticles = query({
     },
 });
 
+/**
+ * One published article by slug (for the SSR /knowledge/[slug] route).
+ * Returns null for missing/draft articles, or for a gated wiki article the
+ * current viewer can't read. Never ships the embedding vector.
+ */
+export const getArticleBySlug = query({
+    args: { slug: v.string() },
+    handler: async (ctx, args) => {
+        const article = await ctx.db
+            .query('knowledgeArticles')
+            .withIndex('by_slug', (q) => q.eq('slug', args.slug))
+            .first();
+        if (!article || article.status !== 'published') return null;
+        if (!(await ensureWorkspaceReadable(ctx, article.workspace))) return null;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { embedding, embeddingUpdatedAt, ...rest } = article;
+        return rest;
+    },
+});
+
+/**
+ * Slugs of all published HELP articles — for generateStaticParams on the SSR
+ * route. Help workspace only (wiki is gated and must not be statically built).
+ */
+export const listPublishedHelpSlugs = query({
+    args: {},
+    handler: async (ctx) => {
+        const articles = await ctx.db
+            .query('knowledgeArticles')
+            .withIndex('by_workspace_status', (q) =>
+                q.eq('workspace', 'help').eq('status', 'published'),
+            )
+            .collect();
+        return articles.map((a) => ({ slug: a.slug, updatedAt: a.updatedAt }));
+    },
+});
+
 /** FAQs in a workspace, ordered. Wiki gated. */
 export const listFaqs = query({
     args: { workspace: workspaceArg },

--- a/docs/changes/GEO-SEO-REALITY-CHECK.md
+++ b/docs/changes/GEO-SEO-REALITY-CHECK.md
@@ -1,0 +1,180 @@
+# GEO/SEO Plan — Reality-Check & Scoped P0
+
+**Date:** 2026-06-18
+**Re:** ClickUp 86ca9u21z — "Tendso GEO + SEO Strategy & Implementation Plan (AI IDEA — UNVERIFIED)"
+**This doc is:** the first deliverable the ticket asked for — a codebase-verified reality check on the AI plan, OQ recommendations, and a scoped P0 sprint. **Not** an endorsement of the whole flywheel.
+
+> Method: every load-bearing technical claim in the plan was checked against the real code (file:line). Verdicts below. Where the plan and reality disagree, reality wins — as the ticket instructed.
+
+---
+
+## 1. Verdict on the plan's own codebase claims (C1–C6)
+
+The plan already flagged these as "corrections from an audit." My independent check against the code:
+
+| # | Plan's corrected claim | My verdict | Evidence |
+|---|---|---|---|
+| **C1** | No shared Astro `<head>`; 15 page components each emit their own `<!DOCTYPE>/<head>`; BaseLayout unused | ✅ **TRUE** | 15 variants (PageA–O) in `astro-site-template/src/`; `index.astro:24-25` explicitly says they "do not compose with BaseLayout"; `BaseLayout.astro` is orphaned. The `<SiteHead>` refactor (P0.8) is real and is **15 files**, not one. |
+| **C2** | Deployed Worker ignores the request, serves ONE HTML string for all paths | ✅ **TRUE** | `app/api/publish-website/route.ts:179-191` — Worker embeds one `const html` and returns it for every request; Astro builds `output: 'static'` → single `index.html`. Per-site `robots.txt`/`sitemap.xml`/`llms.txt`/IndexNow-key files would all 404-to-homepage. |
+| **C3** | `generatedWebsites` has no `slug`; city/category/coords live on `submissions`; `listPublished` is a full-scan + N+1 join | ✅ **TRUE** | `convex/schema.ts:193-269` (no slug); `generatedWebsites.ts:123-149` (`.filter()` no index = full scan; `ctx.db.get(submissionId)` in the loop = N+1). |
+| **C4** | KB queries are `api.knowledge.listArticles({workspace})`; `by_slug` index exists; no public `getBySlug` | ✅ **TRUE** | `convex/knowledge.ts:74-93`; `by_slug` index at `schema.ts:892`; no `getArticleBySlug` export. |
+| **C5** | KB `body` is a typed `kbBlock[]` (not HTML); no `faqs` field; `updatedAt` exists | ✅ **TRUE** | `schema.ts:8-17` (kbBlock union), `:876` (body array), no `faqs` on the article (separate `knowledgeFaqs` table at `:906`), `updatedAt` at `:883`. |
+| **C6** | Sites deploy as one Worker per business on `*.workers.dev`; no wildcard `*.tendso.ph` router | ✅ **TRUE** | `publish-website/route.ts:74-84` → `https://{worker}.{subdomain}.workers.dev`. No wildcard router exists. |
+
+**Bottom line: the plan's C1–C6 corrections are all accurate.** The AI plan is unusually self-aware — it already caught its own worst factual errors. That raises my confidence in proceeding, *carefully*.
+
+## 2. Extra facts the audit surfaced (things the plan assumes but didn't fully verify)
+
+| Assumption in the plan | Reality | Impact on the plan |
+|---|---|---|
+| Reuse existing 768-dim Gemini vectors for the uniqueness gate | ✅ **Exists** — `knowledgeArticles.by_embedding` vector index (768d), `knowledgeAI.ts:46`. **But** it's wired for KB articles, not generated sites. | The embedding *infra* is proven (we just used it for the KB). Reusing it for site-uniqueness (P0.10) means a **new** vector index on generated-site content + the embed pipeline — not free, but the pattern is established. |
+| `googlePlaceId` available for `aggregateRating` matching (P1.6) | ⚠️ **Only on `prospects` and `leads` tables**, not `submissions`/`generatedWebsites`. | The submissions↔prospects fuzzy-match (P1.6) is required, not optional — there's no direct join. Confirms the plan's ≤50m matcher is real work. |
+| `services` for schema `hasOfferCatalog` | On `generatedWebsites` (`:255`), **not** `submissions`. | Fine, but the directory denormalization (C3) must pull from both tables. |
+| Zero existing structured data | ✅ **TRUE** — grep for `application/ld+json` / `schema.org` / `LocalBusiness` = **0 hits** anywhere. | Greenfield. Nothing to migrate; also nothing to break. |
+| No `robots.ts` / `sitemap.ts` / `/knowledge/[slug]` route today | ✅ **TRUE** — `/knowledge` is a single client SPA page; no dynamic article route. | P0.2/P0.3/P0.11 are all net-new files. Low regression risk. |
+
+**One correction to the plan itself:** the plan calls C2 a problem to "fix." It's not a bug — it's a deliberate single-page static design. The right read (which the plan's C2 row actually lands on): **don't try to serve per-site SEO files from the Worker; serve robots/IndexNow-key from the platform domain only.** Agreed.
+
+## 3. The honest strategic assessment (pressure-testing the bet)
+
+The ticket asked me to pressure-test the *big bet*, not just the file paths. My take:
+
+**What's genuinely strong and low-risk — do it regardless of the flywheel:**
+- **KB SSR conversion (P0.11).** The KB is a client-side SPA today → invisible to every AI crawler (they don't run JS). We *just* seeded 23 articles + embeddings. Converting to SSR is pure upside, no scaled-content risk (it's real human/RAG content on one domain), and it directly serves the "how do I get my barbershop online" queries. **Highest ROI, lowest risk item in the entire plan.**
+- **Platform schema + robots + sitemap + OG (P0.2–P0.7).** Standard hygiene on `tendso.app`. Greenfield, additive, can't backfire. The plan's per-engine bot allowlist (allow GPTBot/OAI-SearchBot/ClaudeBot/Google-Extended/PerplexityBot/Bingbot; block Bytespider/CCBot) is sound.
+- **Astro `<SiteHead>` schema bake (P0.8).** Genuine multiplier — fixes every future site once. But it's a **15-component refactor (XL)**, confirmed by C1. Not a quick win.
+
+**What is bet-the-company risky and must NOT ship naively:**
+- **The "1000s of unique AI sites build authority" core bet.** This is *exactly* the scaled-content pattern Google's enforcement targets. It only survives behind the **content gate (P0.10)** — completeness + embedding-uniqueness + owner-verified facts + structural variation. **My position: the gate is not a feature of this plan, it is the precondition for shipping any of the site-generation SEO at all.** Without it, baking schema into 1000s of near-dup sites *accelerates* a penalty rather than helping.
+- **The directory (P1.2).** Empty/thin city pages are doorway content by definition. The plan's "gate go-live on ≥20 real businesses/city" is correct and non-negotiable. We don't have that inventory yet, so **P1.2 is not a near-term item regardless of sprint capacity.**
+- **The footer backlink (P1.3).** `nofollow sponsored`, homepage-only, rotated anchors — the plan is right that a dofollow exact-match variant across thousands of sites is a textbook PBN trigger. Easy to get wrong; cheap to get right.
+
+**What I'd deprioritize / not build yet:**
+- **Wikidata (P2.1)** — premature; needs independent coverage first (OQ-11). The plan agrees.
+- **AI-citation dashboard (P2.5)** — the plan itself flags the unit economics are unvalidated and tooling may cost more than the ₱1,500 tier. Don't build before the 5-business pilot.
+- **`*.tendso.ph` migration (P0.1)** — this is an **architecture rewrite of `publish-website`** (C6: per-site Workers → wildcard router Worker reading `Host`), plus Cloudflare-for-SaaS SSL cost. It's a real project, not a toggle. It gates the *client-site* authority work but **not** the platform/KB work.
+
+## 4. The key insight that reorders the plan
+
+**The plan's critical path front-loads P0.1 (the domain/router rewrite) because "every `@id` depends on it."** That's true for *client sites*. But it's the single biggest, riskiest piece — and it does **not** block the highest-ROI work (KB SSR + platform schema, which live on `tendso.app`, already a real domain post-migration).
+
+So I'd **split the plan into two independent tracks** rather than one P0.1-gated chain:
+
+- **Track A — Platform & KB (ship now, zero architecture risk):** KB SSR, platform schema/robots/sitemap/OG, GSC/Bing setup. None of this touches the Worker rewrite. Delivers the "people + AI find Tendso" goal (Goal A) on its own.
+- **Track B — Client-site SEO (gated on the hard prerequisites):** the `<SiteHead>` refactor, the content gate, and the `*.tendso.ph` migration. This is where the bet-the-company risk lives; it should not start until OQ-1/2/4/5 are decided and the content gate is built.
+
+This lets us capture the safe wins immediately while the risky architecture decisions get made deliberately.
+
+---
+
+## 5. Recommended answers to the Open Questions
+
+| OQ | Question | My recommendation |
+|---|---|---|
+| **OQ-1** | Canonical platform domain: `tendso.app` vs `tendso.ph`? | **`tendso.com`** — *neither of the plan's options.* You just migrated the whole platform to **`tendso.com`** (Vercel + Clerk + DNS, done this week). The plan assumed `tendso.app`, which doesn't reflect reality. Platform `@id`s should be `https://tendso.com/#...`. **This is the most important correction in this whole note** — the plan hard-codes the wrong domain everywhere. |
+| **OQ-2** | Client-site domain + serving architecture | `<slug>.tendso.ph` subdomains via a **single wildcard router Worker** (reads `Host`, serves HTML from Convex/KV). Avoids per-client SSL cost. Defer client custom-domain (Cloudflare-for-SaaS) to a paid upsell. **But** confirm you own/want `tendso.ph` as the client-site domain vs a subdomain of `tendso.com` (e.g. `<slug>.sites.tendso.com`) — a subpath/subdomain of the domain you already control sidesteps a second DNS+SSL setup entirely. **Recommend `<slug>.sites.tendso.com`** unless there's a reason to keep `.ph`. |
+| **OQ-3** | Gate the directory? | Public, but PDPA-check publishing owner NAP. Moot until inventory exists. |
+| **OQ-4** | Cloudflare spend | The wildcard-router model (one cert) avoids the per-host SSL blowup. Approve Workers Paid; defer Cloudflare-for-SaaS until custom-domain upsell is real. |
+| **OQ-5** | Migrate existing `*.workers.dev` sites? | How many live paid sites exist today? If few (likely, given launch stage), **net-new on the new domain + 301 the handful of existing ones.** Decide with the real count. |
+| **OQ-10** | Content language per region | We just built EN/Tagalog landing localization. The plan's point stands: **Cebu/Lapu-Lapu are Cebuano, not Tagalog** — don't assert `fil` for Visayan businesses. Map region→locale from `submissions.city`/`province`. |
+| **OQ-11** | Independent coverage of Tendso exists? | Almost certainly **no** (pre-launch). → Wikidata (P2.1) is premature. Skip for now. |
+| OQ-6/7/8/9/12 | rating-match threshold / IndexNow throughput / faqs backfill / PR owner / governance owners | All P1+ — decide when those phases are scoped, not now. |
+
+---
+
+## 6. Scoped P0 sprint (what I'd actually build first)
+
+Ordered by **(safe + high-ROI) first**, deferring the architecture rewrite:
+
+**Sprint 1 — Platform & KB visibility (Track A, all low-risk, all on `tendso.com`):**
+1. **`app/robots.ts`** — allow the 6 AI bots, block Bytespider/CCBot, disallow `/api`/`/admin`/`/connect-ai`/`/dashboard`. (S)
+2. **Organization + WebSite JSON-LD** in `app/layout.tsx`, `@id` = `https://tendso.com/#...`. (S)
+3. **`convex/knowledge.getArticleBySlug`** (public query; `by_slug` index exists). (S)
+4. **`app/knowledge/[slug]/page.tsx`** — SSR per-article + `kbBlock`→React renderer + Article/Breadcrumb JSON-LD. *The highest-ROI item.* (L)
+5. **`app/sitemap.ts`** — static + KB articles (defer business profiles until slug exists). (M)
+6. **GSC + Bing Webmaster** verification for `tendso.com` + submit sitemap + AI-citation baseline probes. (S, manual)
+7. SoftwareApplication/Offer + OG/Twitter/canonical sweep. (S/M)
+
+**Sprint 2+ — gated on decisions (Track B):**
+- OQ-1/2/4/5 decided → P0.1 router-Worker rewrite + `slug` field.
+- Content gate (P0.10) — **before** any site-schema scaling.
+- `<SiteHead>` 15-component refactor (P0.8).
+- Then directory/profiles/IndexNow (P1) once inventory + migration exist.
+
+**Do NOT start Track B before the content gate exists and the domain architecture is decided.** That's the line between a flywheel and a de-indexed link farm.
+
+---
+
+## 7. Open questions back to Theo/Steven (blockers for Track B)
+
+1. **Domain reality:** the plan says `tendso.app`; you migrated to **`tendso.com`**. Confirm `tendso.com` is canonical, and decide the client-site domain (`<slug>.tendso.ph` vs `<slug>.sites.tendso.com`). *Blocks every `@id`.*
+2. **How many live paid client sites exist on `*.workers.dev` today?** Determines migrate-vs-net-new (OQ-5).
+3. **Do we own `tendso.ph`?** (Affects OQ-2.)
+4. **Is the SEO/GEO push even the priority right now** vs finishing the owner portal / pricing mobile parity / the dead-Gemini-key fix? This is a large multi-sprint program; sequencing it against the other open work is a product call, not an engineering one.
+
+**My recommendation:** approve **Sprint 1 (Track A)** now — it's safe, high-ROI, and mostly net-new files with near-zero regression risk. Hold **Track B** until OQ-1/2/4/5 are decided and the content gate is designed. Don't let the XL architecture rewrite (P0.1) block the easy KB/platform wins.
+
+---
+
+## 8. ✅ Track A — IMPLEMENTED (2026-06-18)
+
+Built, typechecked, and production-build-verified. All on `tendso.com`, all net-new files (near-zero regression risk).
+
+| File | What it does |
+|---|---|
+| `lib/seo.ts` | `SITE_URL` (canonical `https://tendso.com` — overrides the plan's wrong `tendso.app`), + Organization/WebSite/Article/Breadcrumb/SoftwareApplication JSON-LD builders. |
+| `components/JsonLd.tsx` | Renders JSON-LD as a native `<script type="application/ld+json">` in the **server HTML** (so JS-less AI crawlers read it). |
+| `app/robots.ts` | Allows GPTBot, OAI-SearchBot, ClaudeBot/anthropic-ai/claude-web, Google-Extended, PerplexityBot, Bingbot; **blocks** Bytespider + CCBot; disallows `/api`,`/admin`,`/connect-ai`,`/dashboard`,`/wallet`,`/submit`. |
+| `app/layout.tsx` | Injects the Organization+WebSite `@graph` on every page; adds `metadataBase`, canonical, OG/Twitter defaults. |
+| `convex/knowledge.ts` | `getArticleBySlug` (public, workspace-gated) + `listPublishedHelpSlugs` (for static params/sitemap). |
+| `app/knowledge/[slug]/page.tsx` | **SSR per-article route** (ISR 3600s) — server-rendered body + Article/Breadcrumb JSON-LD + per-article canonical/OG. Converts the KB from invisible-SPA → crawlable. |
+| `app/sitemap.ts` | static marketing pages + published KB articles (business profiles deferred to Track B). |
+
+**Verification (done):**
+- `tsc --noEmit` → clean.
+- `next build` → exit 0; routes built: `/knowledge/[slug]` (ƒ dynamic), `/robots.txt` (○), `/sitemap.xml` (ƒ).
+- **Runtime curl of a KB article (no JS) confirms the raw HTML carries**: `"@type":"Article"`, `"@type":"BreadcrumbList"`, the real `<h1>`, `<link rel="canonical" href="https://tendso.com/...">`, and the full body text. **This is the core win — the KB is now AI-crawler-visible.**
+
+**Known caveat:** `/robots.txt` and `/sitemap.xml` 404 under a local `next start` (Next 16/Turbopack metadata-route quirk — the `.next/server/app/robots.txt.body` artifact builds correctly). They serve fine on **Vercel**, which routes metadata files natively. Verify post-deploy with `curl https://tendso.com/robots.txt`.
+
+**Still manual (not code) — do post-deploy:**
+- Verify `tendso.com` in **Google Search Console** + **Bing Webmaster Tools** ("Import from GSC" to bulk-verify); submit `sitemap.xml`.
+- Capture an **AI-citation baseline** (prompt ChatGPT/Perplexity/Gemini with the target query set) so the 4–8 week lift is measurable.
+- Add SoftwareApplication/Offer schema to the home/pricing page (`softwareApplicationGraph()` is built in `lib/seo.ts`, just not yet wired into `app/page.tsx` — left out to avoid touching the landing page mid-localization work).
+- The `manifest.json` 404 seen in console is pre-existing/unrelated; add a real `public/manifest.json` when convenient.
+
+---
+
+## 9. Track B (D/E/F) — DETAILED, FOR LATER
+
+This is the bet-the-company half. **Do NOT start until the four blockers in §7 are answered.** Detailed scope so it's ready to pick up:
+
+### D — Generated client-site template (the SEO multiplier)
+**Blocked on:** client-site domain decision (OQ-2).
+
+- **D1 · Shared `<SiteHead>` Astro partial.** There is NO shared head today — all **15** PageA–O components emit their own `<!DOCTYPE>/<head>` (audited, C1). Build `astro-site-template/src/components/SiteHead.astro` with title/meta/OG/Twitter/canonical + the LocalBusiness `@graph` + a FAQPage block, and import it into all 15. Thread inputs through `src/data/site-data.json` (the runtime builder reads this). **Effort: XL — it's 15 files, not one.**
+- **D2 · `buildLocalBusinessSchema()` + `categoryToSchemaType()` helpers.** Map `businessType` → Schema.org subtype (HairSalon, Restaurant, BeautySalon, Dentist, Store, …). Phone → `+63` (strip leading 0). Geo ≥4 decimals. Every `@id` → the **permanent client-site domain** (decided in OQ-2), never `workers.dev`.
+- **D3 · Image SEO in the template.** Groq-generate business-specific alt text (`{businessName, service, city}`), descriptive filenames, WebP, explicit width/height (CLS). Free uniqueness signal across sites.
+- **D4 · Region→language (OQ-10).** Cebuano/Bisaya for Central Visayas (Cebu/Lapu-Lapu are NOT Tagalog), Tagalog for NCR/Luzon; emit correct `inLanguage`/hreflang. Map from `submissions.city`/`province`.
+- **Data note (audited):** `services` lives on `generatedWebsites`, `city`/`province`/`barangay`/`coordinates`/`businessType` on `submissions` — the builder must join both. `googlePlaceId` is on `prospects`/`leads` only (drives D's optional rating via E).
+
+### E — The guardrails (the anti-penalty layer — the real risk)
+**Blocked on:** domain-migration decision (OQ-1/2/4/5) + content-gate threshold decisions.
+
+- **E1 · `*.workers.dev` → permanent-domain migration (P0.1, XL architecture rewrite).** Today = one Worker per business on its own `*.workers.dev` subdomain serving ONE html string for all paths (audited, C2/C6). Target = a **single wildcard router Worker** reading the `Host` header and serving `generatedWebsites.htmlContent` from Convex/KV. This is a rewrite of `app/api/publish-website/route.ts deployAsWorker`, plus a Cloudflare cost model (Workers Paid covers compute; client custom domains would need Cloudflare-for-SaaS SSL — defer to a paid upsell). **Add + backfill `generatedWebsites.slug` and `canonicalUrl` here.** Decide migrate-existing vs net-new (OQ-5) — needs the live-site count.
+- **E2 · Content gate before publish (P0.10 — the single most important guardrail).** Block publish unless: completeness (`businessName + category + city + barangay + ≥1 photo + ≥3 services + contact + hours + ≥300-word body`) **AND** uniqueness (embedding-cosine near-dup check vs already-published sites — reuse the proven 768d Gemini embed pipeline from `knowledgeAI.ts`, but on a NEW vector index over generated-site content) **AND** owner-verified facts (hours/services/NAP confirmed by a human before publish — Groq hallucinates these) **AND** structural variation (don't ship identical FAQ-4 + section order across 1000s of sites). Failing records → `noindex` "coming soon", excluded from `listPublished`/sitemap/directory. New fields: `contentComplete`, `wordCount`, `dupScore`, `ownerVerified`. Gate lives in `/api/generate-website` (pre-store) + `/api/publish-website` (pre-deploy). **Threshold decisions are policy, not code — need sign-off.**
+- **E3 · Conditional real `aggregateRating` (P1.6).** Inject ONLY when a matched `prospects.googlePlaceId` has real review data AND the page visibly renders a "Reviews from Google" block. Fuzzy-match `submissions`↔`prospects` on name + lat/lng (≤50m, H3 overlap). Never fabricate stars.
+- **E4 · Attribution footer (P1.3).** ONE homepage-only `rel="nofollow sponsored"` link, rotated non-keyword anchors by category, link on logo only. **No dofollow variant, ever** (dofollow exact-match across 1000s of sites = textbook PBN trigger). Changing it across existing sites = a backfill rebuild job.
+- **E5 · De-index kill-switch (P2.7).** A named, owned alert: if GSC "Crawled–not indexed" on client URLs crosses a threshold, **auto-pause the generation pipeline**. Decide threshold + who gets paged.
+
+### F — The flywheel (directory + profiles + listicles)
+**Blocked on:** ≥~20 published businesses per target city (inventory, not engineering).
+
+- **F1 · Public business profiles `app/businesses/[slug]/page.tsx`.** SSR profile per published business — the **dofollow** node Tendso links FROM. ~150-word unique neighborhood intro (NOT a dup of the client site's copy), services, hours, map, WhatsApp CTA, dofollow link to the live client site, LocalBusiness+Breadcrumb schema, self-canonical. Needs `slug` (E1).
+- **F2 · Directory hubs `app/businesses/[city]` + `[category]/[city]` (GATE ON INVENTORY).** 300–500 words of genuinely unique, human-reviewed local editorial per page; ItemList + FAQPage + Breadcrumb. **Do NOT launch a city until ≥~20 quality businesses exist there** — empty hubs are doorway content that drags the whole domain. Denormalize `city`/`category`/`slug` + add `by_city`/`by_category_city` indexes (the audited N+1 in `listPublished` will not scale). Paginate.
+- **F3 · IndexNow on publish (P1.5).** After deploy, fire IndexNow (Bing/Perplexity consume it; Google does NOT). Serve the key file from `tendso.com` (the single-string Worker can't serve it — C2). **Sequence AFTER E1** (don't IndexNow-submit throwaway `workers.dev` URLs).
+- **F4 · Internal-linking loop + KB listicles (P1.4/P1.8).** Client sites → KB articles → directory → profiles, with a keyword→canonical-surface map to prevent cannibalization. "Best [category] in [city]" KB listicles citing real listed businesses (Article + ItemList).
+- **F5 · Lifecycle/governance (P2.7).** 410/redirect + sitemap removal on churned/closed businesses (avoid soft-404 drag); named owners for the schema template, gate thresholds, and bot allowlist; regression snapshot test on generated HTML.
+
+### Mobile impact of Track B
+Only **E2 (content gate)** touches mobile, and only because it lives in the shared Convex publish flow the APK also calls: when the gate ships, **mobile submissions get gated server-side automatically**. The only mobile UI work is surfacing a "pending review / needs more info" state instead of assuming instant publish. Everything else in D/E/F is web/Astro/Convex — no APK change.

--- a/docs/changes/OWNER-PORTAL-PRICING-PLAN.md
+++ b/docs/changes/OWNER-PORTAL-PRICING-PLAN.md
@@ -529,6 +529,8 @@ creatorPayout = commissionFor(sellPrice)              // 50% of sellPrice ONLY �
 
 **Custom domain:** charge the **real registrar price** (from the domain-availability check), not a flat ₱500. The flat `CUSTOM_DOMAIN_ADDON` is only a fallback when no real price is available. The domain is a registrar pass-through — **never** part of the 50% commission.
 
+**⚠️ Audio rate changed — remove the old ₱300/₱500 split from mobile:** payout is now `commissionFor(sellPrice)` (50% of the sell price) **regardless of interview type**. The old flat **₱500 video / ₱300 audio** rates are GONE. An audio submission at the ₱999 base now earns ₱500 (same as video), not ₱300. Any mobile screen that displays "₱300 audio / ₱500 video" must be updated to show the 50%-of-sale model. (Confirm with the client that equal audio pay is intended — flagged as a possible one-line revert.)
+
 **Earnings timing (Phase 3):** `creatorPayout` is frozen at submit and credited to the creator's balance on the existing **paid** transition (`payments.creditCreatorForPayment`), not at approval — already shared, so mobile gets it automatically with no APK change.
 
 

--- a/docs/changes/PRESSURE-TEST-AI-SEO.md
+++ b/docs/changes/PRESSURE-TEST-AI-SEO.md
@@ -1,0 +1,48 @@
+[AI IDEA — Steven rethink it] Build GEO + SEO into every generated page (schema, sitemap, crawlable KB, backlink flywheel)
+
+Your job:
+
+Pressure-test every assumption — especially the big bet ("1000s of unique AI-generated local sites build authority"), the cost models, and the per-engine claims.
+Correct what's wrong. The AI's own critics already caught fabricated codebase "facts" (there is no generatedWebsites.slug; the Cloudflare Worker serves one HTML string for all paths; KB queries are api.knowledge.* not api.knowledgeArticles.*; the Astro template has no shared <head> — 15 components each emit their own). Assume more errors are lurking — confirm every file path, table field, and API behavior against the real code before building.
+Implement it the best possible way using your own judgment. Where the doc and reality disagree, reality wins. Where it's vague, your engineering judgment wins.
+Do NOT implement blindly. Several tactics will backfire if shipped naively (scaled-content de-indexing, footer-link → PBN reclassification, fabricated review ratings, hallucinated business hours/NAP). The guardrails ARE the point.
+
+📄 Full plan (read the whole thing)
+
+ClickUp Doc: https://app.clickup.com/90151674303/docs/2kyqardz-3915 — "Tendso GEO + SEO Strategy & Implementation Plan (AI IDEA — UNVERIFIED)", in the Tendso folder. 4 pages: (1) Read First · Strategy & Flywheel, (2) Implementation · P0 Foundation, (3) Implementation · P1 Flywheel + P2 Advanced, (4) Measurement · Risks · Open Questions. All detail — full code skeletons, JSON-LD blocks, 13-row risk register, and 12 open questions — lives in those 4 pages.
+
+🎯 The goal
+
+Increase Tendso's SEO + GEO reach so that (A) people looking for Tendso find it and AI engines (ChatGPT, Perplexity, Gemini, Google AI Overviews) recommend it, and (B) every client site we generate ranks + gets cited locally — the product value the ₱999→₱4,999 fee buys.
+
+💡 The core idea (the unfair advantage)
+
+Tendso mass-generates local-business websites, so GEO/SEO can be baked into the generation template once and apply to every future site — and every generated site can feed a backlink + directory + entity flywheel back to the Tendso brand:
+
+Generated client sites get LocalBusiness/FAQ/Breadcrumb JSON-LD schema, answer-first content, Bing indexing + IndexNow.
+A public Tendso directory (/businesses/[city]/[category]) links out to client sites (the real dofollow authority flow); client sites carry only a nofollow sponsored attribution footer back (NOT an authority link — doing it dofollow at scale = penalty).
+The Knowledge Base (today an invisible client-side SPA) becomes crawlable SSR → topical authority + AI citations for "how do I get my barbershop in Cebu online" type queries.
+
+🔑 The 3 non-negotiable guardrails (per the AI's own risk analysis)
+
+Content gate before publish — completeness + embedding-uniqueness + owner-verified facts + structural variation. 1000s of thin/near-dup AI pages is exactly the Google scaled-content enforcement pattern. Word count alone does NOT satisfy the policy.
+Get off *.workers.dev (zero authority) onto *.tendso.ph before spending on indexing/authority — and set every schema @id to the permanent domain from day one. (This is an architecture rewrite of publish-website, not a DNS toggle.)
+Named de-index kill-switch — auto-pause the generation pipeline if GSC "Crawled–not indexed" on client URLs crosses a threshold.
+
+🧭 Suggested critical path (P0 first — see doc for full detail + code skeletons)
+
+Decide OQ-1/OQ-2/OQ-4/OQ-5 (domain + client-site serving architecture + Cloudflare SSL cost + migration of existing sites) — blocks almost everything.
+P0.1 domain/router-Worker + add slug to generatedWebsites.
+P0.8 + P0.10 + P0.13 shared <SiteHead> across the 15 Astro components + content/uniqueness/owner-verify gate + schema validation (fixes all future sites safely).
+P0.9 + P0.11 + P0.3 + P0.2 KB SSR routes + sitemap + robots (un-hides the platform; allow GPTBot/OAI-SearchBot/ClaudeBot/Google-Extended/PerplexityBot/Bingbot, block Bytespider/CCBot).
+P0.12 + P1.5 GSC + Bing Webmaster + tendso.ph property + IndexNow (opens the Bing→ChatGPT gate).
+P1.1–P1.4 business profiles + inventory-gated directory + safe attribution footer + internal-linking loop (closes the flywheel).
+P2 data-study PR → Wikidata (only after independent coverage exists) → validated upsell dashboard.
+
+📋 First deliverable from you
+
+Before writing code: a short reality-check note on the doc (or as a task comment) — which assumptions hold, which are wrong, what you'd change, and your recommended OQ-1/OQ-2 decisions. Then we scope the P0 sprint from there.
+
+(There are 12 Open Questions and a 13-row risk register in page 4 of the doc — please weigh in on those.)
+
+

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,167 @@
+/**
+ * SEO / GEO helpers — canonical URLs + Schema.org JSON-LD builders.
+ *
+ * Pure data builders (no React) so they're usable in metadata, route handlers,
+ * and server components alike. Render the output with <JsonLd> (see jsonLd.tsx)
+ * or a native <script type="application/ld+json">.
+ *
+ * CANONICAL DOMAIN: tendso.com (platform migrated 2026-06). The plan doc assumed
+ * tendso.app — that's wrong; every @id/canonical here uses tendso.com.
+ * Override with NEXT_PUBLIC_SITE_URL only if it's a real https origin (the dev
+ * default localhost:3000 is ignored for canonical/schema, which must be absolute
+ * production URLs).
+ */
+
+const ENV_URL = process.env.NEXT_PUBLIC_SITE_URL;
+export const SITE_URL =
+    ENV_URL && ENV_URL.startsWith('https://') ? ENV_URL.replace(/\/$/, '') : 'https://tendso.com';
+
+export const ORG_ID = `${SITE_URL}/#organization`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+
+/** Absolute URL for a path (leading slash optional). */
+export function abs(path: string): string {
+    if (path.startsWith('http')) return path;
+    return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+/**
+ * Platform Organization + WebSite @graph. Injected once in the root layout so
+ * every page carries the entity. Leave a Wikidata sameAs slot for later (P2).
+ */
+export function organizationGraph() {
+    return {
+        '@context': 'https://schema.org',
+        '@graph': [
+            {
+                '@type': 'Organization',
+                '@id': ORG_ID,
+                name: 'Tendso',
+                url: SITE_URL,
+                logo: { '@type': 'ImageObject', url: abs('/tendso-icon.png'), width: 512, height: 512 },
+                description:
+                    'Tendso helps Filipino local businesses get online fast. A creator visits, asks a few questions, photographs the shop, and a website goes live in 48 hours.',
+                slogan: "The Thinking Ends Here. So the work doesn't.",
+                areaServed: { '@type': 'Country', name: 'Philippines' },
+                knowsAbout: [
+                    'local business websites',
+                    'Philippine SME digitization',
+                    'field agent networks',
+                    'web publishing',
+                ],
+                // sameAs left intentionally minimal — only add profiles that
+                // actually resolve + are consistent (an unresolving sameAs is an
+                // entity-confusion signal). Wikidata QID added later (P2).
+                sameAs: [] as string[],
+                contactPoint: {
+                    '@type': 'ContactPoint',
+                    contactType: 'customer support',
+                    availableLanguage: ['English', 'Filipino'],
+                },
+            },
+            {
+                '@type': 'WebSite',
+                '@id': WEBSITE_ID,
+                url: SITE_URL,
+                name: 'Tendso',
+                publisher: { '@id': ORG_ID },
+                inLanguage: 'en-PH',
+                potentialAction: {
+                    '@type': 'SearchAction',
+                    target: {
+                        '@type': 'EntryPoint',
+                        urlTemplate: `${SITE_URL}/knowledge?q={search_term_string}`,
+                    },
+                    'query-input': 'required name=search_term_string',
+                },
+            },
+        ],
+    };
+}
+
+export interface ArticleSchemaInput {
+    slug: string;
+    title: string;
+    summary: string;
+    keywords?: string[];
+    createdAtMs: number;
+    updatedAtMs: number;
+    faqs?: Array<{ question: string; answer: string }>;
+}
+
+/**
+ * Article + BreadcrumbList (+ FAQPage when faqs exist) @graph for a KB article.
+ * FAQPage mainEntity stays [] until the faqs field is populated (P1.7) — an
+ * empty FAQPage is harmless; fabricated Q&A is not.
+ */
+export function knowledgeArticleGraph(a: ArticleSchemaInput) {
+    const articleUrl = abs(`/knowledge/${a.slug}`);
+    const graph: Record<string, unknown>[] = [
+        {
+            '@type': 'Article',
+            '@id': `${articleUrl}/#article`,
+            headline: a.title,
+            description: a.summary,
+            keywords: a.keywords ?? [],
+            datePublished: new Date(a.createdAtMs).toISOString(),
+            dateModified: new Date(a.updatedAtMs).toISOString(),
+            author: { '@id': ORG_ID },
+            publisher: { '@id': ORG_ID },
+            mainEntityOfPage: articleUrl,
+            inLanguage: 'en-PH',
+            isPartOf: { '@id': WEBSITE_ID },
+        },
+        {
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+                { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+                { '@type': 'ListItem', position: 2, name: 'Knowledge Base', item: abs('/knowledge') },
+                { '@type': 'ListItem', position: 3, name: a.title, item: articleUrl },
+            ],
+        },
+    ];
+    if (a.faqs && a.faqs.length > 0) {
+        graph.push({
+            '@type': 'FAQPage',
+            isPartOf: { '@id': `${articleUrl}/#article` },
+            mainEntity: a.faqs.map((f) => ({
+                '@type': 'Question',
+                name: f.question,
+                acceptedAnswer: { '@type': 'Answer', text: f.answer },
+            })),
+        });
+    }
+    return { '@context': 'https://schema.org', '@graph': graph };
+}
+
+/**
+ * SoftwareApplication + tiered Offer for the home/pricing page.
+ * price MUST be a string per Schema.org; region = PH.
+ */
+export function softwareApplicationGraph() {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        '@id': `${SITE_URL}/#software`,
+        name: 'Tendso',
+        applicationCategory: 'BusinessApplication',
+        operatingSystem: 'Web, Android',
+        publisher: { '@id': ORG_ID },
+        offers: [
+            {
+                '@type': 'Offer',
+                name: 'Website (launch price)',
+                price: '999',
+                priceCurrency: 'PHP',
+                eligibleRegion: { '@type': 'Country', name: 'Philippines' },
+            },
+            {
+                '@type': 'Offer',
+                name: 'Website (full price ceiling)',
+                price: '4999',
+                priceCurrency: 'PHP',
+                eligibleRegion: { '@type': 'Country', name: 'Philippines' },
+            },
+        ],
+    };
+}


### PR DESCRIPTION
## Summary

Two landing-adjacent features built this session, both **net-new / additive** (near-zero regression risk):

1. **SEO / GEO — Track A** — makes the platform + Knowledge Base discoverable to AI chatbots (ChatGPT, Perplexity, Gemini, Google AIO) and search engines.
2. **EN/Tagalog landing localization** — the navbar language switcher now actually works.

Both verified: `tsc --noEmit` clean, `next build` exit 0.

---

## 1. SEO / GEO — Track A

Implements the safe, high-ROI half of the GEO plan (ClickUp 86ca9u21z). Full reality-check + the deferred D/E/F scope are in `docs/changes/GEO-SEO-REALITY-CHECK.md`. **The plan assumed `tendso.app`; this uses the real canonical `tendso.com`.**

| File | What |
|---|---|
| `lib/seo.ts` | `SITE_URL` + Organization/WebSite/Article/Breadcrumb/SoftwareApplication JSON-LD builders |
| `components/JsonLd.tsx` | Renders JSON-LD in **server HTML** (AI crawlers don't run JS) |
| `app/robots.ts` | Allow GPTBot, OAI-SearchBot, ClaudeBot, Google-Extended, PerplexityBot, Bingbot; **block** Bytespider/CCBot; hide app/admin routes |
| `app/layout.tsx` | Organization+WebSite `@graph` on every page + canonical/OG metadata |
| `app/knowledge/[slug]/page.tsx` | **SSR per-article route (ISR)** — converts the KB from an invisible client SPA → crawlable HTML with Article/Breadcrumb JSON-LD |
| `app/sitemap.ts` | static pages + published KB articles |
| `convex/knowledge.ts` | `getArticleBySlug` + `listPublishedHelpSlugs` (workspace-gated, published-only) |

**Core win, verified:** the raw (no-JS) HTML of a KB article now carries `"@type":"Article"`, `"@type":"BreadcrumbList"`, the real `<h1>`, `<link rel="canonical" href="https://tendso.com/...">`, and the full body text — i.e. the KB is now citable by AI engines.

## 2. EN/Tagalog landing localization

- `components/landing/i18n.tsx` — `LanguageProvider` + `useT()` (localStorage persistence, `tl → en → key` fallback so partial translation never blanks).
- Wires the previously-decorative navbar language dropdown; localizes Navbar, Hero, BusinessPricing, CTA, Footer.
- Removes the unused region/country dropdown (PH-only).
- Fixes stale **"₱500 video / ₱300 audio"** copy (hero + HowItWorks) → the 50%-of-sale model.

---

## Reviewer notes
- `robots.txt` / `sitemap.xml` 404 under a local `next start` (Next 16 / Turbopack metadata-route quirk — artifacts build correctly). They serve fine on **Vercel**; verify post-deploy: `curl https://tendso.com/robots.txt`.
- **Tagalog copy needs a native-speaker review** before treating as final.
- **Manual, post-deploy:** verify `tendso.com` in Google Search Console + Bing Webmaster Tools, submit the sitemap, capture an AI-citation baseline.
- `softwareApplicationGraph()` exists in `lib/seo.ts` but isn't wired into the pricing page yet (avoided touching it mid-localization).

## NOT in this PR (deferred by design)
GEO plan Track B/C (D/E/F): client-site `<SiteHead>` schema bake, the content-uniqueness gate, the `*.workers.dev` → permanent-domain migration, and the directory/flywheel. All detailed in `GEO-SEO-REALITY-CHECK.md` §9 — blocked on domain + content-gate decisions, not engineering time.
