### PR TITLE
docs: Discord launch copy-paste pack

### DIFF
--- a/docs/changes/DISCORD-LAUNCH-MESSAGES.md
+++ b/docs/changes/DISCORD-LAUNCH-MESSAGES.md
@@ -1,0 +1,156 @@
+# Tendso — Discord copy-paste pack
+
+> Each block below is ready to paste into Discord as-is. Headers (the `###` lines) are notes for you — don't paste those. Replace anything in `[[brackets]]` before posting.
+
+---
+
+## 1 · ANNOUNCEMENT — share the app
+
+### Paste into #announcements:
+
+```
+@everyone 🎉 **Tendso is LIVE** — https://tendso.com
+
+Tendso is the platform where you get paid to put Filipino local businesses online. 🇵🇭
+
+You visit a local shop — a barbershop, carinderia, salon, sari-sari store, auto repair — ask a few quick questions, snap some photos, record a short interview. Our AI builds them a real website in 24–48 hours. The owner pays, **you keep 50%.**
+
+**👉 Get started: https://tendso.com**
+Download the app, sign up, pass a short quiz, and start earning.
+
+No experience needed. No fees to join. Work part-time, full-time, your pace.
+
+React with ✅ if you're in — questions go in #faq or #support 👇
+```
+
+---
+
+## 2 · "WHAT IS TENDSO" — pinned intro
+
+### Paste into #start-here or #welcome (then pin it):
+
+```
+**👋 Welcome to Tendso**
+
+Tendso turns local Filipino businesses into real websites — and pays everyday people (that's you) to make it happen.
+
+**How it works in one line:** you find a local business → capture their info in the app → our AI builds their site → they pay → you earn 50%.
+
+🌐 **Website / download:** https://tendso.com
+📒 **Knowledge base:** https://tendso.com/knowledge
+💬 **Questions:** #faq · #support
+
+Read the 📜 #rules, then head to https://tendso.com to sign up. Let's get earning. 💰
+```
+
+---
+
+## 3 · HOW TO EARN — high-level overview (make it crystal clear)
+
+### Paste into #how-to-earn (then pin it):
+
+```
+**💰 HOW YOU EARN ON TENDSO — start to payout**
+
+**Step 1 — Sign up & get verified**
+Go to https://tendso.com, download the app, and create your account. Take a short certification quiz. After you pass, your account goes **under review** — our team approves you (usually within 24 hours). You'll get notified the moment you're in. ✅
+
+**Step 2 — Find a local business**
+Walk into any local shop near you — barbershop, salon, restaurant, sari-sari store, auto repair, anything. Pitch them a website for **₱999**.
+
+**Step 3 — Capture it in the app**
+Collect their business info, take 3–5 photos, and record a short audio or video interview. Submit in one tap. The app guides you through every step.
+
+**Step 4 — AI builds the site**
+Our AI turns your capture into a real, coded website in **24–48 hours**. We even enhance the photos automatically.
+
+**Step 5 — Owner approves & pays**
+The business owner reviews their live site. They only pay when they're happy with it.
+
+**Step 6 — You get paid 💸**
+You keep **50% of every sale**, sent straight to your **Wise** wallet — usually within 24 hours of the owner paying.
+
+━━━━━━━━━━━━━━━━━━━━
+**📈 How much can you earn?**
+• You start at the **₱999** launch price → you keep **₱500** per site.
+• After your **first 5 approved submissions**, you unlock **price-setting**: charge anywhere up to **₱4,999** and still keep 50% — up to **₱2,500 per site.**
+• The more you charge, the more you earn.
+• **Refer a friend:** earn **₱1,000** when someone you invited lands their first paid submission.
+
+**👉 Everything starts here: https://tendso.com**
+```
+
+---
+
+## 4 · FAQ — short version
+
+### Paste into #faq (then pin it):
+
+```
+**❓ TENDSO FAQ**
+
+**Is it free to join?** Yes. No fees, no deposit. We never ask you to pay to start.
+
+**How much do I earn?** 50% of every site — ₱500 at the ₱999 start, up to ₱2,500 once you unlock higher pricing. +₱1,000 per referral.
+
+**How do I get paid?** Via Wise, usually within 24 hours of the owner paying.
+
+**Do I need skills or a laptop?** No. Just a phone. The AI builds the site; the app guides you.
+
+**Why can't I submit after the quiz?** Your account is under review — we approve you within ~24 hours, then you're in.
+
+**Is it legit?** Yes — real site (https://tendso.com), real businesses, real Wise payouts. We never charge you to join.
+
+**Still stuck?** Ask in #support 👇
+```
+
+---
+
+## 5 · SERVER RULES — 10 rules
+
+### Paste into #rules (then pin it):
+
+```
+**📜 TENDSO SERVER RULES**
+
+**1. Be respectful.** Treat every member like a teammate. No harassment, hate speech, slurs, or personal attacks.
+
+**2. No spam.** Don't flood channels, mass-mention, or post the same message repeatedly. Use the right channel for your message.
+
+**3. Keep it on-topic.** Use channels for their purpose — #faq for questions, #support for help, #wins for your earnings/sites, etc.
+
+**4. No scams or fake offers.** Tendso never charges you to join or asks for upfront payment. Anyone here asking you to pay them, send "processing fees," or share your password is a scammer — report them immediately.
+
+**5. Protect private info.** Never share your password, Wise login, OTP codes, or another person's personal details. Keep business owners' info confidential.
+
+**6. No self-promo or unrelated ads.** This server is for Tendso. Don't advertise other apps, MLMs, crypto, or "earn money fast" schemes.
+
+**7. Honest work only.** No fake businesses, no made-up info, no fabricated photos or reviews. Real shops, real details — that's what keeps the platform (and your payouts) alive.
+
+**8. One account per person.** Don't create multiple accounts to game referrals or submissions.
+
+**9. English or Filipino is fine** — just keep it clear and civil. NSFW, gore, and illegal content are never allowed.
+
+**10. Listen to the team.** Admins and mods have the final say. If you disagree, take it to DMs or #support calmly — don't argue in public channels.
+
+Breaking these can get you muted, kicked, or banned. Play fair and let's all earn. 🤝
+```
+
+---
+
+## 6 · QUICK CTA — drop anytime to re-share the link
+
+### Paste into any channel when you want to nudge:
+
+```
+Ready to earn? 💰 Download Tendso and sign up 👉 https://tendso.com
+Visit a local shop, capture it in the app, keep 50% of every sale. Paid via Wise.
+```
+
+---
+
+### Notes for you (don't paste)
+- All numbers above match the live product: **₱999 base → ₱4,999 cap after 5 approved submissions, 50% commission, ₱1,000 referral, Wise payouts, admin approval after the quiz.** If any of those change, update this file.
+- Replace `@everyone` with `@here` or a role ping if you don't want to hit everyone.
+- Set up channels referenced here (#announcements, #start-here, #how-to-earn, #faq, #rules, #support, #wins) or rename to match yours before pasting the cross-links.
+- The download today is the Android APK via https://tendso.com (iOS "coming soon" per the site). If iOS ships, add it.


### PR DESCRIPTION
## Summary

Adds `docs/changes/DISCORD-LAUNCH-MESSAGES.md` — a copy-paste-ready Discord pack for the Tendso community launch. Each block is in a code fence so it can be grabbed in one click and pasted straight into Discord.

**Docs-only. No code changes.**

## What's in it
1. **Announcement** — `@everyone` launch post advertising **https://tendso.com** as the main site + app download ("download the app and earn").
2. **"What is Tendso" intro** — pinnable welcome, one-line explainer + links.
3. **How to earn** — clear 6-step overview (sign up & get verified → find a business → capture in app → AI builds → owner approves & pays → paid via Wise), plus the earnings breakdown.
4. **FAQ (short)** — the 6 questions a newcomer actually asks (fees, earnings, payout, skills/laptop, why-can't-I-submit-after-the-quiz, is-it-legit).
5. **10 server rules** — respect, no spam, on-topic, anti-scam, protect private info, no MLM/self-promo, honest work, one account, language/NSFW, listen to the team.
6. **Quick CTA** — reusable link-drop.

## Accuracy
All numbers match the **live product** as built this cycle: ₱999 base → ₱4,999 cap after 5 approved submissions, 50% commission, ₱1,000 referral, Wise payouts, and the admin-approval-after-quiz flow. A "Notes for you" section (not meant to be pasted) lists the placeholders to adjust before posting (channel names, `@everyone` vs role ping, iOS when it ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)