### PR TITLE
Fix: creator payout shows frozen 50% value (not dead ₱500/₱300) + state pricing-unlock on landing

### DIFF
--- a/app/submit/success/page.tsx
+++ b/app/submit/success/page.tsx
@@ -9,6 +9,7 @@ import { Id } from "@/convex/_generated/dataModel"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Loader2 } from "lucide-react"
+import { commissionFor, BASE_PRICE, formatPHP } from "@/lib/pricing"
 
 export default function SubmissionSuccessPage() {
     const router = useRouter()
@@ -103,10 +104,11 @@ export default function SubmissionSuccessPage() {
         }
     }
 
-    // Determine payout based on interview type (check both R2 URLs and storage IDs)
-    const hasVideo = submission?.videoUrl || submission?.videoStorageId
-    const hasAudio = submission?.audioUrl || submission?.audioStorageId
-    const payout = hasVideo ? 500 : (hasAudio ? 300 : null)
+    // Show the payout the submission actually froze — 50% of the creator's sale
+    // price (commissionFor), NOT the abolished flat ₱500/₱300 video/audio rate.
+    // Audio and video earn the same rate now. Legacy submissions without a frozen
+    // creatorPayout fall back to the 50% of the ₱999 base price (= ₱500).
+    const payout = submission?.creatorPayout ?? commissionFor(BASE_PRICE)
 
     // Loading state - wait for submission to load too
     if (!isLoaded || !isSignedIn || creator === undefined || (submissionId && submission === undefined)) {
@@ -144,7 +146,7 @@ export default function SubmissionSuccessPage() {
                     <div className="pb-4 border-b border-gray-100">
                         <p className="text-sm text-gray-500 uppercase font-medium tracking-wide">Expected Payout</p>
                         <p className="text-3xl font-bold text-amber-600 mt-1">
-                            ₱{payout || '---'}
+                            {formatPHP(payout)}
                         </p>
                     </div>
 

--- a/components/landing/CreatorEarningFlow.tsx
+++ b/components/landing/CreatorEarningFlow.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from "framer-motion";
 import { Search, Send, Sparkles, BadgeCheck, Wallet, ArrowRight } from "lucide-react";
+import { BASE_PRICE, PRICE_CEILING, UNLOCK_THRESHOLD, commissionFor, formatPHP } from "@/lib/pricing";
 
 const flowSteps = [
   {
@@ -27,7 +28,7 @@ const flowSteps = [
   {
     icon: Wallet,
     label: "You get paid",
-    desc: "₱500 per submission (50% of every sale). Direct to your Wise wallet, usually within 24 hours.",
+    desc: `Keep 50% of every sale, straight to your Wise wallet (usually within 24 hours). You start at the ${formatPHP(BASE_PRICE)} launch price (${formatPHP(commissionFor(BASE_PRICE))} to you). After ${UNLOCK_THRESHOLD} successful submissions you unlock price-setting — charge up to ${formatPHP(PRICE_CEILING)} and keep half (up to ${formatPHP(commissionFor(PRICE_CEILING))}).`,
   },
 ];
 

--- a/components/landing/landingData.ts
+++ b/components/landing/landingData.ts
@@ -38,7 +38,7 @@
  *    - Drop the screenshot at /public/Pages/<slug>.png.
  */
 
-import { BASE_PRICE, CUSTOM_DOMAIN_PRICE, REFERRAL_BONUS, commissionFor } from "@/lib/pricing";
+import { BASE_PRICE, PRICE_CEILING, UNLOCK_THRESHOLD, CUSTOM_DOMAIN_PRICE, REFERRAL_BONUS, commissionFor, formatPHP } from "@/lib/pricing";
 
 export type Creator = {
     id: string;
@@ -362,6 +362,7 @@ export const TESTIMONIALS: Testimonial[] = [
 
 // ── FAQ ────────────────────────────────────────────────────────────────────
 export const FAQ_CREATOR: FaqEntry[] = [
+    { q: "How much can I charge — and earn?", a: `You start at the ${formatPHP(BASE_PRICE)} launch price and keep 50% (${formatPHP(commissionFor(BASE_PRICE))} per site). After your first ${UNLOCK_THRESHOLD} successful submissions you unlock price-setting: charge anywhere up to ${formatPHP(PRICE_CEILING)} and still keep half — up to ${formatPHP(commissionFor(PRICE_CEILING))} per site. The more you charge, the more you earn.` },
     { q: "How do I get paid?", a: "Straight to your Wise account. The app handles invoices, taxes, and receipts. You don't touch a spreadsheet." },
     { q: "When do I get paid?", a: "Within 48 hours of the business owner approving their site. Faster on weekends — we don't sit on your money." },
     { q: "Do I need experience?", a: "No. The guided capture walks you through every interview, every photo, every step. If you can use TikTok, you can use this." },


### PR DESCRIPTION
## The bug

`app/submit/success/page.tsx` showed the creator's payout as `hasVideo ? 500 : 300` — the **abolished flat video/audio model**. So an audio submission always displayed **₱300**, ignoring the creator's actual sale price and the 50%-of-sale model that's been live since the pricing engine merged.

## The fix

- **`app/submit/success/page.tsx`** — display `submission.creatorPayout` (the 50% value frozen at submit time by `setDomainTier`/`submit`), rendered with `formatPHP`, with a `commissionFor(BASE_PRICE)` fallback for legacy rows. Now:
  - audio and video show the **same** rate (format-independent, as designed),
  - a first-5 creator (₱999 intro) shows **₱500**,
  - a creator who set ₱2,500 shows **₱1,250**.
  No schema/data change — the correct value was already on the submission, just not read.

- **`components/landing/CreatorEarningFlow.tsx` + `landingData.ts`** — state the creator pricing mechanic explicitly (numbers pulled from `lib/pricing` so they can't go stale): **start at ₱999 → after 5 successful submissions unlock price-setting → up to ₱4,999, keep 50%.** Added a creator FAQ: *"How much can I charge — and earn?"*

## Verification
- `tsc --noEmit` → clean
- `next build` → exit 0; `/submit/success` prerenders

## Note for the mobile team
The mobile app's success screen almost certainly has the **same hardcoded ₱500/₱300** display bug. The server data is already correct; mobile just needs the same one-line change (read the frozen `creatorPayout`) in the separate mobile repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)