### PR TITLE
fix(email): itemize payment email with the real domain price, not a flat ₱500

### DIFF
--- a/app/api/preview-email/route.ts
+++ b/app/api/preview-email/route.ts
@@ -89,6 +89,7 @@ export async function GET(request: NextRequest) {
                 referenceCode,
                 platformEmail: process.env.WISE_EMAIL,
                 customDomain,
+                domainCostPHP: (submission as any).domainCostPHP || undefined,
             })
         } else if (type === 'domain_setup_progress') {
             const submissionAny = submission as any

--- a/app/api/send-website-email/route.ts
+++ b/app/api/send-website-email/route.ts
@@ -100,6 +100,7 @@ export async function POST(request: NextRequest) {
             referenceCode: paymentToken.referenceCode,
             platformEmail: process.env.WISE_EMAIL,
             customDomain: (submission as any).requestedDomain || undefined,
+            domainCostPHP: (submission as any).domainCostPHP || undefined,
         })
 
         // Record email sent timestamp

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -138,7 +138,8 @@ interface PaymentLinkEmailData {
     paymentLink: string;
     referenceCode: string;
     platformEmail?: string;
-    customDomain?: string; // If set, template shows breakdown (website ₱999 + domain ₱500)
+    customDomain?: string; // If set, template shows a website + domain breakdown
+    domainCostPHP?: number; // Real frozen domain price (submissions.domainCostPHP) for the breakdown split
 }
 
 export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
@@ -151,6 +152,7 @@ export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
             referenceCode: data.referenceCode,
             platformEmail: data.platformEmail,
             customDomain: data.customDomain,
+            domainCostPHP: data.domainCostPHP,
         });
         return await sendEmail({
             to: data.businessOwnerEmail,

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -183,8 +183,15 @@ export function getPaymentLinkEmailHtml(params: {
     referenceCode: string
     platformEmail?: string
     customDomain?: string
+    // The REAL frozen domain price (submissions.domainCostPHP). Used to split the
+    // itemized breakdown correctly. Falls back to the flat CUSTOM_DOMAIN_ADDON
+    // only for legacy submissions that predate real-domain pricing.
+    domainCostPHP?: number
 }): string {
-    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain } = params
+    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain, domainCostPHP } = params
+    // Real domain charge for the line-item split; the website-package line is the remainder.
+    const domainLine = domainCostPHP && domainCostPHP > 0 ? domainCostPHP : CUSTOM_DOMAIN_ADDON
+    const websiteLine = amount - domainLine
     const wiseEmail = platformEmail || paymentConfig.wiseEmail || 'frmwrkd.media@gmail.com'
 
     return `
@@ -242,7 +249,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Website Package</td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(amount - CUSTOM_DOMAIN_ADDON)}</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(websiteLine)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>
@@ -252,7 +259,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Custom Domain: <strong style="color:#C89548;">${customDomain}</strong></td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(CUSTOM_DOMAIN_ADDON)}</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(domainLine)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>


### PR DESCRIPTION
## Problem

The payment-link email (`getPaymentLinkEmailHtml`) renders a two-line cost breakdown for custom-domain orders — **Website Package** + **Custom Domain**. Both lines were derived from the hardcoded `CUSTOM_DOMAIN_ADDON` constant (₱500):

```
Website Package:  amount − CUSTOM_DOMAIN_ADDON   // amount − 500
Custom Domain:    CUSTOM_DOMAIN_ADDON            // always ₱500
```

But the pricing engine now charges the domain's **real registrar price**, frozen on `submissions.domainCostPHP`, and `amount = sellPrice + domainCostPHP`. So whenever a domain cost ≠ ₱500, the emailed split was wrong:

- a ₱720 domain showed **"Custom Domain ₱500"**, and
- **"Website Package"** was overstated by ₱220.

The **total** (`amount`) was always correct — only the itemized split misrepresented it. To a business owner, the line items didn't add up to a believable breakdown.

## Fix

Thread the real `domainCostPHP` through the email send chain and split the breakdown on it; fall back to `CUSTOM_DOMAIN_ADDON` only for legacy submissions that predate real-domain pricing.

| File | Change |
|---|---|
| `lib/email/templates.ts` | `getPaymentLinkEmailHtml` accepts optional `domainCostPHP`; Custom Domain row = real price, Website Package row = `amount − domainCostPHP` |
| `lib/email/service.ts` | `sendPaymentLinkEmail` forwards `domainCostPHP` |
| `app/api/send-website-email/route.ts` | passes `submission.domainCostPHP` (the live send path) |
| `app/api/preview-email/route.ts` | passes it too, so the admin email preview matches what's actually sent |

## Scope & safety
- **No schema/data change** — `domainCostPHP` is already frozen on the submission at submit time.
- **Backward compatible** — submissions without a frozen `domainCostPHP` fall back to the old ₱500 line, so nothing breaks for legacy rows.
- Only the **payment-link** email had the itemized split; the payment-confirmation email shows the total only and was unaffected.

## Verification
- `tsc --noEmit` → clean.
- Logic check: domain ₱720, sellPrice ₱2,500 → `amount` ₱3,220 → email now shows Website Package ₱2,500 + Custom Domain ₱720 = ₱3,220. ✅

## Context
Last instance of the abolished flat-₱500 assumption (the success-page payout and landing copy were fixed in earlier PRs); this clears it from the transactional email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)