### PR TITLE
Devpatch8

### DIFF
--- a/__tests__/owner/ownerClaim.test.ts
+++ b/__tests__/owner/ownerClaim.test.ts
@@ -1,0 +1,84 @@
+import {
+    generateClaimToken,
+    isValidClaimTokenFormat,
+    claimTokenExpiry,
+    isClaimTokenUsable,
+    normalizeEmail,
+    emailMatchesSubmission,
+    ownsSubmission,
+    CLAIM_TOKEN_TTL_MS,
+} from '../../lib/ownerClaim';
+
+describe('ownerClaim — token format & expiry', () => {
+    it('generates a 64-char hex token', () => {
+        const t = generateClaimToken();
+        expect(t).toMatch(/^[0-9a-f]{64}$/);
+    });
+    it('generates distinct tokens', () => {
+        const set = new Set(Array.from({ length: 50 }, () => generateClaimToken()));
+        expect(set.size).toBe(50);
+    });
+    it('validates format strictly', () => {
+        expect(isValidClaimTokenFormat('a'.repeat(64))).toBe(true);
+        expect(isValidClaimTokenFormat('A'.repeat(64))).toBe(false); // uppercase
+        expect(isValidClaimTokenFormat('a'.repeat(63))).toBe(false); // too short
+        expect(isValidClaimTokenFormat('xyz')).toBe(false);
+        expect(isValidClaimTokenFormat('')).toBe(false);
+    });
+    it('sets a 7-day expiry', () => {
+        const now = 1_000_000;
+        expect(claimTokenExpiry(now)).toBe(now + CLAIM_TOKEN_TTL_MS);
+    });
+});
+
+describe('ownerClaim — token usability', () => {
+    const now = 1_000_000;
+    it('pending + not expired = usable', () => {
+        expect(isClaimTokenUsable({ status: 'pending', expiresAt: now + 1000 }, now)).toBe(true);
+    });
+    it('expired = not usable', () => {
+        expect(isClaimTokenUsable({ status: 'pending', expiresAt: now - 1 }, now)).toBe(false);
+        expect(isClaimTokenUsable({ status: 'pending', expiresAt: now }, now)).toBe(false); // boundary
+    });
+    it('already consumed / cancelled = not usable', () => {
+        expect(isClaimTokenUsable({ status: 'consumed', expiresAt: now + 1000 }, now)).toBe(false);
+        expect(isClaimTokenUsable({ status: 'cancelled', expiresAt: now + 1000 }, now)).toBe(false);
+        expect(isClaimTokenUsable({ status: 'expired', expiresAt: now + 1000 }, now)).toBe(false);
+    });
+});
+
+describe('ownerClaim — email match (the claim trust anchor)', () => {
+    it('normalizes (trim + lowercase)', () => {
+        expect(normalizeEmail('  Owner@Shop.PH ')).toBe('owner@shop.ph');
+        expect(normalizeEmail(undefined)).toBe('');
+    });
+    it('matches case/whitespace-insensitively', () => {
+        expect(emailMatchesSubmission('owner@shop.ph', '  Owner@Shop.PH')).toBe(true);
+    });
+    it('rejects a mismatch', () => {
+        expect(emailMatchesSubmission('attacker@evil.com', 'owner@shop.ph')).toBe(false);
+    });
+    it('rejects empty/missing on either side (no blank-matches-blank)', () => {
+        expect(emailMatchesSubmission('', '')).toBe(false);
+        expect(emailMatchesSubmission(undefined, 'owner@shop.ph')).toBe(false);
+        expect(emailMatchesSubmission('owner@shop.ph', null)).toBe(false);
+    });
+});
+
+describe('ownerClaim — ownership check (the per-mutation gate)', () => {
+    const ownerships = [
+        { businessOwnerId: 'owner1', submissionId: 'subA' },
+        { businessOwnerId: 'owner1', submissionId: 'subB' },
+    ];
+    it('allows an owner to act on their own submission', () => {
+        expect(ownsSubmission('owner1', 'subA', ownerships)).toBe(true);
+        expect(ownsSubmission('owner1', 'subB', ownerships)).toBe(true);
+    });
+    it("blocks acting on someone else's submission (the URL-hop attack)", () => {
+        expect(ownsSubmission('owner1', 'subC', ownerships)).toBe(false);
+        expect(ownsSubmission('owner2', 'subA', ownerships)).toBe(false);
+    });
+    it('blocks when the owner has no ownership rows', () => {
+        expect(ownsSubmission('owner9', 'subA', [])).toBe(false);
+    });
+});

--- a/app/api/preview-email/route.ts
+++ b/app/api/preview-email/route.ts
@@ -89,6 +89,7 @@ export async function GET(request: NextRequest) {
                 referenceCode,
                 platformEmail: process.env.WISE_EMAIL,
                 customDomain,
+                domainCostPHP: (submission as any).domainCostPHP || undefined,
             })
         } else if (type === 'domain_setup_progress') {
             const submissionAny = submission as any

--- a/app/api/send-website-email/route.ts
+++ b/app/api/send-website-email/route.ts
@@ -90,6 +90,21 @@ export async function POST(request: NextRequest) {
         const paymentConfig = getPaymentConfig()
         const paymentLink = paymentConfig.getPaymentLink(paymentToken.token)
 
+        // Mint an owner claim token → "Edit my website" link (Phase 1 owner portal).
+        // Best-effort: if it fails, still send the payment email (claim is additive).
+        let editMyWebsiteUrl: string | undefined
+        try {
+            const claim = await fetchMutation(api.businessOwners.issueClaimTokenForEmail, {
+                submissionId: submissionId as Id<"submissions">,
+            })
+            const base = process.env.NEXT_PUBLIC_SITE_URL?.startsWith('https://')
+                ? process.env.NEXT_PUBLIC_SITE_URL.replace(/\/$/, '')
+                : 'https://tendso.com'
+            editMyWebsiteUrl = `${base}/my-business/claim?token=${claim.token}`
+        } catch (e) {
+            console.error('Failed to mint owner claim token (non-fatal):', e)
+        }
+
         // Send payment link email (includes custom domain breakdown if applicable)
         await sendPaymentLinkEmail({
             businessName: submission.businessName,
@@ -100,6 +115,7 @@ export async function POST(request: NextRequest) {
             referenceCode: paymentToken.referenceCode,
             platformEmail: process.env.WISE_EMAIL,
             customDomain: (submission as any).requestedDomain || undefined,
+            editMyWebsiteUrl,
         })
 
         // Record email sent timestamp

--- a/app/api/send-website-email/route.ts
+++ b/app/api/send-website-email/route.ts
@@ -100,6 +100,7 @@ export async function POST(request: NextRequest) {
             referenceCode: paymentToken.referenceCode,
             platformEmail: process.env.WISE_EMAIL,
             customDomain: (submission as any).requestedDomain || undefined,
+            domainCostPHP: (submission as any).domainCostPHP || undefined,
         })
 
         // Record email sent timestamp

--- a/app/my-business/[submissionId]/page.tsx
+++ b/app/my-business/[submissionId]/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * Scoped owner editor — content-only, fenced to a website the signed-in owner
+ * owns. Reads/writes via ownership-gated Convex functions (getMyWebsiteContent /
+ * updateMyWebsiteContent), which re-check websiteOwnerships server-side, so a
+ * guessed submissionId in the URL is rejected, not just hidden.
+ *
+ * Owners edit content fields only (text, services, contact). Templates, domains,
+ * status, and the build pipeline are NOT exposed here — by design.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useOwnerAuth } from "@/hooks/useOwnerAuth";
+import { Loader2, ArrowLeft, Check } from "lucide-react";
+
+type ContactPatch = { email: string; phone: string; address?: string };
+
+export default function OwnerEditPage() {
+    const params = useParams();
+    const submissionId = params.submissionId as Id<"submissions">;
+    const router = useRouter();
+    const { isOwner, isSignedIn, loading } = useOwnerAuth();
+
+    const content = useQuery(
+        api.businessOwners.getMyWebsiteContent,
+        isOwner ? { submissionId } : "skip",
+    );
+    const save = useMutation(api.businessOwners.updateMyWebsiteContent);
+
+    // Local form state, seeded from the loaded content once.
+    const [form, setForm] = useState<Record<string, string>>({});
+    const [contact, setContact] = useState<ContactPatch | null>(null);
+    const [seeded, setSeeded] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [saved, setSaved] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!loading && isSignedIn === false) router.replace("/login");
+    }, [loading, isSignedIn, router]);
+
+    useEffect(() => {
+        if (content && !seeded) {
+            const c = content as Record<string, unknown>;
+            setForm({
+                businessName: (c.businessName as string) ?? "",
+                tagline: (c.tagline as string) ?? "",
+                aboutText: (c.aboutText as string) ?? "",
+                heroHeadline: (c.heroHeadline as string) ?? "",
+                heroSubheadline: (c.heroSubheadline as string) ?? "",
+                aboutHeadline: (c.aboutHeadline as string) ?? "",
+                aboutDescription: (c.aboutDescription as string) ?? "",
+                servicesHeadline: (c.servicesHeadline as string) ?? "",
+            });
+            const ct = c.contact as ContactPatch | undefined;
+            setContact({ email: ct?.email ?? "", phone: ct?.phone ?? "", address: ct?.address ?? "" });
+            setSeeded(true);
+        }
+    }, [content, seeded]);
+
+    const setField = (k: string, v: string) => {
+        setForm((f) => ({ ...f, [k]: v }));
+        setSaved(false);
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            const patch: Record<string, unknown> = { ...form };
+            if (contact && (contact.email || contact.phone || contact.address)) {
+                patch.contact = { email: contact.email, phone: contact.phone, address: contact.address || undefined };
+            }
+            await save({ submissionId, patch });
+            setSaved(true);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to save changes.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (loading || (isOwner && content === undefined)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "#FBF3E0" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "#E4B05E" }} />
+            </div>
+        );
+    }
+
+    // content === null → not owned (gate rejected) or no content row.
+    if (content === null) {
+        return (
+            <div className="min-h-screen flex items-center justify-center px-6" style={{ background: "#FBF3E0", color: "#5C3A0F" }}>
+                <div className="max-w-md text-center space-y-3">
+                    <h1 className="text-2xl font-bold">Website not available</h1>
+                    <p style={{ color: "#C89548" }}>You don&apos;t have access to this website, or its content isn&apos;t ready yet.</p>
+                    <Link href="/my-business" className="inline-block hover:underline" style={{ color: "#E4B05E" }}>← Back to my business</Link>
+                </div>
+            </div>
+        );
+    }
+
+    const textFields: Array<{ key: string; label: string; multiline?: boolean }> = [
+        { key: "businessName", label: "Business name" },
+        { key: "tagline", label: "Tagline" },
+        { key: "heroHeadline", label: "Hero headline" },
+        { key: "heroSubheadline", label: "Hero subheadline" },
+        { key: "aboutHeadline", label: "About — headline" },
+        { key: "aboutDescription", label: "About — description", multiline: true },
+        { key: "aboutText", label: "About — text", multiline: true },
+        { key: "servicesHeadline", label: "Services — headline" },
+    ];
+
+    return (
+        <div className="min-h-screen px-6 py-10" style={{ background: "#FBF3E0", color: "#5C3A0F" }}>
+            <div className="max-w-xl mx-auto space-y-6">
+                <Link href="/my-business" className="inline-flex items-center gap-1 text-sm hover:underline" style={{ color: "#C89548" }}>
+                    <ArrowLeft className="w-4 h-4" /> My business
+                </Link>
+
+                <header>
+                    <h1 className="text-2xl font-bold">Edit your website</h1>
+                    <p className="mt-1 text-sm" style={{ color: "#C89548" }}>Update your text and contact details. Changes save to your live site.</p>
+                </header>
+
+                {error && (
+                    <div className="p-4 rounded-lg" style={{ background: "#fde2e2", color: "#dc2626" }}>{error}</div>
+                )}
+
+                <div className="bg-white rounded-2xl p-6 space-y-4" style={{ border: "1px solid #F5E4C0" }}>
+                    {textFields.map((f) => (
+                        <div key={f.key}>
+                            <label className="text-xs font-medium uppercase tracking-wide" style={{ color: "#71717a" }}>{f.label}</label>
+                            {f.multiline ? (
+                                <textarea
+                                    value={form[f.key] ?? ""}
+                                    onChange={(e) => setField(f.key, e.target.value)}
+                                    rows={3}
+                                    className="mt-1 w-full px-3 py-2 border rounded-lg"
+                                    style={{ borderColor: "#F5E4C0" }}
+                                />
+                            ) : (
+                                <input
+                                    value={form[f.key] ?? ""}
+                                    onChange={(e) => setField(f.key, e.target.value)}
+                                    className="mt-1 w-full px-3 py-2 border rounded-lg"
+                                    style={{ borderColor: "#F5E4C0" }}
+                                />
+                            )}
+                        </div>
+                    ))}
+
+                    <div className="pt-2 border-t" style={{ borderColor: "#F5E4C0" }}>
+                        <p className="text-xs font-semibold uppercase tracking-wide mb-2" style={{ color: "#71717a" }}>Contact</p>
+                        {(["phone", "email", "address"] as const).map((k) => (
+                            <div key={k} className="mb-3">
+                                <label className="text-xs capitalize" style={{ color: "#71717a" }}>{k}</label>
+                                <input
+                                    value={contact?.[k] ?? ""}
+                                    onChange={(e) => { setContact((c) => ({ ...(c ?? { email: "", phone: "" }), [k]: e.target.value })); setSaved(false); }}
+                                    className="mt-1 w-full px-3 py-2 border rounded-lg"
+                                    style={{ borderColor: "#F5E4C0" }}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <button
+                    onClick={handleSave}
+                    disabled={saving}
+                    className="w-full h-12 rounded-xl text-white font-bold inline-flex items-center justify-center gap-2 disabled:opacity-50"
+                    style={{ background: "#E4B05E" }}
+                >
+                    {saving ? <Loader2 className="h-5 w-5 animate-spin" /> : saved ? <><Check className="h-5 w-5" /> Saved</> : "Save changes"}
+                </button>
+                <p className="text-center text-xs" style={{ color: "#71717a" }}>
+                    Need a bigger change, or help? Reply to any Tendso email and our team will assist.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/app/my-business/claim/page.tsx
+++ b/app/my-business/claim/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * Claim landing — the target of the "Edit my website" email button.
+ * URL: /my-business/claim?token=<64hex>
+ *
+ * Flow: the owner must be signed in (Clerk passwordless, with the email the site
+ * was sold to). claimWebsite enforces that the signed-in email matches the
+ * submission's ownerEmail server-side — a leaked link is useless otherwise.
+ */
+
+import { useEffect, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+
+function ClaimInner() {
+    const params = useSearchParams();
+    const token = params.get("token") ?? "";
+    const router = useRouter();
+    const { isLoaded, isSignedIn } = useUser();
+
+    const tokenInfo = useQuery(api.businessOwners.getClaimToken, token ? { token } : "skip");
+    const claim = useMutation(api.businessOwners.claimWebsite);
+
+    const [error, setError] = useState<string | null>(null);
+    const [claiming, setClaiming] = useState(false);
+
+    // Not signed in → send to login, returning here afterward.
+    useEffect(() => {
+        if (isLoaded && !isSignedIn) {
+            router.replace(`/login?redirect_url=${encodeURIComponent(`/my-business/claim?token=${token}`)}`);
+        }
+    }, [isLoaded, isSignedIn, router, token]);
+
+    // Auto-redeem once signed in and the token is usable.
+    useEffect(() => {
+        if (!isSignedIn || !tokenInfo || claiming) return;
+        if (!tokenInfo.usable) return;
+        setClaiming(true);
+        claim({ token })
+            .then((res) => router.replace(`/my-business/${res.submissionId}`))
+            .catch((e) => {
+                setError(e instanceof Error ? e.message : "Could not claim this website.");
+                setClaiming(false);
+            });
+    }, [isSignedIn, tokenInfo, claim, token, router, claiming]);
+
+    if (!token) {
+        return <ClaimMessage icon="error" title="Invalid link" body="This claim link is missing its token." />;
+    }
+    if (!isLoaded || tokenInfo === undefined || (isSignedIn && tokenInfo?.usable && !error)) {
+        return <ClaimMessage icon="spinner" title="Claiming your website…" body="One moment." />;
+    }
+    if (tokenInfo === null || !tokenInfo.usable) {
+        return (
+            <ClaimMessage
+                icon="error"
+                title="This link can't be used"
+                body="It may have expired or already been used. Open the latest email from Tendso, or ask us to resend your link."
+            />
+        );
+    }
+    if (error) {
+        return <ClaimMessage icon="error" title="Couldn't claim this website" body={error} />;
+    }
+    return <ClaimMessage icon="spinner" title="Almost there…" body="Verifying your account." />;
+}
+
+function ClaimMessage({ icon, title, body }: { icon: "spinner" | "ok" | "error"; title: string; body: string }) {
+    return (
+        <div className="min-h-screen flex items-center justify-center px-6" style={{ background: "#FBF3E0", color: "#5C3A0F" }}>
+            <div className="max-w-md text-center space-y-4">
+                {icon === "spinner" && <Loader2 className="w-10 h-10 mx-auto animate-spin" style={{ color: "#E4B05E" }} />}
+                {icon === "ok" && <CheckCircle2 className="w-10 h-10 mx-auto" style={{ color: "#E4B05E" }} />}
+                {icon === "error" && <AlertCircle className="w-10 h-10 mx-auto" style={{ color: "#dc2626" }} />}
+                <h1 className="text-2xl font-bold">{title}</h1>
+                <p style={{ color: "#C89548" }}>{body}</p>
+            </div>
+        </div>
+    );
+}
+
+export default function ClaimPage() {
+    return (
+        <Suspense fallback={<ClaimMessage icon="spinner" title="Loading…" body="" />}>
+            <ClaimInner />
+        </Suspense>
+    );
+}

--- a/app/my-business/page.tsx
+++ b/app/my-business/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * Business Owner Portal — dashboard. Lists the websites the signed-in owner has
+ * claimed (via the "Edit my website" email link). Owners are a separate audience
+ * from creators; this whole route group is gated by Clerk + a businessOwners row.
+ *
+ * See docs/changes/OWNER-PORTAL-PRICING-PLAN.md Phase 1.
+ */
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { useOwnerAuth } from "@/hooks/useOwnerAuth";
+import { Loader2, Globe, Pencil, Users, ExternalLink } from "lucide-react";
+
+export default function MyBusinessDashboard() {
+    const { isOwner, isSignedIn, loading } = useOwnerAuth();
+    const router = useRouter();
+    const websites = useQuery(api.businessOwners.getMyWebsites, isOwner ? {} : "skip");
+
+    useEffect(() => {
+        if (!loading && isSignedIn === false) router.replace("/login");
+    }, [loading, isSignedIn, router]);
+
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center" style={{ background: "#FBF3E0" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: "#E4B05E" }} />
+            </div>
+        );
+    }
+
+    // Signed in but no claimed sites yet → nudge to use the email link.
+    if (!isOwner) {
+        return (
+            <div className="min-h-screen flex items-center justify-center px-6" style={{ background: "#FBF3E0" }}>
+                <div className="max-w-md text-center space-y-4">
+                    <Globe className="w-12 h-12 mx-auto" style={{ color: "#E4B05E" }} />
+                    <h1 className="text-2xl font-bold" style={{ color: "#5C3A0F" }}>No website claimed yet</h1>
+                    <p style={{ color: "#C89548" }}>
+                        Open the <strong>&quot;Edit my website&quot;</strong> link in any email from Tendso to claim and manage your site here.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen px-6 py-12" style={{ background: "#FBF3E0", color: "#5C3A0F" }}>
+            <div className="max-w-2xl mx-auto space-y-6">
+                <header>
+                    <h1 className="text-3xl font-bold">My business</h1>
+                    <p className="mt-1" style={{ color: "#C89548" }}>Manage your website&apos;s content.</p>
+                </header>
+
+                {websites === undefined ? (
+                    <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#E4B05E" }} />
+                ) : websites.length === 0 ? (
+                    <p style={{ color: "#C89548" }}>No websites yet.</p>
+                ) : (
+                    <div className="space-y-4">
+                        {websites.map((w) => (
+                            <div key={w.submissionId} className="bg-white rounded-2xl p-5" style={{ border: "1px solid #F5E4C0" }}>
+                                <div className="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h2 className="text-lg font-semibold">{w.businessName}</h2>
+                                        <p className="text-xs mt-1 capitalize" style={{ color: "#71717a" }}>Status: {w.status}</p>
+                                        <p className="text-xs mt-1 flex items-center gap-1" style={{ color: "#71717a" }}>
+                                            <Users className="w-3.5 h-3.5" /> {w.leadCount} lead{w.leadCount === 1 ? "" : "s"}
+                                        </p>
+                                    </div>
+                                    {w.publishedUrl && (
+                                        <a
+                                            href={w.publishedUrl}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="text-sm inline-flex items-center gap-1 hover:underline"
+                                            style={{ color: "#C89548" }}
+                                        >
+                                            View <ExternalLink className="w-3.5 h-3.5" />
+                                        </a>
+                                    )}
+                                </div>
+                                <div className="mt-4">
+                                    <Link
+                                        href={`/my-business/${w.submissionId}`}
+                                        className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-white font-medium text-sm"
+                                        style={{ background: "#E4B05E" }}
+                                    >
+                                        <Pencil className="w-4 h-4" /> Edit website
+                                    </Link>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as airtable from "../airtable.js";
 import type * as analytics from "../analytics.js";
 import type * as analyticsJobs from "../analyticsJobs.js";
 import type * as auditLogs from "../auditLogs.js";
+import type * as businessOwners from "../businessOwners.js";
 import type * as creators from "../creators.js";
 import type * as crons from "../crons.js";
 import type * as discord from "../discord.js";
@@ -71,6 +72,7 @@ declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   analyticsJobs: typeof analyticsJobs;
   auditLogs: typeof auditLogs;
+  businessOwners: typeof businessOwners;
   creators: typeof creators;
   crons: typeof crons;
   discord: typeof discord;

--- a/convex/businessOwners.ts
+++ b/convex/businessOwners.ts
@@ -1,0 +1,337 @@
+import { v } from 'convex/values';
+import { query, mutation, internalMutation } from './_generated/server';
+import type { QueryCtx, MutationCtx } from './_generated/server';
+import type { Doc, Id } from './_generated/dataModel';
+import {
+    generateClaimToken,
+    isValidClaimTokenFormat,
+    isClaimTokenUsable,
+    claimTokenExpiry,
+    emailMatchesSubmission,
+} from '../lib/ownerClaim';
+
+/**
+ * Business Owner Portal — identity, claim flow, and ownership-gated content edits.
+ * See docs/changes/OWNER-PORTAL-PRICING-PLAN.md Phase 1.
+ *
+ * Trust model (the load-bearing rules — pure logic lives in lib/ownerClaim.ts):
+ *  - An owner is a businessOwners row, authenticated via Clerk (passwordless).
+ *  - They claim a website by clicking an "Edit my website" link whose single-use
+ *    token was emailed to the submission's ownerEmail. At claim time the signed-in
+ *    email MUST match that ownerEmail (emailMatchesSubmission).
+ *  - EVERY content mutation re-checks websiteOwnerships server-side — a leaked link
+ *    or a guessed submission id can never edit a site the caller doesn't own.
+ */
+
+// ---- identity helpers ----
+
+async function getOwner(ctx: QueryCtx | MutationCtx): Promise<Doc<'businessOwners'> | null> {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    return await ctx.db
+        .query('businessOwners')
+        .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+        .first();
+}
+
+/** Server-side ownership gate: throws unless the signed-in owner owns this submission. */
+async function requireOwnership(
+    ctx: QueryCtx | MutationCtx,
+    submissionId: Id<'submissions'>,
+): Promise<Doc<'businessOwners'>> {
+    const owner = await getOwner(ctx);
+    if (!owner) throw new Error('Not signed in as a business owner');
+    const link = await ctx.db
+        .query('websiteOwnerships')
+        .withIndex('by_submission', (q) => q.eq('submissionId', submissionId))
+        .filter((q) => q.eq(q.field('businessOwnerId'), owner._id))
+        .first();
+    if (!link) throw new Error('Forbidden: you do not own this website');
+    return owner;
+}
+
+// ==================== QUERIES ====================
+
+/** The current viewer's owner profile (null if not an owner / not signed in). */
+export const me = query({
+    args: {},
+    handler: async (ctx) => getOwner(ctx),
+});
+
+/** Inspect a claim token before redeeming (the claim landing page calls this). */
+export const getClaimToken = query({
+    args: { token: v.string() },
+    handler: async (ctx, args) => {
+        if (!isValidClaimTokenFormat(args.token)) return null;
+        const row = await ctx.db
+            .query('ownerClaimTokens')
+            .withIndex('by_token', (q) => q.eq('token', args.token))
+            .first();
+        if (!row) return null;
+        const submission = await ctx.db.get(row.submissionId);
+        return {
+            status: row.status,
+            expiresAt: row.expiresAt,
+            usable: isClaimTokenUsable(row, Date.now()),
+            businessName: submission?.businessName ?? null,
+            email: row.email,
+        };
+    },
+});
+
+/** All websites the signed-in owner has claimed, with live URL + status + a leads count. */
+export const getMyWebsites = query({
+    args: {},
+    handler: async (ctx) => {
+        const owner = await getOwner(ctx);
+        if (!owner) return [];
+        const links = await ctx.db
+            .query('websiteOwnerships')
+            .withIndex('by_owner', (q) => q.eq('businessOwnerId', owner._id))
+            .collect();
+        const out = [];
+        for (const link of links) {
+            const submission = await ctx.db.get(link.submissionId);
+            if (!submission) continue;
+            const website = await ctx.db
+                .query('generatedWebsites')
+                .withIndex('by_submissionId', (q) => q.eq('submissionId', link.submissionId))
+                .first();
+            const leadCount = (
+                await ctx.db
+                    .query('leads')
+                    .withIndex('by_submission', (q) => q.eq('submissionId', link.submissionId))
+                    .collect()
+            ).length;
+            out.push({
+                submissionId: link.submissionId,
+                businessName: submission.businessName,
+                status: submission.status,
+                publishedUrl: website?.publishedUrl ?? null,
+                websiteId: website?._id ?? null,
+                leadCount,
+                claimedAt: link.claimedAt,
+            });
+        }
+        return out;
+    },
+});
+
+/** Editable content for a website the owner owns. Ownership-gated. */
+export const getMyWebsiteContent = query({
+    args: { submissionId: v.id('submissions') },
+    handler: async (ctx, args) => {
+        await requireOwnership(ctx, args.submissionId);
+        const website = await ctx.db
+            .query('generatedWebsites')
+            .withIndex('by_submissionId', (q) => q.eq('submissionId', args.submissionId))
+            .first();
+        if (!website) return null;
+        return await ctx.db
+            .query('websiteContent')
+            .withIndex('by_websiteId', (q) => q.eq('websiteId', website._id))
+            .first();
+    },
+});
+
+// ==================== CLAIM FLOW ====================
+
+/**
+ * Admin-gated: mint a claim token so the email layer can build the
+ * "Edit my website" link. Called from the admin-only send-email route.
+ * Returns the raw token (the route turns it into a /my-business/claim URL).
+ */
+export const issueClaimTokenForEmail = mutation({
+    args: { submissionId: v.id('submissions') },
+    handler: async (ctx, args): Promise<{ token: string }> => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Not authenticated');
+        const me = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        return await mintClaimToken(ctx, args.submissionId);
+    },
+});
+
+/** Shared token-minting logic (used by the internal + admin entry points). */
+async function mintClaimToken(ctx: MutationCtx, submissionId: Id<'submissions'>): Promise<{ token: string }> {
+    const submission = await ctx.db.get(submissionId);
+    if (!submission?.ownerEmail) throw new Error('Submission has no owner email');
+
+    // Supersede older pending tokens so only the latest link works.
+    const prior = await ctx.db
+        .query('ownerClaimTokens')
+        .withIndex('by_submission', (q) => q.eq('submissionId', submissionId))
+        .filter((q) => q.eq(q.field('status'), 'pending'))
+        .collect();
+    for (const p of prior) await ctx.db.patch(p._id, { status: 'cancelled' });
+
+    const now = Date.now();
+    const token = generateClaimToken();
+    await ctx.db.insert('ownerClaimTokens', {
+        submissionId,
+        token,
+        email: submission.ownerEmail,
+        status: 'pending',
+        createdAt: now,
+        expiresAt: claimTokenExpiry(now),
+    });
+    return { token };
+}
+
+/**
+ * Internal: mint a claim token for a submission (called when sending the
+ * "Edit my website" email from server code). Cancels any prior pending token.
+ */
+export const issueClaimToken = internalMutation({
+    args: { submissionId: v.id('submissions') },
+    handler: async (ctx, args) => mintClaimToken(ctx, args.submissionId),
+});
+
+/**
+ * Redeem a claim token: the signed-in (Clerk) user becomes/links a businessOwner
+ * and gains ownership of the submission's website.
+ *
+ * HARD CHECK: the signed-in verified email must equal the submission's ownerEmail
+ * (emailMatchesSubmission). A leaked link is useless without controlling that inbox.
+ */
+export const claimWebsite = mutation({
+    args: { token: v.string() },
+    handler: async (ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) throw new Error('Sign in to claim your website');
+        if (!isValidClaimTokenFormat(args.token)) throw new Error('Invalid claim link');
+
+        const tokenRow = await ctx.db
+            .query('ownerClaimTokens')
+            .withIndex('by_token', (q) => q.eq('token', args.token))
+            .first();
+        if (!tokenRow) throw new Error('Claim link not found');
+        if (!isClaimTokenUsable(tokenRow, Date.now())) {
+            throw new Error('This claim link has expired or already been used');
+        }
+
+        const submission = await ctx.db.get(tokenRow.submissionId);
+        if (!submission) throw new Error('Website not found');
+
+        // The trust anchor: signed-in email must match the email on file.
+        const signedInEmail = (identity.email as string | undefined) ?? undefined;
+        if (!emailMatchesSubmission(signedInEmail, submission.ownerEmail)) {
+            throw new Error(
+                'This link was sent to a different email. Sign in with the email your website was registered to.',
+            );
+        }
+
+        // Upsert the businessOwner for this Clerk user.
+        let owner = await ctx.db
+            .query('businessOwners')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+            .first();
+        if (!owner) {
+            const ownerId = await ctx.db.insert('businessOwners', {
+                clerkId: identity.subject,
+                email: signedInEmail!,
+                name: (identity.name as string | undefined) ?? submission.ownerName,
+                phone: submission.ownerPhone,
+                createdAt: Date.now(),
+            });
+            owner = await ctx.db.get(ownerId);
+        }
+        if (!owner) throw new Error('Failed to create owner profile');
+
+        // Link ownership (idempotent — don't double-link on a re-click).
+        const existing = await ctx.db
+            .query('websiteOwnerships')
+            .withIndex('by_submission', (q) => q.eq('submissionId', tokenRow.submissionId))
+            .filter((q) => q.eq(q.field('businessOwnerId'), owner!._id))
+            .first();
+        if (!existing) {
+            await ctx.db.insert('websiteOwnerships', {
+                businessOwnerId: owner._id,
+                submissionId: tokenRow.submissionId,
+                role: 'owner',
+                claimedAt: Date.now(),
+            });
+        }
+
+        // Consume the single-use token.
+        await ctx.db.patch(tokenRow._id, { status: 'consumed', consumedAt: Date.now() });
+
+        return { submissionId: tokenRow.submissionId };
+    },
+});
+
+// ==================== CONTENT EDIT (ownership-gated) ====================
+
+/**
+ * Owner edits to their site's content fields. Content-only by design: owners
+ * cannot touch templates, domains, status, or the build pipeline (those aren't
+ * in this arg set). Every call re-checks ownership server-side.
+ */
+export const updateMyWebsiteContent = mutation({
+    args: {
+        submissionId: v.id('submissions'),
+        // Content-only fields owners may edit (must exist on websiteContent).
+        patch: v.object({
+            businessName: v.optional(v.string()),
+            tagline: v.optional(v.string()),
+            aboutText: v.optional(v.string()),
+            heroHeadline: v.optional(v.string()),
+            heroSubheadline: v.optional(v.string()),
+            aboutHeadline: v.optional(v.string()),
+            aboutDescription: v.optional(v.string()),
+            servicesHeadline: v.optional(v.string()),
+            servicesSubheadline: v.optional(v.string()),
+            services: v.optional(
+                v.array(
+                    v.object({
+                        name: v.string(),
+                        description: v.string(),
+                        icon: v.optional(v.string()),
+                    }),
+                ),
+            ),
+            contact: v.optional(
+                v.object({
+                    email: v.string(),
+                    phone: v.string(),
+                    address: v.optional(v.string()),
+                }),
+            ),
+        }),
+    },
+    handler: async (ctx, args) => {
+        const owner = await requireOwnership(ctx, args.submissionId);
+
+        const website = await ctx.db
+            .query('generatedWebsites')
+            .withIndex('by_submissionId', (q) => q.eq('submissionId', args.submissionId))
+            .first();
+        if (!website) throw new Error('Website not found');
+        const content = await ctx.db
+            .query('websiteContent')
+            .withIndex('by_websiteId', (q) => q.eq('websiteId', website._id))
+            .first();
+        if (!content) throw new Error('Website content not found');
+
+        // Drop undefined keys so a partial patch never clobbers unrelated fields.
+        const updates = Object.fromEntries(
+            Object.entries(args.patch).filter(([, val]) => val !== undefined),
+        );
+        await ctx.db.patch(content._id, updates);
+
+        // Audit (the forensic answer to "wrong info got injected").
+        await ctx.db.insert('auditLogs', {
+            adminId: `owner:${owner._id}`,
+            action: 'owner_content_edit',
+            targetType: 'submission',
+            targetId: args.submissionId,
+            metadata: { fields: Object.keys(updates), websiteId: website._id },
+            timestamp: Date.now(),
+        });
+
+        return { ok: true, fieldsUpdated: Object.keys(updates).length };
+    },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -812,6 +812,48 @@ export default defineSchema({
 
     // ==================== PAYMENT TOKENS ====================
     // Cryptographic tokens for secure payment links (one-time use, expiring)
+    // ==================== BUSINESS OWNER PORTAL (Phase 1 — additive) ====================
+    // Owners are a SEPARATE audience from creators (different table, passwordless
+    // Clerk magic-link). See docs/changes/OWNER-PORTAL-PRICING-PLAN.md §1.1.
+    businessOwners: defineTable({
+        clerkId: v.string(),                 // Clerk user id (passwordless / magic-link)
+        email: v.string(),                   // verified email — the identity anchor
+        name: v.optional(v.string()),
+        phone: v.optional(v.string()),
+        createdAt: v.number(),
+    })
+        .index('by_clerk_id', ['clerkId'])
+        .index('by_email', ['email']),
+
+    // Links an owner to the website(s) they've claimed. One owner → many sites.
+    websiteOwnerships: defineTable({
+        businessOwnerId: v.id('businessOwners'),
+        submissionId: v.id('submissions'),
+        role: v.string(),                    // "owner" (room for "manager" later)
+        claimedAt: v.number(),
+    })
+        .index('by_owner', ['businessOwnerId'])
+        .index('by_submission', ['submissionId']),
+
+    // Single-use claim tokens carried by the "Edit my website" email button.
+    // Mirrors the paymentTokens pattern (64-char hex, expiry, status).
+    ownerClaimTokens: defineTable({
+        submissionId: v.id('submissions'),
+        token: v.string(),                   // 64-char hex (lib/ownerClaim.generateClaimToken)
+        email: v.string(),                   // the on-file ownerEmail this token was issued to
+        status: v.union(
+            v.literal('pending'),
+            v.literal('consumed'),
+            v.literal('expired'),
+            v.literal('cancelled'),
+        ),
+        createdAt: v.number(),
+        expiresAt: v.number(),               // createdAt + 7 days
+        consumedAt: v.optional(v.number()),
+    })
+        .index('by_token', ['token'])
+        .index('by_submission', ['submissionId']),
+
     paymentTokens: defineTable({
         submissionId: v.id('submissions'),
         token: v.string(),                              // 64-char hex token (32 random bytes)

--- a/hooks/useOwnerAuth.ts
+++ b/hooks/useOwnerAuth.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useUser } from "@clerk/nextjs";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+/**
+ * Owner-portal auth hook — mirrors useAdminAuth, but for the businessOwners
+ * audience (separate Clerk identity, passwordless). Returns the owner profile
+ * and loading state. `isOwner` is true once a businessOwners row exists for the
+ * signed-in Clerk user (i.e. they've claimed at least one website).
+ */
+export function useOwnerAuth() {
+    const { user, isLoaded, isSignedIn } = useUser();
+    const owner = useQuery(
+        api.businessOwners.me,
+        user ? {} : "skip",
+    );
+    const loading = !isLoaded || (!!user && owner === undefined);
+    return {
+        owner: owner ?? null,
+        isOwner: !!owner,
+        isSignedIn: !!isSignedIn,
+        loading,
+    };
+}

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -138,7 +138,8 @@ interface PaymentLinkEmailData {
     paymentLink: string;
     referenceCode: string;
     platformEmail?: string;
-    customDomain?: string; // If set, template shows breakdown (website ₱999 + domain ₱500)
+    customDomain?: string; // If set, template shows a website + domain breakdown
+    domainCostPHP?: number; // Real frozen domain price (submissions.domainCostPHP) for the breakdown split
 }
 
 export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
@@ -151,6 +152,7 @@ export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
             referenceCode: data.referenceCode,
             platformEmail: data.platformEmail,
             customDomain: data.customDomain,
+            domainCostPHP: data.domainCostPHP,
         });
         return await sendEmail({
             to: data.businessOwnerEmail,

--- a/lib/email/service.ts
+++ b/lib/email/service.ts
@@ -139,6 +139,7 @@ interface PaymentLinkEmailData {
     referenceCode: string;
     platformEmail?: string;
     customDomain?: string; // If set, template shows breakdown (website ₱999 + domain ₱500)
+    editMyWebsiteUrl?: string; // Owner-portal claim link → "Edit my website" button
 }
 
 export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
@@ -151,6 +152,7 @@ export async function sendPaymentLinkEmail(data: PaymentLinkEmailData) {
             referenceCode: data.referenceCode,
             platformEmail: data.platformEmail,
             customDomain: data.customDomain,
+            editMyWebsiteUrl: data.editMyWebsiteUrl,
         });
         return await sendEmail({
             to: data.businessOwnerEmail,

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -183,8 +183,15 @@ export function getPaymentLinkEmailHtml(params: {
     referenceCode: string
     platformEmail?: string
     customDomain?: string
+    // The REAL frozen domain price (submissions.domainCostPHP). Used to split the
+    // itemized breakdown correctly. Falls back to the flat CUSTOM_DOMAIN_ADDON
+    // only for legacy submissions that predate real-domain pricing.
+    domainCostPHP?: number
 }): string {
-    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain } = params
+    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain, domainCostPHP } = params
+    // Real domain charge for the line-item split; the website-package line is the remainder.
+    const domainLine = domainCostPHP && domainCostPHP > 0 ? domainCostPHP : CUSTOM_DOMAIN_ADDON
+    const websiteLine = amount - domainLine
     const wiseEmail = platformEmail || paymentConfig.wiseEmail || 'frmwrkd.media@gmail.com'
 
     return `
@@ -242,7 +249,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Website Package</td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(amount - CUSTOM_DOMAIN_ADDON)}</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(websiteLine)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>
@@ -252,7 +259,7 @@ export function getPaymentLinkEmailHtml(params: {
                                                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                                                         <tr>
                                                             <td style="font-size:14px;color:#374151;">Custom Domain: <strong style="color:#C89548;">${customDomain}</strong></td>
-                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(CUSTOM_DOMAIN_ADDON)}</td>
+                                                            <td align="right" style="font-size:14px;color:#111827;font-weight:700;">${formatPHP(domainLine)}</td>
                                                         </tr>
                                                     </table>
                                                 </td>

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -183,8 +183,9 @@ export function getPaymentLinkEmailHtml(params: {
     referenceCode: string
     platformEmail?: string
     customDomain?: string
+    editMyWebsiteUrl?: string // Owner-portal claim link
 }): string {
-    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain } = params
+    const { businessName, businessOwnerName, amount, referenceCode, platformEmail, customDomain, editMyWebsiteUrl } = params
     const wiseEmail = platformEmail || paymentConfig.wiseEmail || 'frmwrkd.media@gmail.com'
 
     return `
@@ -386,7 +387,16 @@ export function getPaymentLinkEmailHtml(params: {
                             </table>
                         </td>
                     </tr>
-
+                    ${editMyWebsiteUrl ? `
+                    <!-- Edit my website (owner portal claim link) -->
+                    <tr>
+                        <td style="padding:8px 40px 24px;text-align:center;">
+                            <p style="margin:0 0 12px;font-size:14px;color:#374151;">Want to update your text, photos, or details yourself?</p>
+                            <a href="${editMyWebsiteUrl}" style="display:inline-block;padding:12px 28px;background:#ffffff;border:2px solid #E4B05E;color:#92400e;font-size:15px;font-weight:700;text-decoration:none;border-radius:10px;">✏️ Edit my website</a>
+                            <p style="margin:10px 0 0;font-size:12px;color:#9ca3af;">Signs you in with this email — no password needed.</p>
+                        </td>
+                    </tr>
+                    ` : ''}
                     <!-- Footer -->
                     <tr>
                         <td style="padding:24px 40px;border-top:1px solid #e5e7eb;text-align:center;">

--- a/lib/ownerClaim.ts
+++ b/lib/ownerClaim.ts
@@ -1,0 +1,89 @@
+/**
+ * Business-owner claim + ownership — pure helpers, no DB/framework deps. Unit-tested.
+ *
+ * The security model (see docs/changes/OWNER-PORTAL-PRICING-PLAN.md Phase 1):
+ *  - A business owner is a separate identity (businessOwners table), not a creator.
+ *  - They prove ownership of a website by possessing the email it was sold to
+ *    (submissions.ownerEmail) — the same email the payment link goes to. Email is
+ *    the identity anchor, never an instruction channel.
+ *  - "Edit my website" emails carry a single-use claim token (this module mints +
+ *    validates it). First click claims the site; later sign-in is Clerk passwordless.
+ *
+ * These functions are the load-bearing trust boundary, so they're pure + tested:
+ * token format/expiry, and the email-match + ownership checks the server enforces.
+ */
+
+const CLAIM_TOKEN_BYTES = 32; // 256-bit, same strength as paymentTokens
+export const CLAIM_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/** Generate a 64-char hex claim token (crypto random). Uses the Web Crypto API,
+ *  available in Convex's V8 runtime, browsers, and Node 18+ — no Node-only deps. */
+export function generateClaimToken(): string {
+    const bytes = new Uint8Array(CLAIM_TOKEN_BYTES);
+    (globalThis as { crypto: Crypto }).crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** A claim token is well-formed iff it's 64 lowercase hex chars. */
+export function isValidClaimTokenFormat(token: string): boolean {
+    return typeof token === 'string' && /^[0-9a-f]{64}$/.test(token);
+}
+
+/** When a freshly-minted token should expire, given "now". */
+export function claimTokenExpiry(nowMs: number): number {
+    return nowMs + CLAIM_TOKEN_TTL_MS;
+}
+
+export interface ClaimTokenState {
+    status: 'pending' | 'consumed' | 'expired' | 'cancelled';
+    expiresAt: number;
+}
+
+/**
+ * Whether a claim token can be redeemed right now. A token is usable only if it's
+ * still `pending` AND not past expiry. Centralized so the mutation and any UI agree.
+ */
+export function isClaimTokenUsable(token: ClaimTokenState, nowMs: number): boolean {
+    if (token.status !== 'pending') return false;
+    if (nowMs >= token.expiresAt) return false;
+    return true;
+}
+
+/** Normalize an email for comparison (trim + lowercase). The owner-email match anchor. */
+export function normalizeEmail(email: string | undefined | null): string {
+    return (email ?? '').trim().toLowerCase();
+}
+
+/**
+ * The core ownership-trust check at claim time: the signed-in Clerk identity's
+ * verified email must match the email the submission was sold to. Without this,
+ * anyone with a leaked claim link could attach a site to their own account.
+ */
+export function emailMatchesSubmission(
+    signedInEmail: string | undefined | null,
+    submissionOwnerEmail: string | undefined | null,
+): boolean {
+    const a = normalizeEmail(signedInEmail);
+    const b = normalizeEmail(submissionOwnerEmail);
+    return a.length > 0 && a === b;
+}
+
+export interface OwnershipRow {
+    businessOwnerId: string;
+    submissionId: string;
+}
+
+/**
+ * Whether `ownerId` may act on `submissionId`, given their ownership rows.
+ * This is the check EVERY owner-facing content mutation must run server-side —
+ * the line that stops one owner editing another's site by guessing an ID.
+ */
+export function ownsSubmission(
+    ownerId: string,
+    submissionId: string,
+    ownerships: OwnershipRow[],
+): boolean {
+    return ownerships.some(
+        (o) => o.businessOwnerId === ownerId && o.submissionId === submissionId,
+    );
+}


### PR DESCRIPTION
# Latest Changes ✨ 

**Business Owner Portal UI:**

* Added `app/my-business/page.tsx`: Dashboard listing all websites claimed by the signed-in owner, with links to edit each site. Handles cases where no sites are claimed and redirects unauthenticated users to login.
* Added `app/my-business/[submissionId]/page.tsx`: Content editor page for owners, gated by ownership and authentication. Allows editing of website text and contact fields only, with server-side enforcement of ownership. ([app/my-business/[submissionId]/page.tsxR1-R190](diffhunk://#diff-ae492c56486e4fad2d4dc1ef2ac733441bca55cb91ee52fd91f0540f18e8f04eR1-R190))
* Added `app/my-business/claim/page.tsx`: Claim landing page for the "Edit my website" email link. Handles authentication, token validation, and redemption, redirecting the owner to their editor upon success.

**API and Email Integration:**

* In `app/api/send-website-email/route.ts`, integrated claim token minting and added the "Edit my website" link to outgoing emails. Handles failures gracefully and passes the claim link to email templates. [[1]](diffhunk://#diff-328288b4bd96c825e6d21b3a9ae93238c90e9de3112d073823138c44bca4c05aR93-R107) [[2]](diffhunk://#diff-328288b4bd96c825e6d21b3a9ae93238c90e9de3112d073823138c44bca4c05aR118-R119)
* In `app/api/preview-email/route.ts`, included `domainCostPHP` in the email preview context to support dynamic email content.

**Testing and Validation:**

* Added `__tests__/owner/ownerClaim.test.ts`: Comprehensive tests for claim token generation, validation, expiry, email normalization, and ownership checks, ensuring the security and reliability of the claim process.