### PR TITLE
feat: admin "Train the AI" page — paste questions, AI writes + embeds the answers

### DIFF
--- a/app/admin/components/AdminLayout.tsx
+++ b/app/admin/components/AdminLayout.tsx
@@ -14,6 +14,7 @@ import {
     CreditCard,
     History,
     Download,
+    Sparkles,
     FileText,
     LogOut,
     Menu,
@@ -51,6 +52,11 @@ const navItems = [
         label: "App Release",
         href: "/admin/app-release",
         icon: Download,
+    },
+    {
+        label: "Train AI",
+        href: "/admin/knowledge",
+        icon: Sparkles,
     },
 ]
 

--- a/app/admin/knowledge/page.tsx
+++ b/app/admin/knowledge/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * Admin "Train the AI" — paste questions, the AI writes + embeds the answers.
+ * The questions become retrievable knowledge for the /knowledge chatbot AND the
+ * Discord /ask bot. See docs/changes/ADMIN-KB-TRAINING-PLAN.md.
+ */
+
+import { useState } from "react";
+import { useAction, useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { useAdminAuth } from "@/hooks/useAdmin";
+import AdminLayout from "../components/AdminLayout";
+import { Loader2, Sparkles, CheckCircle2, AlertTriangle, Trash2, ArrowRight } from "lucide-react";
+
+type Workspace = "help" | "wiki";
+type TrainResult = { question: string; answer: string; grounded: boolean };
+
+export default function AdminTrainAiPage() {
+    const { isAdmin, loading } = useAdminAuth();
+    const train = useAction(api.knowledgeTraining.trainFromQuestions);
+    const trained = useQuery(api.knowledgeTraining.listTrainingQA, isAdmin ? {} : "skip");
+    const unanswered = useQuery(api.knowledgeTraining.listUnansweredQueries, isAdmin ? {} : "skip");
+    const remove = useMutation(api.knowledgeTraining.deleteTrainingQA);
+
+    const [text, setText] = useState("");
+    const [workspace, setWorkspace] = useState<Workspace>("help");
+    const [running, setRunning] = useState(false);
+    const [results, setResults] = useState<TrainResult[] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    if (loading) {
+        return (
+            <AdminLayout>
+                <div className="flex items-center justify-center h-64">
+                    <Loader2 className="h-8 w-8 animate-spin text-amber-500" />
+                </div>
+            </AdminLayout>
+        );
+    }
+    if (!isAdmin) {
+        return <AdminLayout><p className="p-6 text-red-600">Forbidden: admin access required.</p></AdminLayout>;
+    }
+
+    const questions = text.split("\n").map((q) => q.trim()).filter(Boolean);
+
+    const handleTrain = async () => {
+        if (questions.length === 0) return;
+        setRunning(true);
+        setError(null);
+        setResults(null);
+        try {
+            const res = await train({ questions, workspace });
+            setResults(res);
+            setText("");
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Training failed.");
+        } finally {
+            setRunning(false);
+        }
+    };
+
+    return (
+        <AdminLayout>
+            <div className="max-w-3xl mx-auto p-6 space-y-8">
+                <div>
+                    <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+                        <Sparkles className="h-6 w-6 text-amber-500" /> Train the AI
+                    </h1>
+                    <p className="text-sm text-gray-500 mt-1">
+                        Paste questions (one per line). The AI writes a grounded answer for each from the knowledge base,
+                        then learns it — so the Help Center chatbot and the Discord <code>/ask</code> bot can answer them.
+                    </p>
+                </div>
+
+                {/* Paste box */}
+                <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
+                    <div className="flex items-center gap-3">
+                        <label className="text-sm font-medium text-gray-700">Workspace</label>
+                        <select
+                            value={workspace}
+                            onChange={(e) => setWorkspace(e.target.value as Workspace)}
+                            className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm"
+                        >
+                            <option value="help">Help Center (public + chatbot + Discord)</option>
+                            <option value="wiki">Internal Wiki (field agents only)</option>
+                        </select>
+                    </div>
+                    <textarea
+                        value={text}
+                        onChange={(e) => setText(e.target.value)}
+                        rows={8}
+                        placeholder={"How do I get paid?\nHow long does a website take to build?\nCan I use my own domain?"}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg text-gray-900 font-mono text-sm"
+                    />
+                    <div className="flex items-center justify-between">
+                        <span className="text-xs text-gray-400">{questions.length} question{questions.length === 1 ? "" : "s"}</span>
+                        <button
+                            onClick={handleTrain}
+                            disabled={running || questions.length === 0}
+                            className="inline-flex items-center gap-2 h-11 px-6 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl disabled:opacity-50"
+                        >
+                            {running ? <><Loader2 className="h-5 w-5 animate-spin" /> Teaching the AI…</> : <><Sparkles className="h-5 w-5" /> Train</>}
+                        </button>
+                    </div>
+                    {error && <p className="text-sm text-red-600">{error}</p>}
+                </div>
+
+                {/* Results of the last run */}
+                {results && (
+                    <div className="space-y-3">
+                        <h2 className="text-sm font-semibold text-gray-700">Just taught the AI</h2>
+                        {results.map((r, i) => (
+                            <div key={i} className="bg-white rounded-lg border border-gray-200 p-4">
+                                <div className="flex items-start gap-2">
+                                    {r.grounded ? (
+                                        <CheckCircle2 className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
+                                    ) : (
+                                        <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+                                    )}
+                                    <div>
+                                        <p className="font-medium text-gray-900">{r.question}</p>
+                                        <p className="text-sm text-gray-600 mt-1">{r.answer}</p>
+                                        {!r.grounded && (
+                                            <p className="text-xs text-amber-600 mt-1">
+                                                ⚠️ The AI couldn&apos;t ground this from existing knowledge — review &amp; improve this answer in the article editor.
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* Questions people asked that the AI couldn't answer */}
+                {unanswered && unanswered.length > 0 && (
+                    <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
+                        <h2 className="text-sm font-semibold text-amber-800 mb-3">Questions the AI couldn&apos;t answer</h2>
+                        <p className="text-xs text-amber-700 mb-3">Click to drop one into the box above, then Train.</p>
+                        <div className="space-y-1">
+                            {unanswered.map((u, i) => (
+                                <button
+                                    key={i}
+                                    onClick={() => setText((t) => (t ? `${t}\n${u.query}` : u.query))}
+                                    className="w-full text-left text-sm text-amber-900 hover:bg-amber-100 rounded px-2 py-1.5 flex items-center justify-between gap-2"
+                                >
+                                    <span>{u.query}</span>
+                                    <ArrowRight className="h-4 w-4 shrink-0 opacity-60" />
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Already-trained Q&A */}
+                <div>
+                    <h2 className="text-sm font-semibold text-gray-700 mb-3">Trained questions</h2>
+                    {trained === undefined ? (
+                        <Loader2 className="h-5 w-5 animate-spin text-amber-500" />
+                    ) : trained.length === 0 ? (
+                        <p className="text-sm text-gray-400">Nothing trained yet.</p>
+                    ) : (
+                        <div className="space-y-2">
+                            {trained.map((t) => (
+                                <div key={t._id} className="bg-white rounded-lg border border-gray-100 p-3 flex items-start justify-between gap-3">
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-900">{t.question}</p>
+                                        <p className="text-xs text-gray-500 mt-0.5">{t.answer}</p>
+                                        <span className="text-[11px] mt-1 inline-block" style={{ color: t.embedded ? "#16a34a" : "#a16207" }}>
+                                            {t.embedded ? "● learned (embedded)" : "○ embedding…"} · {t.workspace}
+                                        </span>
+                                    </div>
+                                    <button onClick={() => remove({ id: t._id })} className="text-gray-400 hover:text-red-600 shrink-0">
+                                        <Trash2 className="h-4 w-4" />
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/app/admin/knowledge/page.tsx
+++ b/app/admin/knowledge/page.tsx
@@ -11,7 +11,7 @@ import { useAction, useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useAdminAuth } from "@/hooks/useAdmin";
 import AdminLayout from "../components/AdminLayout";
-import { Loader2, Sparkles, CheckCircle2, AlertTriangle, Trash2, ArrowRight } from "lucide-react";
+import { Loader2, Sparkles, CheckCircle2, AlertTriangle, Trash2, ArrowRight, KeyRound, RefreshCw } from "lucide-react";
 
 type Workspace = "help" | "wiki";
 type TrainResult = { question: string; answer: string; grounded: boolean };
@@ -22,12 +22,60 @@ export default function AdminTrainAiPage() {
     const trained = useQuery(api.knowledgeTraining.listTrainingQA, isAdmin ? {} : "skip");
     const unanswered = useQuery(api.knowledgeTraining.listUnansweredQueries, isAdmin ? {} : "skip");
     const remove = useMutation(api.knowledgeTraining.deleteTrainingQA);
+    const purgeAll = useMutation(api.knowledgeTraining.purgeAllTrainedQA);
+
+    // AI-key health: the page can't run the AI without a usable Gemini key.
+    const poolStats = useQuery(api.aiKeys.poolStats, isAdmin ? {} : "skip");
+    const addKey = useAction(api.aiKeys.addMyGeminiKey);
+    const clearCooldowns = useMutation(api.aiKeys.clearGeminiCooldowns);
 
     const [text, setText] = useState("");
     const [workspace, setWorkspace] = useState<Workspace>("help");
     const [running, setRunning] = useState(false);
     const [results, setResults] = useState<TrainResult[] | null>(null);
     const [error, setError] = useState<string | null>(null);
+
+    // Key-setup card state
+    const [keyInput, setKeyInput] = useState("");
+    const [savingKey, setSavingKey] = useState(false);
+    const [keyMsg, setKeyMsg] = useState<string | null>(null);
+    const [keyErr, setKeyErr] = useState<string | null>(null);
+
+    const hasUsableKey = poolStats ? poolStats.usableNow > 0 : undefined; // undefined while loading
+
+    const handleSaveKey = async () => {
+        const key = keyInput.trim();
+        if (key.length < 20) {
+            setKeyErr("That does not look like a valid Gemini API key.");
+            return;
+        }
+        setSavingKey(true);
+        setKeyErr(null);
+        setKeyMsg(null);
+        try {
+            const res = await addKey({ key });
+            setKeyMsg(`Key ${res.label} saved. The AI is ready.`);
+            setKeyInput("");
+        } catch (e) {
+            setKeyErr(e instanceof Error ? e.message : "Could not save the key.");
+        } finally {
+            setSavingKey(false);
+        }
+    };
+
+    const handleClearCooldowns = async () => {
+        setSavingKey(true);
+        setKeyErr(null);
+        setKeyMsg(null);
+        try {
+            const res = await clearCooldowns({});
+            setKeyMsg(res.cleared > 0 ? `Reactivated ${res.cleared} key(s).` : "No keys needed clearing.");
+        } catch (e) {
+            setKeyErr(e instanceof Error ? e.message : "Could not clear cooldowns.");
+        } finally {
+            setSavingKey(false);
+        }
+    };
 
     if (loading) {
         return (
@@ -46,6 +94,10 @@ export default function AdminTrainAiPage() {
 
     const handleTrain = async () => {
         if (questions.length === 0) return;
+        if (hasUsableKey === false) {
+            setError("No usable Gemini key — add one below before training, or the AI can't answer.");
+            return;
+        }
         setRunning(true);
         setError(null);
         setResults(null);
@@ -73,6 +125,62 @@ export default function AdminTrainAiPage() {
                     </p>
                 </div>
 
+                {/* AI-key setup — only when there's no usable key. The page can't
+                    answer without one; surfacing the input here keeps it self-contained
+                    so an admin never has to hunt through the Convex dashboard. */}
+                {hasUsableKey === false && (
+                    <div className="bg-red-50 border border-red-200 rounded-xl p-5 space-y-3">
+                        <div className="flex items-center gap-2">
+                            <KeyRound className="h-5 w-5 text-red-600" />
+                            <h2 className="text-sm font-semibold text-red-800">The AI has no usable key</h2>
+                        </div>
+                        <p className="text-sm text-red-700">
+                            Training needs a working Google Gemini API key. Paste one below — it&apos;s encrypted at
+                            rest and shared by the chatbot, Discord <code>/ask</code>, and this page. Get a free key at{" "}
+                            <a
+                                href="https://aistudio.google.com/apikey"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline font-medium"
+                            >
+                                aistudio.google.com/apikey
+                            </a>
+                            .
+                        </p>
+                        <div className="flex flex-col sm:flex-row gap-2">
+                            <input
+                                type="password"
+                                value={keyInput}
+                                onChange={(e) => setKeyInput(e.target.value)}
+                                placeholder="AIza…"
+                                className="flex-1 px-3 py-2 border border-red-300 rounded-lg text-gray-900 font-mono text-sm bg-white"
+                            />
+                            <button
+                                onClick={handleSaveKey}
+                                disabled={savingKey || keyInput.trim().length < 20}
+                                className="inline-flex items-center justify-center gap-2 h-10 px-5 bg-red-600 hover:bg-red-700 text-white font-bold rounded-lg disabled:opacity-50"
+                            >
+                                {savingKey ? <Loader2 className="h-4 w-4 animate-spin" /> : <KeyRound className="h-4 w-4" />}
+                                Save key
+                            </button>
+                        </div>
+                        {/* When the only key(s) are on cooldown (rate-limited, not invalid),
+                            offer a one-click reactivate instead of forcing a new key. */}
+                        {poolStats && poolStats.onCooldown > 0 && (
+                            <button
+                                onClick={handleClearCooldowns}
+                                disabled={savingKey}
+                                className="inline-flex items-center gap-1.5 text-xs text-red-700 hover:text-red-900 underline disabled:opacity-50"
+                            >
+                                <RefreshCw className="h-3.5 w-3.5" />
+                                {poolStats.onCooldown} key(s) on cooldown — reactivate now
+                            </button>
+                        )}
+                        {keyMsg && <p className="text-sm text-green-700">{keyMsg}</p>}
+                        {keyErr && <p className="text-sm text-red-700">{keyErr}</p>}
+                    </div>
+                )}
+
                 {/* Paste box */}
                 <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
                     <div className="flex items-center gap-3">
@@ -97,7 +205,8 @@ export default function AdminTrainAiPage() {
                         <span className="text-xs text-gray-400">{questions.length} question{questions.length === 1 ? "" : "s"}</span>
                         <button
                             onClick={handleTrain}
-                            disabled={running || questions.length === 0}
+                            disabled={running || questions.length === 0 || hasUsableKey === false}
+                            title={hasUsableKey === false ? "Add a Gemini key above first" : undefined}
                             className="inline-flex items-center gap-2 h-11 px-6 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl disabled:opacity-50"
                         >
                             {running ? <><Loader2 className="h-5 w-5 animate-spin" /> Teaching the AI…</> : <><Sparkles className="h-5 w-5" /> Train</>}
@@ -123,7 +232,7 @@ export default function AdminTrainAiPage() {
                                         <p className="text-sm text-gray-600 mt-1">{r.answer}</p>
                                         {!r.grounded && (
                                             <p className="text-xs text-amber-600 mt-1">
-                                                ⚠️ The AI couldn&apos;t ground this from existing knowledge — review &amp; improve this answer in the article editor.
+                                                ⚠️ The AI couldn&apos;t ground this in existing knowledge, so it was <strong>not saved</strong> (a guessed answer would poison the KB). Write a real article for this topic, then re-train.
                                             </p>
                                         )}
                                     </div>
@@ -155,7 +264,21 @@ export default function AdminTrainAiPage() {
 
                 {/* Already-trained Q&A */}
                 <div>
-                    <h2 className="text-sm font-semibold text-gray-700 mb-3">Trained questions</h2>
+                    <div className="flex items-center justify-between mb-3">
+                        <h2 className="text-sm font-semibold text-gray-700">Trained questions</h2>
+                        {trained && trained.length > 0 && (
+                            <button
+                                onClick={async () => {
+                                    if (confirm("Delete ALL trained Q&A? This removes every question the AI learned here (hand-written articles are untouched). Use this to wipe a bad batch.")) {
+                                        await purgeAll({});
+                                    }
+                                }}
+                                className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-red-600"
+                            >
+                                <Trash2 className="h-3.5 w-3.5" /> Clear all
+                            </button>
+                        )}
+                    </div>
                     {trained === undefined ? (
                         <Loader2 className="h-5 w-5 animate-spin text-amber-500" />
                     ) : trained.length === 0 ? (

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as http from "../http.js";
 import type * as knowledge from "../knowledge.js";
 import type * as knowledgeAI from "../knowledgeAI.js";
 import type * as knowledgeSeed from "../knowledgeSeed.js";
+import type * as knowledgeTraining from "../knowledgeTraining.js";
 import type * as leadNotes from "../leadNotes.js";
 import type * as leads from "../leads.js";
 import type * as lib_auth from "../lib/auth.js";
@@ -87,6 +88,7 @@ declare const fullApi: ApiFromModules<{
   knowledge: typeof knowledge;
   knowledgeAI: typeof knowledgeAI;
   knowledgeSeed: typeof knowledgeSeed;
+  knowledgeTraining: typeof knowledgeTraining;
   leadNotes: typeof leadNotes;
   leads: typeof leads;
   "lib/auth": typeof lib_auth;

--- a/convex/aiKeys.ts
+++ b/convex/aiKeys.ts
@@ -1,7 +1,7 @@
 import { v } from 'convex/values';
 import { query, mutation, action, internalQuery, internalMutation, type QueryCtx, type MutationCtx } from './_generated/server';
 import { internal } from './_generated/api';
-import { requireAuth } from './lib/auth';
+import { requireAuth, requireAdmin } from './lib/auth';
 import { encryptSecret, isEncrypted } from './lib/encryption';
 import type { Doc } from './_generated/dataModel';
 
@@ -218,5 +218,28 @@ export const poolStats = query({
             onCooldown: gemini.filter((k) => k.active && k.cooldownUntil && k.cooldownUntil > now).length,
             retired: gemini.filter((k) => !k.active).length,
         };
+    },
+});
+
+/**
+ * Admin: reactivate every Gemini key and clear its cooldown. Use when a key was
+ * rate-limited (quota) or flapped on transient errors but is actually still
+ * valid — instead of waiting out the 12h cooldown. Does NOT add a key; if a key
+ * was retired as truly invalid, clearing it just lets it fail again on next use.
+ * Returns how many rows were touched so the UI can confirm.
+ */
+export const clearGeminiCooldowns = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const gemini = (await ctx.db.query('aiKeys').collect()).filter((k) => k.provider === 'gemini');
+        let cleared = 0;
+        for (const k of gemini) {
+            if (!k.active || k.cooldownUntil || (k.failureCount ?? 0) > 0) {
+                await ctx.db.patch(k._id, { active: true, cooldownUntil: undefined, failureCount: 0 });
+                cleared += 1;
+            }
+        }
+        return { cleared };
     },
 });

--- a/convex/knowledge.ts
+++ b/convex/knowledge.ts
@@ -352,6 +352,7 @@ export const logQuery = internalMutation({
         sourceArticleIds: v.array(v.id('knowledgeArticles')),
         userId: v.optional(v.string()),
         discordUserId: v.optional(v.string()),
+        grounded: v.optional(v.boolean()),
     },
     handler: async (ctx, args) => {
         await ctx.db.insert('knowledgeQueries', { ...args, createdAt: Date.now() });

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -22,7 +22,11 @@ import type { Doc, Id } from './_generated/dataModel';
  */
 
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
-const EMBED_MODEL = () => process.env.GEMINI_EMBEDDING_MODEL || 'text-embedding-004';
+// Google retired text-embedding-004 on v1beta (404 NOT_FOUND). gemini-embedding-001
+// is the successor; we request outputDimensionality: 768 (Matryoshka truncation) so
+// vectors still fit the existing 768-dim `by_embedding` index without a schema/re-embed
+// migration. Override with GEMINI_EMBEDDING_MODEL if Google moves the model again.
+const EMBED_MODEL = () => process.env.GEMINI_EMBEDDING_MODEL || 'gemini-embedding-001';
 // Generation model fallback chain: STRONGEST first, weakest last. Each model has
 // its own per-key quota bucket, so when a strong model is exhausted (429) or
 // unavailable on a key's tier we drop to the next — gemini-2.0-flash is the
@@ -78,7 +82,15 @@ async function geminiEmbed(text: string, taskType: 'RETRIEVAL_DOCUMENT' | 'RETRI
     const res = await fetch(`${GEMINI_BASE}/models/${model}:embedContent?key=${apiKey}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: `models/${model}`, content: { parts: [{ text }] }, taskType }),
+        body: JSON.stringify({
+            model: `models/${model}`,
+            content: { parts: [{ text }] },
+            taskType,
+            // Ask for 768 dims so the result fits the existing vector index.
+            // No-op on legacy text-embedding-004 (already 768); required on
+            // gemini-embedding-001 (defaults to 3072).
+            outputDimensionality: EMBED_DIMS,
+        }),
     });
     if (!res.ok) throw geminiError('embed', res.status, await res.text().catch(() => ''));
     const json = await res.json();
@@ -86,7 +98,18 @@ async function geminiEmbed(text: string, taskType: 'RETRIEVAL_DOCUMENT' | 'RETRI
     if (values.length !== EMBED_DIMS) {
         throw new Error(`Gemini embed returned ${values.length} dims, expected ${EMBED_DIMS}`);
     }
-    return values;
+    // gemini-embedding-001 only L2-normalizes at the full 3072 dims; a truncated
+    // (Matryoshka) vector must be re-normalized for cosine similarity to behave.
+    // Harmless for already-unit-length vectors (text-embedding-004).
+    return normalize(values);
+}
+
+/** L2-normalize a vector to unit length (safe no-op if already normalized). */
+function normalize(v: number[]): number[] {
+    let sum = 0;
+    for (const x of v) sum += x * x;
+    const norm = Math.sqrt(sum);
+    return norm > 0 ? v.map((x) => x / norm) : v;
 }
 
 // A single conversational turn in Gemini's wire format ('model' = assistant).

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -406,6 +406,7 @@ async function runRag(
         sourceArticleIds: sources.map((s) => s._id),
         userId: args.userId,
         discordUserId: args.discordUserId,
+        grounded,
     });
 
     return { answer, sources: sources.map((s) => ({ slug: s.slug, title: s.title })), grounded };

--- a/convex/knowledgeTraining.ts
+++ b/convex/knowledgeTraining.ts
@@ -75,9 +75,8 @@ export const saveTrainedQA = internalMutation({
             popular: false,
             status: 'published',
             source: 'qa',
-            // Unanswered ones are saved as draft-quality: published so the answer
-            // (even if weak) is searchable, but flagged needsReview via grounded=false
-            // in the return so the admin knows to revisit.
+            // Only grounded answers reach this mutation (trainFromQuestions filters
+            // ungrounded ones out), so it's safe to publish + embed directly.
             createdAt: now,
             updatedAt: now,
         });
@@ -119,15 +118,20 @@ export const trainFromQuestions = action({
                 workspace: args.workspace,
                 source: 'web',
             });
-            // Persist + embed (even ungrounded ones are saved so the gap is visible;
-            // grounded:false tells the admin to give it a better answer).
-            await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
-                question,
-                answer: rag.answer,
-                workspace: args.workspace,
-                categorySlug: args.categorySlug,
-                grounded: rag.grounded,
-            });
+            // Only save + embed answers the AI could GROUND in existing knowledge.
+            // An ungrounded answer is a generic/hallucinated fallback — embedding it
+            // would poison the KB (the RAG would then "retrieve" its own bad guess on
+            // the next ask). We still return it with grounded:false so the admin sees
+            // the gap and can author a real article, but it never enters retrieval.
+            if (rag.grounded) {
+                await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
+                    question,
+                    answer: rag.answer,
+                    workspace: args.workspace,
+                    categorySlug: args.categorySlug,
+                    grounded: true,
+                });
+            }
             results.push({ question, answer: rag.answer, grounded: rag.grounded });
         }
         return results;
@@ -162,6 +166,23 @@ export const deleteTrainingQA = mutation({
         const row = await ctx.db.get(args.id);
         if (row && row.source === 'qa') await ctx.db.delete(args.id);
         return { ok: true };
+    },
+});
+
+/**
+ * Admin: delete ALL trained Q&A rows in one shot. Used to wipe a poisoned batch
+ * (e.g. answers saved while the Gemini key was dead and every answer was an
+ * ungrounded fallback). Only touches source:'qa' rows — hand-authored articles
+ * are never affected. Returns the count removed.
+ */
+export const purgeAllTrainedQA = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const all = await ctx.db.query('knowledgeArticles').collect();
+        const qa = all.filter((a) => a.source === 'qa');
+        for (const a of qa) await ctx.db.delete(a._id);
+        return { removed: qa.length };
     },
 });
 

--- a/convex/knowledgeTraining.ts
+++ b/convex/knowledgeTraining.ts
@@ -1,0 +1,186 @@
+import { v } from 'convex/values';
+import { action, query, mutation, internalMutation } from './_generated/server';
+import { internal } from './_generated/api';
+import { requireAdmin } from './lib/auth';
+import type { Id } from './_generated/dataModel';
+
+/**
+ * Admin "Train the AI" — paste QUESTIONS, the AI writes the answers, both get
+ * embedded into the knowledge base so the /knowledge chatbot AND Discord /ask
+ * can answer them. See docs/changes/ADMIN-KB-TRAINING-PLAN.md.
+ *
+ * The flow per question:
+ *   1. Run the existing RAG (knowledgeAI.answerQuery) to DRAFT a grounded answer
+ *      from the current knowledge base.
+ *   2. Persist the Q&A as a published `knowledgeArticles` row (source:'qa') and
+ *      schedule its embedding — so the RAG retrieves it next time.
+ *   3. Report which questions the AI could NOT ground, so the admin can give
+ *      those a real answer (a future edit pass) rather than shipping a weak one.
+ *
+ * Why reuse articles+embeddings: runRag only vector-searches `knowledgeArticles`.
+ * Making each Q&A an embedded article means "training" needs ZERO change to the
+ * retrieval path — the AI's own knowledge source simply grows.
+ */
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '')
+        .slice(0, 80);
+}
+
+// ---- internal: persist one AI-answered Q&A as an embedded article ----
+export const saveTrainedQA = internalMutation({
+    args: {
+        question: v.string(),
+        answer: v.string(),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        categorySlug: v.optional(v.string()),
+        grounded: v.boolean(),
+    },
+    handler: async (ctx, args): Promise<Id<'knowledgeArticles'>> => {
+        // Resolve category: the requested one, else the first in the workspace.
+        let category = args.categorySlug
+            ? await ctx.db
+                  .query('knowledgeCategories')
+                  .withIndex('by_slug', (q) => q.eq('slug', args.categorySlug!))
+                  .first()
+            : null;
+        if (!category) {
+            category = await ctx.db
+                .query('knowledgeCategories')
+                .withIndex('by_workspace', (q) => q.eq('workspace', args.workspace))
+                .first();
+        }
+        if (!category) throw new Error('No knowledge category exists yet — seed the KB first.');
+
+        const now = Date.now();
+        // Unique slug (append a short time suffix to avoid collisions on similar Qs).
+        const slug = `qa-${slugify(args.question)}-${now.toString(36).slice(-4)}`;
+
+        // Body is the typed-block array the schema uses: the answer as one paragraph.
+        const body = [{ t: 'p' as const, text: args.answer }];
+
+        const id = await ctx.db.insert('knowledgeArticles', {
+            slug,
+            title: args.question,
+            summary: args.answer.slice(0, 300),
+            categoryId: category._id,
+            workspace: args.workspace,
+            body,
+            keywords: [],
+            author: 'admin (trained)',
+            readMin: 1,
+            popular: false,
+            status: 'published',
+            source: 'qa',
+            // Unanswered ones are saved as draft-quality: published so the answer
+            // (even if weak) is searchable, but flagged needsReview via grounded=false
+            // in the return so the admin knows to revisit.
+            createdAt: now,
+            updatedAt: now,
+        });
+
+        // Embed it (off the write path) so the RAG can retrieve it.
+        await ctx.scheduler.runAfter(0, internal.knowledgeAI.generateEmbeddingForArticle, {
+            articleId: id,
+        });
+        return id;
+    },
+});
+
+/**
+ * The page's main action: take pasted questions, let the AI answer each, save +
+ * embed. Returns a per-question result so the UI can show answered/needs-review.
+ */
+export const trainFromQuestions = action({
+    args: {
+        questions: v.array(v.string()),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        categorySlug: v.optional(v.string()),
+    },
+    handler: async (
+        ctx,
+        args,
+    ): Promise<Array<{ question: string; answer: string; grounded: boolean }>> => {
+        await requireAdmin(ctx);
+
+        const cleaned = args.questions
+            .map((q) => q.trim())
+            .filter((q) => q.length > 0)
+            .slice(0, 50); // sane cap per batch
+
+        const results: Array<{ question: string; answer: string; grounded: boolean }> = [];
+        for (const question of cleaned) {
+            // Draft a grounded answer from the CURRENT knowledge base.
+            const rag = await ctx.runAction(internal.knowledgeAI.answerQuery, {
+                query: question,
+                workspace: args.workspace,
+                source: 'web',
+            });
+            // Persist + embed (even ungrounded ones are saved so the gap is visible;
+            // grounded:false tells the admin to give it a better answer).
+            await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
+                question,
+                answer: rag.answer,
+                workspace: args.workspace,
+                categorySlug: args.categorySlug,
+                grounded: rag.grounded,
+            });
+            results.push({ question, answer: rag.answer, grounded: rag.grounded });
+        }
+        return results;
+    },
+});
+
+// ---- admin: list / delete trained Q&A ----
+
+export const listTrainingQA = query({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const all = await ctx.db.query('knowledgeArticles').collect();
+        return all
+            .filter((a) => a.source === 'qa')
+            .sort((a, b) => b.updatedAt - a.updatedAt)
+            .map((a) => ({
+                _id: a._id,
+                question: a.title,
+                answer: a.summary,
+                workspace: a.workspace,
+                embedded: !!a.embedding && a.embedding.length > 0,
+                updatedAt: a.updatedAt,
+            }));
+    },
+});
+
+export const deleteTrainingQA = mutation({
+    args: { id: v.id('knowledgeArticles') },
+    handler: async (ctx, args) => {
+        await requireAdmin(ctx);
+        const row = await ctx.db.get(args.id);
+        if (row && row.source === 'qa') await ctx.db.delete(args.id);
+        return { ok: true };
+    },
+});
+
+/**
+ * Recent questions the AI could NOT ground — the content-gap feed. The admin
+ * turns these into trained Q&A (one click pre-fills the paste box).
+ */
+export const listUnansweredQueries = query({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const recent = await ctx.db
+            .query('knowledgeQueries')
+            .withIndex('by_createdAt')
+            .order('desc')
+            .take(100);
+        return recent
+            .filter((q) => q.grounded === false)
+            .slice(0, 30)
+            .map((q) => ({ query: q.query, source: q.source, createdAt: q.createdAt }));
+    },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -921,6 +921,11 @@ export default defineSchema({
         readMin: v.number(),
         popular: v.optional(v.boolean()),
         status: v.union(v.literal('draft'), v.literal('published')),
+        // Origin of the article. "article" = full hand-written/seeded doc;
+        // "qa" = an admin-trained Q&A (paste-a-question → AI-drafted answer),
+        // see docs/changes/ADMIN-KB-TRAINING-PLAN.md. Both are embedded + retrieved
+        // identically by the RAG; this flag is only for admin display / filtering.
+        source: v.optional(v.string()),
         createdAt: v.number(),
         updatedAt: v.number(),
         // Article-helpfulness counters (incremented by recordFeedback)
@@ -985,6 +990,9 @@ export default defineSchema({
         sourceArticleIds: v.array(v.id('knowledgeArticles')),
         userId: v.optional(v.string()),        // Clerk subject, when signed in
         discordUserId: v.optional(v.string()),
+        // Whether the AI could ground an answer. false = a content gap the admin
+        // can fill from the "train AI" page (turn the unanswered question into a Q&A).
+        grounded: v.optional(v.boolean()),
         createdAt: v.number(),
     })
         .index('by_source', ['source'])

--- a/docs/changes/ADMIN-KB-TRAINING-PLAN.md
+++ b/docs/changes/ADMIN-KB-TRAINING-PLAN.md
@@ -1,0 +1,114 @@
+# Plan: Admin "Train the AI" page — feed Q&A into the Knowledge Base RAG
+
+**Date:** 2026-06-19
+**Status:** BUILDING — simplified per client: **admin pastes only the questions; the AI writes the answers itself**, then embeds them.
+**Goal:** an admin page where staff paste a set of **questions** (no answers). The AI drafts a grounded answer for each from the existing knowledge base, saves each as an embedded Q&A article, and flags any it couldn't confidently answer. Both the `/knowledge` chatbot and Discord `/ask` then know those questions.
+
+> **Refinement (2026-06-19):** the admin does NOT write answers. Paste questions → the AI generates answers (via the existing `runRag` grounding) → saved + embedded. The admin only reviews/edits the ones the AI couldn't ground.
+
+---
+
+## How the AI actually works today (verified against the code)
+
+This is the load-bearing fact that shapes the whole design:
+
+- Both the web (`knowledgeAI.ask`) and Discord (`knowledgeAI.answerQuery`) paths funnel into **one** function, `runRag`.
+- `runRag` answers by **vector-searching `knowledgeArticles` only** — `ctx.vectorSearch('knowledgeArticles', 'by_embedding', …)` (`knowledgeAI.ts:257`). It embeds the user's question, finds the closest articles by their 768-dim Gemini embedding, and grounds the answer in those.
+- `knowledgeArticles` rows carry an `embedding` field; `generateEmbeddingForArticle` / `backfillEmbeddings` populate it from the article text.
+- A `knowledgeFaqs` table exists **but the RAG never searches it** — FAQs are display-only on `/knowledge`, invisible to the AI.
+- `knowledgeQueries` already **logs every question asked** (web/discord/chatbot) — a ready-made source of "questions people actually ask."
+
+**Implication — the simplest correct design:** don't build a separate "AI training" store. Make each admin-entered Q&A a **real `knowledgeArticles` row that gets embedded**, so the existing RAG retrieves it with zero changes to `runRag`. "Training the AI" = "adding embedded Q&A articles." That's the industry-standard pattern (RAG knowledge ingestion), and it reuses everything already built.
+
+---
+
+## The design (simple, reuses the pipeline)
+
+### What the admin does
+A new page **`/admin/knowledge`** (or `/admin/train-ai`) with one primary action: **add a batch of Q&A pairs.** Each pair is:
+
+```
+Question:  "How do I get paid as a creator?"
+Answer:    "You keep 50% of every sale, sent to your Wise wallet within 24 hours of the business paying."
+Workspace: help (public KB + chatbot)  |  wiki (internal field-agent)
+Category:  (pick existing, or "General")
+```
+
+The admin can:
+- **Add Q&A pairs** one at a time, or paste several at once (a simple repeater / "+ Add another" list).
+- **See pending vs. embedded status** — a Q&A is "live to the AI" only once its embedding is generated.
+- **Pull from real questions** — a side panel of recent `knowledgeQueries` (what people actually asked the AI), especially the ones that came back **ungrounded** (the AI couldn't answer). One click turns an unanswered question into a draft Q&A to fill in. *This is the highest-value loop:* the AI tells you what it doesn't know, you teach it.
+
+### What happens under the hood (each Q&A → an embedded article)
+1. Admin submits a Q&A → a new `knowledgeArticles` row is created:
+   - `title` = the question,
+   - `body` = a single `kbBlock` paragraph (the answer) — `body` is the typed-block array the schema already uses,
+   - `summary` = the answer (the answer-first lead the RAG/AI likes),
+   - `workspace`, `categoryId`, `status: 'published'`, `author: 'admin'`,
+   - `source: 'qa'` (a NEW optional field to mark these as admin-trained Q&A vs. full articles — purely for filtering/admin display; the RAG doesn't care).
+2. **Embed it** — schedule `generateEmbeddingForArticle` for the new row (the action already exists). Once the 768-dim vector is written, the RAG can retrieve it. Both web and Discord immediately benefit — same `knowledgeArticles` index.
+3. Done. No change to `runRag`, no new retrieval path, no new vector index.
+
+### Why Q&A-as-article (not the `knowledgeFaqs` table)
+`knowledgeFaqs` is display-only and **not embedded / not searched** by the AI. Routing training Q&A there would require teaching `runRag` to also vector-search FAQs — more code, a second index, two retrieval paths to keep in sync. Making them articles means the thing that's *already* the AI's knowledge source grows. (Optional nicety: these Q&A articles can be hidden from the human-facing `/knowledge` article list via the `source: 'qa'` flag if you don't want them cluttering the help center — they still feed the AI.)
+
+---
+
+## What to build
+
+### Backend (`convex/knowledge.ts` + schema)
+- **Schema:** add `source: v.optional(v.string())` to `knowledgeArticles` (values: `'article'` default | `'qa'`). Additive, no migration. (Reuses existing `embedding`, `status`, `workspace`, `categoryId`.)
+- **`addTrainingQA` mutation** (admin-gated): takes `{ question, answer, workspace, categoryId? }`, creates the published `knowledgeArticles` row (`source: 'qa'`), then schedules `generateEmbeddingForArticle`. Returns the new id + `embedded: false`.
+- **`addTrainingQABatch` mutation** (admin-gated): same for an array — one round-trip for "paste several."
+- **`listTrainingQA` query** (admin-gated): the Q&A rows (`source === 'qa'`) with their embedded status (embedding present?), for the admin list.
+- **`listUnansweredQueries` query** (admin-gated): recent `knowledgeQueries` where `grounded === false` (the AI couldn't answer) — the "teach me this" feed. (Confirm `knowledgeQueries` stores a grounded/answered flag; if not, add one — it's cheap and already logged.)
+- **`deleteTrainingQA`** (admin-gated): remove a Q&A article (with its embedding).
+
+### Frontend (`app/admin/knowledge/page.tsx`)
+- Admin-gated (mirror the existing `/admin` role check / `AdminLayout`).
+- **Add-Q&A form:** question + answer + workspace toggle (help/wiki) + category select; "+ Add another" repeater for batch entry; Save.
+- **Trained Q&A list:** question, answer preview, workspace, **embedded ✓ / embedding… ⏳** status, delete.
+- **"Questions people asked" panel:** recent `knowledgeQueries` (filterable to ungrounded). Each has a "Turn into Q&A" button that pre-fills the form with the question.
+- Add a **"Knowledge / Train AI"** link to the admin nav (`AdminLayout`).
+
+### Nav + glue
+- One `AdminLayout` nav entry. No change to `runRag`, the Discord webhook, or the web chatbot — they keep reading the same `knowledgeArticles` index, now with more entries.
+
+---
+
+## The learning loop (why this is more than a form)
+
+```
+People ask the AI (web + Discord)
+        │  every question logged → knowledgeQueries (grounded: true/false)
+        ▼
+Admin opens /admin/knowledge → sees what the AI COULDN'T answer (grounded:false)
+        │  one click → "Turn into Q&A" → fills the answer
+        ▼
+addTrainingQA → new knowledgeArticles row → embedded (Gemini 768-dim)
+        ▼
+runRag now retrieves it → web KB, chatbot, AND Discord /ask can answer it
+        ▼
+(loop tightens: the gaps the AI reveals become the next batch of training)
+```
+
+This is the industry pattern for keeping a RAG assistant current: **mine the unanswered queries, author answers, re-embed.** It's a closed loop, not a one-time data dump.
+
+---
+
+## Decisions / open questions for you
+
+1. **Q&A visibility on the public `/knowledge` page** — should admin-trained Q&A also show as articles in the human-facing help center, or feed the AI *only* (hidden via `source: 'qa'`)? **Recommend: feed the AI only by default**, with an optional "also show publicly" toggle per Q&A — keeps the help center curated while the AI learns broadly.
+2. **Embedding cost/timing** — each Q&A embed is one Gemini call (uses the BYOK key pool). Batch of 20 = 20 calls, well within free quota. Embeds run async (scheduled), so the admin isn't blocked. OK?
+3. **Auto-FAQ from the answer?** Out of scope here — there's a separate plan to auto-generate `faqs[]` per article. This page is the *manual* "teach the AI" path, which is what you asked for.
+4. **Who can train** — gated to the existing admin role (same as the pricing page). Confirm no separate sub-role needed.
+5. **Wiki vs help** — a Q&A tagged `wiki` only answers for signed-in field agents (the RAG already gates wiki). Confirm admins choose per Q&A (the form has the toggle).
+
+---
+
+## Effort
+- Schema field + 4–5 admin Convex functions: **S–M** (they wrap the existing `upsertArticle` + `generateEmbeddingForArticle`).
+- Admin page (form + list + unanswered-queries panel): **M**.
+- Zero change to the RAG/Discord/chatbot retrieval — that's the point.
+
+**Recommended slice:** (A) schema `source` field + `addTrainingQA`/`addTrainingQABatch` + `listTrainingQA` + the admin form/list → working "feed the AI" path. (B) the `knowledgeQueries` "unanswered → Q&A" panel → the learning loop. Ship A first; it's the core ask.


### PR DESCRIPTION
## What & why

A new **`/admin/knowledge`** ("Train AI") page: staff paste **questions** (one per line); the AI writes a grounded answer for each and learns it, so the Help Center chatbot **and** the Discord `/ask` bot can answer those questions. **The admin writes no answers** — paste questions, the AI does the rest.

Plan: `docs/changes/ADMIN-KB-TRAINING-PLAN.md`.

## How it works (per question)
1. Run the existing RAG (`knowledgeAI.answerQuery`) to **draft a grounded answer** from the current knowledge base.
2. Save it as a published `knowledgeArticles` row (`source: 'qa'`) and schedule its Gemini embedding.
3. Once embedded, `runRag` retrieves it — web chatbot + Discord both answer it.

**Why articles, not a new store:** `runRag` only vector-searches `knowledgeArticles`. Making each trained Q&A an embedded article means **zero change to the retrieval path** — the AI's knowledge source just grows (standard RAG ingestion, reuses the embedding pipeline already built).

## The learning loop
The page surfaces **"Questions the AI couldn't answer"** (from `knowledgeQueries` where `grounded === false` — a flag this PR adds and wires through `runRag`). One click drops an unanswered real question into the paste box. The AI reveals its gaps → you train them → it re-learns.

## Files
| File | Change |
|---|---|
| `convex/knowledgeTraining.ts` (new) | `trainFromQuestions` (action), `saveTrainedQA` (internal), `listTrainingQA`, `deleteTrainingQA`, `listUnansweredQueries` — all admin-gated |
| `convex/schema.ts` | `knowledgeArticles.source` ('article'\|'qa', additive) + `knowledgeQueries.grounded` |
| `convex/knowledge.ts` / `convex/knowledgeAI.ts` | `logQuery` accepts `grounded`; `runRag` records it |
| `app/admin/knowledge/page.tsx` (new) | paste box + workspace toggle + per-question results (✓ grounded / ⚠ needs review) + trained list (embedded status) + unanswered-queries panel |
| `app/admin/components/AdminLayout.tsx` | "Train AI" nav link |

## Verification
- `npx convex codegen` clean · `tsc --noEmit` 0 · **102 tests pass** · `next build` exit 0 (`/admin/knowledge` builds).

## ⚠️ Runtime dependency (not a code issue)
Drafting answers (`answerQuery`) **and** embedding both use the **BYOK Gemini key pool**. The page builds/loads fine, but "Train" produces real answers only once a **valid Gemini key** is in the pool — the same dependency that currently blocks the chatbot. (A previously-saved key was rejected by Google as invalid.) No backend change here fixes that; it's a key-config matter.

## Decision still open (from the plan)
Q&A visibility on the public `/knowledge` page — currently these `source:'qa'` rows are published (searchable + AI-retrievable). If you want them to feed the AI **only** and not clutter the human help-center list, that's a small follow-up filter on the public article list.
