### PR TITLE
Devpatch8

### DIFF
--- a/app/certification-quiz/page.tsx
+++ b/app/certification-quiz/page.tsx
@@ -113,7 +113,10 @@ export default function CertificationQuizPage() {
     const router = useRouter()
     const { user, isLoaded } = useUser()
     const creator = useQuery(api.creators.getByClerkId, user ? { clerkId: user.id } : "skip")
-    const certify = useMutation(api.creators.certify)
+    // Passing the quiz now marks the creator as quiz-passed (awaiting admin
+    // approval), matching mobile — NOT auto-certified. Admin approves in
+    // /admin/pending-approvals, which sets certifiedAt and releases the gate.
+    const markQuizPassed = useMutation(api.creators.markQuizPassed)
 
     const [currentQ, setCurrentQ] = useState(0)
     const [selected, setSelected] = useState<number | null>(null)
@@ -166,9 +169,9 @@ export default function CertificationQuizPage() {
             if (score >= 4) {
                 setCertifying(true)
                 try {
-                    if (creator?._id) await certify({ id: creator._id })
+                    if (creator?._id) await markQuizPassed({ id: creator._id })
                 } catch (e) {
-                    console.error("Certification failed:", e)
+                    console.error("Marking quiz passed failed:", e)
                 }
                 setCertifying(false)
                 setPhase("pass")
@@ -197,8 +200,8 @@ export default function CertificationQuizPage() {
                     <div className="w-16 h-16 bg-amber-50 rounded-full flex items-center justify-center mx-auto mb-4">
                         <Trophy className="w-8 h-8 text-amber-500" />
                     </div>
-                    <h1 className="text-2xl font-bold text-zinc-900 mb-1">Congratulations!</h1>
-                    <p className="text-zinc-500 text-sm">You passed with a score of <span className="font-bold text-amber-600">{finalScore}/5</span></p>
+                    <h1 className="text-2xl font-bold text-zinc-900 mb-1">Quiz passed!</h1>
+                    <p className="text-zinc-500 text-sm">Score of <span className="font-bold text-amber-600">{finalScore}/5</span> — your application is now under review.</p>
                 </div>
 
                 {/* Certificate */}
@@ -215,10 +218,10 @@ export default function CertificationQuizPage() {
                     style={{ transitionDelay: '600ms' }}
                 >
                     <Button
-                        onClick={() => router.push("/dashboard")}
+                        onClick={() => router.push("/pending")}
                         className="w-full h-12 bg-amber-500 hover:bg-amber-600 text-white font-semibold rounded-xl shadow-lg shadow-amber-500/20"
                     >
-                        Go to Dashboard
+                        Continue
                     </Button>
                 </div>
             </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { useEffect } from "react"
 import Link from "next/link"
 import { Wallet, Store, Clock, Loader2, Bell, User, Users, ChevronRight } from "lucide-react"
 import { BottomNav } from "@/components/BottomNav"
+import { creatorRedirect } from "@/lib/creatorGate"
 
 export default function DashboardPage() {
     const router = useRouter()
@@ -67,10 +68,11 @@ export default function DashboardPage() {
         }
     }, [isLoaded, isSignedIn, creator, router])
 
-    // Redirect uncertified creators to training
+    // Route uncertified creators by lifecycle state (pending / rejected / training).
     useEffect(() => {
-        if (isLoaded && isSignedIn && creator && creator.role !== 'admin' && !creator.certifiedAt) {
-            router.replace("/training")
+        if (isLoaded && isSignedIn && creator) {
+            const dest = creatorRedirect(creator)
+            if (dest) router.replace(dest)
         }
     }, [isLoaded, isSignedIn, creator, router])
 

--- a/app/leads/[leadId]/page.tsx
+++ b/app/leads/[leadId]/page.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import { creatorRedirect } from "@/lib/creatorGate";
 import type { Id } from "@/convex/_generated/dataModel";
 import { toast } from "sonner";
 import {
@@ -65,8 +66,9 @@ export default function CreatorLeadDetailPage({
         if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
     }, [isLoaded, isSignedIn, creator, router]);
     useEffect(() => {
-        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
-            router.replace("/training");
+        if (isLoaded && isSignedIn && creator) {
+            const dest = creatorRedirect(creator);
+            if (dest) router.replace(dest);
         }
     }, [isLoaded, isSignedIn, creator, router]);
 

--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -28,6 +28,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import { creatorRedirect } from "@/lib/creatorGate";
 import {
     APIProvider,
     Map as GoogleMap,
@@ -113,8 +114,9 @@ function DiscoverInner() {
         if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
     }, [isLoaded, isSignedIn, creator, router]);
     useEffect(() => {
-        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
-            router.replace("/training");
+        if (isLoaded && isSignedIn && creator) {
+            const dest = creatorRedirect(creator);
+            if (dest) router.replace(dest);
         }
     }, [isLoaded, isSignedIn, creator, router]);
 

--- a/app/leads/live/page.tsx
+++ b/app/leads/live/page.tsx
@@ -25,6 +25,7 @@ import { useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useAction, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import { creatorRedirect } from "@/lib/creatorGate";
 import {
     APIProvider,
     Map as GoogleMap,
@@ -84,8 +85,9 @@ function LiveBusinessesInner() {
         if (isLoaded && isSignedIn && creator === null) router.push("/onboarding");
     }, [isLoaded, isSignedIn, creator, router]);
     useEffect(() => {
-        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
-            router.replace("/training");
+        if (isLoaded && isSignedIn && creator) {
+            const dest = creatorRedirect(creator);
+            if (dest) router.replace(dest);
         }
     }, [isLoaded, isSignedIn, creator, router]);
 

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -21,6 +21,7 @@ import { useUser } from "@clerk/nextjs";
 import { useQuery, useMutation } from "convex/react";
 import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
+import { creatorRedirect } from "@/lib/creatorGate";
 import type { Id } from "@/convex/_generated/dataModel";
 import { BottomNav } from "@/components/BottomNav";
 import {
@@ -124,8 +125,9 @@ function CreatorLeadsInner() {
         if (isLoaded && isSignedIn && creator && creator.role === "admin") router.push("/admin");
     }, [isLoaded, isSignedIn, creator, router]);
     useEffect(() => {
-        if (isLoaded && isSignedIn && creator && creator.role !== "admin" && !creator.certifiedAt) {
-            router.replace("/training");
+        if (isLoaded && isSignedIn && creator) {
+            const dest = creatorRedirect(creator);
+            if (dest) router.replace(dest);
         }
     }, [isLoaded, isSignedIn, creator, router]);
 

--- a/app/pending/page.tsx
+++ b/app/pending/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+/**
+ * Creator "application under review" gate — web equivalent of mobile's
+ * /pending-review. A creator who passed the onboarding quiz (quizPassedAt set)
+ * but isn't approved yet (certifiedAt unset) lands here. The ONLY escape is
+ * sign out; an admin approving/rejecting auto-routes them off this page in
+ * real time via the Convex live query (no refresh).
+ *
+ * See docs/changes/CREATOR-PENDING-APPROVAL-PAGE.md.
+ * Routes are flat on web (/pending, /dashboard, /verification-rejected) — the
+ * brief's /creator/* prefix does not apply here.
+ */
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useUser, useClerk } from "@clerk/nextjs";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Loader2, Clock, CheckCircle2, LogOut } from "lucide-react";
+
+function timeAgo(ms?: number): string {
+    if (!ms) return "";
+    const diff = Date.now() - ms;
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins} min ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs} hr${hrs > 1 ? "s" : ""} ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days} day${days > 1 ? "s" : ""} ago`;
+}
+
+export default function PendingPage() {
+    const { user, isLoaded, isSignedIn } = useUser();
+    const { signOut } = useClerk();
+    const router = useRouter();
+
+    const creator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip",
+    );
+
+    // Not signed in → login.
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) router.replace("/login");
+    }, [isLoaded, isSignedIn, router]);
+
+    // Live auto-route the moment an admin acts (Convex live query fires ~1s).
+    useEffect(() => {
+        if (creator === undefined || creator === null) return;
+        if (creator.role === "admin" || creator.certifiedAt) {
+            router.replace("/dashboard");
+        } else if (creator.rejectedAt) {
+            router.replace("/verification-rejected");
+        } else if (!creator.quizPassedAt) {
+            // Hasn't passed the quiz — they don't belong on the pending gate.
+            router.replace("/training");
+        }
+    }, [creator, router]);
+
+    // Spinner while loading or while a redirect condition is resolving.
+    const pending =
+        creator &&
+        creator.role !== "admin" &&
+        creator.quizPassedAt &&
+        !creator.certifiedAt &&
+        !creator.rejectedAt;
+
+    if (!isLoaded || !isSignedIn || creator === undefined || !pending) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "#FBF3E0" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "#E4B05E" }} />
+            </div>
+        );
+    }
+
+    const firstName = creator.firstName?.trim();
+
+    return (
+        <div
+            className="min-h-screen flex flex-col"
+            style={{ background: "#FBF3E0", color: "#5C3A0F", fontFamily: "var(--font-onest, sans-serif)" }}
+        >
+            {/* Header — sign out is the only action */}
+            <header className="flex justify-end p-4">
+                <button
+                    onClick={() => signOut(() => router.replace("/login"))}
+                    className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full hover:bg-white/60 transition-colors"
+                    style={{ color: "#C89548" }}
+                >
+                    <LogOut className="w-4 h-4" />
+                    Sign out
+                </button>
+            </header>
+
+            <main className="flex-1 flex items-center justify-center px-6 pb-12">
+                <div className="w-full max-w-md text-center space-y-8">
+                    {/* Hero — document-under-review card */}
+                    <div className="relative mx-auto" style={{ width: 240, height: 200 }}>
+                        <div
+                            className="absolute inset-x-0 mx-auto"
+                            style={{
+                                width: 240, height: 180, borderRadius: 28, background: "#fff",
+                                boxShadow: "0 18px 40px rgba(228,176,94,0.18)",
+                            }}
+                        >
+                            {/* pale gold radial accent */}
+                            <div
+                                className="absolute"
+                                style={{ width: 140, height: 140, top: -20, right: -10, borderRadius: "50%", background: "rgba(245,228,192,0.5)" }}
+                            />
+                            {/* document mock-up */}
+                            <div
+                                className="absolute"
+                                style={{
+                                    width: 120, height: 90, top: 38, left: 60, background: "#fff",
+                                    border: "2px solid #E4B05E", borderRadius: 12, padding: 12,
+                                }}
+                            >
+                                <div style={{ width: 50, height: 6, background: "#F5E4C0", borderRadius: 3, marginBottom: 10 }} />
+                                {[0, 1, 2].map((i) => (
+                                    <div key={i} className="flex items-center gap-2" style={{ marginBottom: 6, animation: `pendFade 1.8s ${i * 0.2}s ease-in-out infinite` }}>
+                                        <CheckCircle2 className="w-3.5 h-3.5 shrink-0" style={{ color: "#E4B05E" }} />
+                                        <div style={{ width: 60, height: 4, background: "#a7f3d0", borderRadius: 2 }} />
+                                    </div>
+                                ))}
+                            </div>
+                            {/* rotating search glyph */}
+                            <div className="absolute" style={{ top: 18, right: 24, animation: "pendWobble 4s ease-in-out infinite" }}>
+                                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#C89548" strokeWidth="2">
+                                    <circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" strokeLinecap="round" />
+                                </svg>
+                            </div>
+                            {/* sparkles */}
+                            <span className="absolute" style={{ top: 6, right: 60, fontSize: 14, animation: "pendTwinkle 2.2s ease-in-out infinite" }}>✨</span>
+                            <span className="absolute" style={{ top: 30, right: 8, fontSize: 10, animation: "pendTwinkle 2.6s 0.5s ease-in-out infinite" }}>✨</span>
+                            <span className="absolute" style={{ top: 0, right: 30, fontSize: 12, animation: "pendTwinkle 3s 1s ease-in-out infinite" }}>✨</span>
+                        </div>
+                        {/* avatars peeking over the bottom edge */}
+                        <div className="absolute flex justify-center gap-3 inset-x-0" style={{ bottom: 0 }}>
+                            {["#E4B05E", "#C89548", "#C89548"].map((bg, i) => (
+                                <div
+                                    key={i}
+                                    className="flex items-center justify-center"
+                                    style={{
+                                        width: 40, height: 40, borderRadius: "50%", background: bg,
+                                        border: "3px solid #fff", boxShadow: "0 6px 14px rgba(228,176,94,0.3)",
+                                        animation: `pendBob 2.4s ${i * 0.3}s ease-in-out infinite`,
+                                    }}
+                                >
+                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="#fff"><circle cx="12" cy="8" r="4" /><path d="M4 20c0-4 4-6 8-6s8 2 8 6" /></svg>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Headline */}
+                    <div>
+                        <h1 className="text-3xl font-bold" style={{ fontFamily: "var(--font-instrument-serif, serif)", color: "#5C3A0F" }}>
+                            We&apos;re reviewing your application
+                        </h1>
+                        <p className="mt-3 text-base" style={{ color: "#C89548" }}>
+                            {firstName ? `Hi ${firstName}, ` : ""}our team is carefully going through your quiz results. You&apos;re almost ready to start interviewing businesses.
+                        </p>
+                    </div>
+
+                    {/* ETA card */}
+                    <div className="bg-white rounded-2xl p-5 flex items-center gap-4 text-left" style={{ border: "1px solid #F5E4C0" }}>
+                        <div className="w-11 h-11 rounded-full flex items-center justify-center shrink-0" style={{ background: "#F5E4C0" }}>
+                            <Clock className="w-5 h-5" style={{ color: "#C89548" }} />
+                        </div>
+                        <div>
+                            <p className="text-[11px] font-medium tracking-wide uppercase" style={{ color: "#71717a", fontFamily: "var(--font-mono, monospace)" }}>
+                                Estimated review time
+                            </p>
+                            <p className="text-lg font-bold" style={{ color: "#5C3A0F" }}>Within 24 hours</p>
+                        </div>
+                    </div>
+
+                    {/* Progress checklist */}
+                    <div className="bg-white rounded-2xl p-5 space-y-4 text-left" style={{ border: "1px solid #F5E4C0" }}>
+                        <div className="flex items-center gap-3">
+                            <CheckCircle2 className="w-5 h-5 shrink-0" style={{ color: "#E4B05E" }} />
+                            <div>
+                                <p className="text-sm font-semibold" style={{ color: "#5C3A0F" }}>Quiz passed</p>
+                                <p className="text-xs" style={{ color: "#71717a" }}>{timeAgo(creator.quizPassedAt)}</p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <span className="w-5 h-5 rounded-full shrink-0" style={{ background: "#fbbf24", animation: "pendPulse 1.6s ease-in-out infinite" }} />
+                            <div>
+                                <p className="text-sm font-semibold" style={{ color: "#5C3A0F" }}>Admin review in progress</p>
+                                <p className="text-xs" style={{ color: "#71717a" }}>Our team is verifying your account</p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-3 opacity-50">
+                            <span className="w-5 h-5 rounded-full shrink-0" style={{ border: "2px solid #d4d4d8" }} />
+                            <div>
+                                <p className="text-sm font-semibold" style={{ color: "#5C3A0F" }}>Account activated</p>
+                                <p className="text-xs" style={{ color: "#71717a" }}>Start submitting &amp; earning</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Reassurance footer */}
+                    <div className="flex gap-3 text-left rounded-xl p-3.5" style={{ background: "#FBF3E0", borderLeft: "3px solid #E4B05E" }}>
+                        <span style={{ fontSize: 18 }}>💌</span>
+                        <p className="text-xs leading-relaxed" style={{ color: "#C89548" }}>
+                            We&apos;ll email you the moment you&apos;re approved. You can close this tab — we&apos;ll let you know when you&apos;re in.
+                        </p>
+                    </div>
+                </div>
+            </main>
+
+            <style>{`
+                @keyframes pendFade { 0%,100%{opacity:.4} 50%{opacity:1} }
+                @keyframes pendWobble { 0%,100%{transform:rotate(-6deg)} 50%{transform:rotate(6deg)} }
+                @keyframes pendTwinkle { 0%,100%{opacity:.2} 50%{opacity:1} }
+                @keyframes pendBob { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-4px)} }
+                @keyframes pendPulse { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.25);opacity:.6} }
+                @media (prefers-reduced-motion: reduce) {
+                    [style*="animation"] { animation: none !important; }
+                }
+            `}</style>
+        </div>
+    );
+}

--- a/app/verification-rejected/page.tsx
+++ b/app/verification-rejected/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Creator "application not approved" screen — the bounce target when an admin
+ * sets rejectedAt. Shows the stored rejectionReason. Minimal by design (the
+ * brief scopes resubmission as separate follow-up work); only escape is sign out
+ * or contacting support. Auto-routes away if the admin later re-approves/clears.
+ *
+ * See docs/changes/CREATOR-PENDING-APPROVAL-PAGE.md.
+ */
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useUser, useClerk } from "@clerk/nextjs";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Loader2, XCircle, LogOut } from "lucide-react";
+
+export default function VerificationRejectedPage() {
+    const { user, isLoaded, isSignedIn } = useUser();
+    const { signOut } = useClerk();
+    const router = useRouter();
+
+    const creator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip",
+    );
+
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) router.replace("/login");
+    }, [isLoaded, isSignedIn, router]);
+
+    // If the admin re-approves or clears the rejection, route them onward.
+    useEffect(() => {
+        if (creator === undefined || creator === null) return;
+        if (creator.role === "admin" || creator.certifiedAt) {
+            router.replace("/dashboard");
+        } else if (!creator.rejectedAt) {
+            // Rejection cleared (admin reset) → back to the normal flow.
+            router.replace(creator.quizPassedAt ? "/pending" : "/training");
+        }
+    }, [creator, router]);
+
+    const rejected = creator && creator.role !== "admin" && creator.rejectedAt;
+
+    if (!isLoaded || !isSignedIn || creator === undefined || !rejected) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "#FBF3E0" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "#E4B05E" }} />
+            </div>
+        );
+    }
+
+    const firstName = creator.firstName?.trim();
+    const reason = (creator as { rejectionReason?: string }).rejectionReason;
+
+    return (
+        <div
+            className="min-h-screen flex flex-col"
+            style={{ background: "#FBF3E0", color: "#5C3A0F", fontFamily: "var(--font-onest, sans-serif)" }}
+        >
+            <header className="flex justify-end p-4">
+                <button
+                    onClick={() => signOut(() => router.replace("/login"))}
+                    className="inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-full hover:bg-white/60 transition-colors"
+                    style={{ color: "#C89548" }}
+                >
+                    <LogOut className="w-4 h-4" />
+                    Sign out
+                </button>
+            </header>
+
+            <main className="flex-1 flex items-center justify-center px-6 pb-12">
+                <div className="w-full max-w-md text-center space-y-6">
+                    <div className="w-20 h-20 mx-auto rounded-full flex items-center justify-center" style={{ background: "#fde2e2" }}>
+                        <XCircle className="w-10 h-10" style={{ color: "#dc2626" }} />
+                    </div>
+
+                    <div>
+                        <h1 className="text-3xl font-bold" style={{ fontFamily: "var(--font-instrument-serif, serif)", color: "#5C3A0F" }}>
+                            Application not approved
+                        </h1>
+                        <p className="mt-3 text-base" style={{ color: "#C89548" }}>
+                            {firstName ? `${firstName}, ` : ""}we weren&apos;t able to approve your creator account this time.
+                        </p>
+                    </div>
+
+                    {reason && (
+                        <div className="bg-white rounded-2xl p-5 text-left" style={{ border: "1px solid #F5E4C0" }}>
+                            <p className="text-[11px] font-medium tracking-wide uppercase mb-1" style={{ color: "#71717a", fontFamily: "var(--font-mono, monospace)" }}>
+                                Reason
+                            </p>
+                            <p className="text-sm" style={{ color: "#5C3A0F" }}>{reason}</p>
+                        </div>
+                    )}
+
+                    <div className="flex gap-3 text-left rounded-xl p-3.5" style={{ background: "#FBF3E0", borderLeft: "3px solid #E4B05E" }}>
+                        <span style={{ fontSize: 18 }}>✉️</span>
+                        <p className="text-xs leading-relaxed" style={{ color: "#C89548" }}>
+                            Think this is a mistake? Reach out to the Tendso team and we&apos;ll take another look.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/docs/changes/CREATOR-PENDING-APPROVAL-PAGE.md
+++ b/docs/changes/CREATOR-PENDING-APPROVAL-PAGE.md
@@ -1,0 +1,219 @@
+# Web — Creator Approval Pending Page
+
+> **Single self-contained brief for the web agent.** Build the web-side equivalent of mobile's `/pending-review` screen so creators who sign up via the web Creators page have the same "we're reviewing your application" experience as mobile creators do.
+>
+> **Created 2026-06-19.** Source-of-truth fields live in the existing shared Convex backend — no schema changes required.
+
+---
+
+## 0. Why this exists
+
+The mobile app already has a hard gate: after a creator passes the onboarding quiz, they're routed to `/pending-review`. They cannot submit businesses, cannot access the dashboard, can only sign out — until an admin manually approves them (`creator.certifiedAt` is set) or rejects them (`creator.rejectedAt` is set).
+
+The web Creators page allows signup but **today has no equivalent gate**. Result: a web-only creator who just passed the quiz is dropped into the main creator UI with no clear signal that they're awaiting review. The web admin still has to approve them in the dashboard, but the creator doesn't know that.
+
+This brief specs that gate on web. **No backend changes.** Pure UX + route logic.
+
+---
+
+## 1. The state model (already exists in the shared backend)
+
+The `creators` table already has the three fields the gate needs:
+
+```typescript
+// convex/schema.ts — creators table (existing, no change needed)
+quizPassedAt: v.optional(v.number()),  // creator finished onboarding quiz
+certifiedAt:  v.optional(v.number()),  // admin APPROVED → unlock the app
+rejectedAt:   v.optional(v.number()),  // admin REJECTED → bounce to /verification-rejected
+```
+
+State derivation, in priority order:
+
+| `quizPassedAt` | `certifiedAt` | `rejectedAt` | Creator state | Route |
+|---|---|---|---|---|
+| unset | unset | unset | onboarding | `/onboarding` (existing) |
+| set | unset | unset | **pending review** | **`/creator/pending` (NEW)** |
+| set | set | unset | approved | `/creator/dashboard` (existing) |
+| set | unset | set | rejected | `/creator/verification-rejected` (existing or follow-up) |
+| set | set | set | (impossible — mutually exclusive at any moment) | — |
+
+Routing rule: a creator is "pending" iff `quizPassedAt` is set AND `certifiedAt` is unset AND `rejectedAt` is unset.
+
+---
+
+## 2. What to build
+
+### 2.1 Route guard middleware
+
+Wherever the web app currently gates the `/creator/*` (or equivalent) authenticated area, add the pending check **before** the dashboard renders:
+
+```typescript
+// Pseudocode — adapt to your auth gate / middleware shape
+const creator = await convex.query(api.creators.getByClerkId, { clerkId: user.id });
+
+if (!creator) return redirect("/creator/onboarding");
+if (creator.quizPassedAt && !creator.certifiedAt && !creator.rejectedAt) {
+  return redirect("/creator/pending");
+}
+if (creator.rejectedAt) {
+  return redirect("/creator/verification-rejected");
+}
+// else: certified — let through to dashboard
+```
+
+Apply this on EVERY authenticated creator route (dashboard, submit, wallet, etc.), not just the home page. A creator should not be able to URL-hop around the gate.
+
+**Hard rule (mirrored from mobile):** while on `/creator/pending`, the only escape is **sign out**. No back-button navigation, no in-app links to elsewhere. This matches mobile's `BackHandler` + minimal-chrome behavior.
+
+### 2.2 The page itself — `/creator/pending`
+
+Lift the layout from mobile's `ndm/app/(app)/pending-review.tsx` (Editorial Paper voice, gold accent — same brand). Components:
+
+**Header strip**
+- Single right-aligned "Sign out" button. Nothing else clickable.
+
+**Hero illustration** — match mobile's layered composition exactly (lift the visual, web can use SVG/CSS for the animations instead of Reanimated):
+
+A `240×180` rounded card (white bg, soft gold shadow `#E4B05E` at 15% opacity, `borderRadius: 28`) containing:
+
+1. A pale gold radial accent in the background (`#F5E4C0` at 50% opacity, 140×140 circle, offset top-right)
+2. A nested "document" mock-up — `120×90` white rectangle with a 2px gold border (`#E4B05E`), `borderRadius: 12`. Inside:
+   - A small title-bar block (`50×6`, pale gold `#F5E4C0`)
+   - 3 stacked checklist rows — each a small `Ionicons "checkmark-circle"` in `#E4B05E` followed by a 4px-tall, 60px-wide progress bar (`#a7f3d0` — green-tinted). **The 3 checks fade-in sequentially** (stagger ~200ms each) as the page loads.
+3. A rotating `Ionicons "search"` icon (28px, `#C89548`) overlaid absolutely at `top: 18, right: 24` — slow wobble rotation, 4-6° each way.
+4. Three `✨` sparkle emojis at varied positions/sizes (top-right corner area, 14px / 10px / 12px). They fade in/out on a loop.
+
+Below the card, with `marginTop: -22` so they peek up over the card's bottom edge: three `40×40` avatar circles in `#E4B05E`, `#C89548`, `#C89548`, each with a 3px white border + soft gold shadow. Each contains a person icon (`Ionicons "person"`, `"happy"`, `"person"`). They gently bob (subtle Y-translation animation).
+
+Static fallback is fine if Reanimated-style fine motion is too costly on web — the structure of card + document + checks + sparkles + avatars is the hero, the motion is icing.
+
+**Headline**
+- `We're reviewing your application` (h1, serif, ink color `#5C3A0F`).
+- Personalized sub-line: `Hi {firstName}, our team is carefully going through your quiz results. You're almost ready to start interviewing businesses.` (fall back to `Our team is carefully…` when `firstName` is missing.)
+
+**ETA card**
+- `ESTIMATED REVIEW TIME` (eyebrow, mono, `#71717a`)
+- `Within 24 hours` (heavy, `#5C3A0F`)
+- Clock icon on the left.
+
+**Progress checklist (3 steps)**
+
+| Step | State | Visual |
+|---|---|---|
+| 1. Quiz passed | done | Green/gold check + `timeAgo(creator.quizPassedAt)` underneath |
+| 2. Admin review in progress | in progress | Pulsing amber circle, `Our team is verifying your account` |
+| 3. Account activated | pending | Empty grey circle, `Start submitting & earning` (greyed) |
+
+**Reassurance footer**
+
+A gold-tinted card (`backgroundColor: #FBF3E0`, `borderLeftWidth: 3`, `borderLeftColor: #E4B05E`, `borderRadius: 12`, `padding: 14`). Two-column layout:
+- Left: `💌` emoji (18px)
+- Right: text in `#C89548`, 12px, line-height 18:
+
+  > We'll send you a notification the moment you're approved. You can close the app and we'll let you know when you're in.
+
+**Web translation note:** on web, "close the app" doesn't quite map — the user is on a tab in a browser, not a native app. Consider rewording **only this line** for web:
+
+  > We'll email you the moment you're approved. You can close this tab — we'll let you know when you're in.
+
+The 💌 emoji + the "we'll let you know when you're in" framing stays — that's brand voice.
+
+### 2.3 Auto-route on state change
+
+Critical for parity — when the admin acts in the dashboard, the creator should be moved off this page in real time without needing to refresh. Mobile uses `useQuery` (Convex live query) to subscribe to the creator row. Web should do the same via the Convex React client.
+
+```typescript
+"use client";
+const creator = useQuery(api.creators.getByClerkId, { clerkId });
+const router = useRouter();
+
+useEffect(() => {
+  if (!creator) return;
+  if (creator.certifiedAt) {
+    router.replace("/creator/dashboard");      // approved → home
+  } else if (creator.rejectedAt) {
+    router.replace("/creator/verification-rejected"); // rejected → reason page
+  }
+}, [creator, router]);
+```
+
+Convex's live-query model means this fires within ~1 second of the admin clicking "Approve" — no polling needed.
+
+### 2.4 Admin-side trigger (already exists, just confirm)
+
+Confirm the existing admin dashboard's "Approve creator" action calls the existing Convex mutation (probably `creators.approveCreator` or similar — find in `convex/creators.ts`) and that mutation sets `certifiedAt = Date.now()`. If the web admin dashboard doesn't currently expose this control, expose it on the creator detail page (`/admin/creators/[id]`).
+
+Reject flow likewise — admin sets `rejectedAt` + an optional `rejectionReason` (already in schema if mobile uses it; check `convex/creators.ts` `rejectCreator` mutation).
+
+---
+
+## 3. Visual spec — Editorial Paper + gold (Tendso rebrand)
+
+Use the same design tokens the rest of the web Creators page already uses. Key colors:
+
+| Token | Hex |
+|---|---|
+| Background — page | `#FBF3E0` (pale gold-cream) |
+| Background — cards | `#fff` |
+| Border — cards | `#F5E4C0` |
+| Ink — headlines | `#5C3A0F` (deep amber) |
+| Ink — body | `#C89548` (burnt amber) — secondary text |
+| Ink — muted | `#71717a` |
+| Accent fills (icons, progress dot 1) | `#E4B05E` |
+| In-progress pulse | `#fbbf24` (warm amber) |
+
+Typography: serif headlines (Instrument Serif), Onest body, monospace eyebrows — same as the rest of the Tendso brand surface. The literal "TENDSO" wordmark anywhere uses **Google Sans Flex** (matches mobile's `fonts.wordmark` token).
+
+---
+
+## 4. Verification checklist
+
+After deploy, walk through every state on staging:
+
+- [ ] New creator signs up via web → completes onboarding quiz → lands on `/creator/pending`
+- [ ] Cannot URL-hop to `/creator/dashboard` (route guard redirects back)
+- [ ] Cannot URL-hop to `/creator/submit` etc. (same)
+- [ ] Sign out works
+- [ ] Admin opens dashboard → approves the creator → within ~1s the creator's browser auto-routes to `/creator/dashboard` without a refresh
+- [ ] Different creator: admin rejects → that creator auto-routes to `/creator/verification-rejected` with the reason visible
+- [ ] Mobile and web behavior is identical for the same creator (test: a creator who signed up via web sees the pending page on both surfaces; an admin approval flips both)
+
+---
+
+## 5. What's intentionally NOT in this brief
+
+- ❌ **New schema fields.** Use what's already there. The mobile gate works against these three fields and so should web.
+- ❌ **A new "pending notifications" inbox.** The email-on-approve is implied (the bottom reassurance copy says we'll email). Hooking up that email goes through the existing notification system (`notifications` table + email templates) — separate work.
+- ❌ **Resubmission flow from the pending screen.** Resubmission for rejected creators belongs on `/creator/verification-rejected`, not here.
+- ❌ **Admin-side bulk approval UI.** Out of scope; admins approve one at a time today, which is fine.
+- ❌ **Mobile changes.** Mobile already has this screen built. Nothing to port back.
+
+---
+
+## 6. Reference — files to read on mobile for the design
+
+Mobile's working implementation (read these to lift layout + copy):
+
+- `ndm/app/(app)/pending-review.tsx` — the screen itself (~700 lines, but the layout is straightforward; the bulk is reanimated animations you can simplify or skip on web)
+- `ndm/app/(app)/verification-rejected.tsx` — the rejected-state screen for the bounce target
+- `ndm/convex/creators.ts` — the `approveCreator` / `rejectCreator` mutations + the `getByClerkId` query
+- `ndm/convex/schema.ts` lines 28-32 — the three fields
+
+## 7. Hard rules (still)
+
+- ❌ Mobile must not run `npx convex deploy`. Web repo is the sole deploy authority.
+- ❌ Do NOT rename `quizPassedAt`/`certifiedAt`/`rejectedAt` — mobile reads these by exact name.
+- ❌ Do NOT remove the route guard once added — it's the gate that makes the whole flow safe.
+
+---
+
+## Quick summary
+
+| Item | Effort |
+|---|---|
+| Route guard middleware (1 file) | 15 min |
+| `/creator/pending` page (static + live query subscription) | 2-3 hours including illustration |
+| Admin dashboard approve/reject buttons (if not already wired) | 30-60 min depending on existing UI |
+| Total | **~3-4 hours** |
+
+No backend, no schema, no migration. Pure web UX + route logic against fields the backend already exposes.

--- a/lib/creatorGate.ts
+++ b/lib/creatorGate.ts
@@ -1,0 +1,27 @@
+/**
+ * Where an authenticated creator should be routed based on their lifecycle
+ * state. Single source of truth so every gated page redirects consistently.
+ *
+ * State priority (mutually exclusive at any moment):
+ *   rejected (rejectedAt)                          → /verification-rejected
+ *   passed quiz, not yet approved (quizPassedAt && !certifiedAt) → /pending
+ *   hasn't passed the quiz                         → /training
+ *   approved (certifiedAt) or admin                → null (allow through)
+ *
+ * Returns the path to redirect to, or null if the creator may stay.
+ * Pass the creator row from api.creators.getByClerkId.
+ */
+export interface CreatorGateInput {
+    role?: string;
+    certifiedAt?: number;
+    quizPassedAt?: number;
+    rejectedAt?: number;
+}
+
+export function creatorRedirect(creator: CreatorGateInput | null | undefined): string | null {
+    if (!creator) return null; // not loaded / no profile — caller handles separately
+    if (creator.role === "admin" || creator.certifiedAt) return null; // allowed
+    if (creator.rejectedAt) return "/verification-rejected";
+    if (creator.quizPassedAt) return "/pending";
+    return "/training";
+}


### PR DESCRIPTION
# Latest Changes ✨

**Certification flow changes:**

- Passing the certification quiz now sets a "quiz passed" status (`markQuizPassed`) instead of immediately certifying the creator; admin approval is now required for full certification. The UI and messaging are updated to reflect that the application is under review, and the button directs users to the new `/pending` page. [[1]](diffhunk://#diff-d3d7bea69c48e93517bc1da914752a26a79d73325ea49b755e57f9a73c6a5d89L116-R119) [[2]](diffhunk://#diff-d3d7bea69c48e93517bc1da914752a26a79d73325ea49b755e57f9a73c6a5d89L169-R174) [[3]](diffhunk://#diff-d3d7bea69c48e93517bc1da914752a26a79d73325ea49b755e57f9a73c6a5d89L200-R204) [[4]](diffhunk://#diff-d3d7bea69c48e93517bc1da914752a26a79d73325ea49b755e57f9a73c6a5d89L218-R224)

**Routing and access control updates:**

- Introduced a new `creatorRedirect` utility and updated all relevant pages (`/dashboard`, `/leads`, `/leads/discover`, `/leads/live`, `/leads/[leadId]`) to use it for routing creators based on their lifecycle state. This replaces the previous logic that only checked for certification, allowing for more granular control (pending, rejected, training, etc.). [[1]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R12) [[2]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013L70-R75) [app/leads/[leadId]/page.tsxR18](diffhunk://#diff-30246e3f5df2d4f83d28bcf85e682bdddf2971ba4727596b46aedba6e5ff7459R18), [app/leads/[leadId]/page.tsxL68-R71](diffhunk://#diff-30246e3f5df2d4f83d28bcf85e682bdddf2971ba4727596b46aedba6e5ff7459L68-R71), [[3]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8R31) [[4]](diffhunk://#diff-4dfb7554176327e7f79a9ca6f1b423a4a77ad485bef1142baea01dc28a56b5d8L116-R119) [[5]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eR28) [[6]](diffhunk://#diff-64bc23761bae9f587bd9d2d8855a54d35ec2d84136d4dd6770dedbb3074dea6eL87-R90) [[7]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfR24) [[8]](diffhunk://#diff-c6faf0e3c73bd8e70568d88562a8c5bf7057373af98cb3d50d8006e94cfeeebfL127-R130)

**New pending review page:**

- Added a new `/pending` page (`app/pending/page.tsx`) that presents a dedicated UI for creators whose applications are under admin review. This page provides feedback, a progress checklist, and only allows signing out. It automatically routes users away if their status changes (approved, rejected, or quiz not yet passed).
