### PR TITLE
feat(admin): knowledge-training UX overhaul + pending-creator overview

### DIFF
--- a/app/admin/creators/_views/PendingApprovalsView.tsx
+++ b/app/admin/creators/_views/PendingApprovalsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
@@ -234,16 +235,18 @@ export default function PendingApprovalsView({ isAdmin }: { isAdmin: boolean }) 
                                                     )}
                                                 </div>
                                                 <div>
-                                                    <div
-                                                        className="text-sm"
+                                                    <Link
+                                                        href={`/admin/creators/pending/${c._id}`}
+                                                        className="text-sm hover:underline"
                                                         style={{
                                                             fontFamily: "var(--ed-serif)",
                                                             fontSize: 16,
                                                             color: "var(--ed-ink)",
                                                         }}
+                                                        title="View creator overview"
                                                     >
                                                         {fullName(c)}
-                                                    </div>
+                                                    </Link>
                                                     <div className="ed-label mt-1">
                                                         quiz passed {timeAgo(c.quizPassedAt)}
                                                     </div>

--- a/app/admin/creators/pending/[id]/page.tsx
+++ b/app/admin/creators/pending/[id]/page.tsx
@@ -1,0 +1,249 @@
+"use client"
+
+/**
+ * Pending creator overview — opened when an admin clicks a creator in the
+ * Pending Approvals queue. Shows a high-level profile (identity, contact,
+ * referral, quiz/waiting status, payout) so the admin can decide before
+ * approving or rejecting. Approve/Reject reuse the same mutations + reject
+ * dialog as the queue view.
+ */
+
+import { useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import Link from "next/link"
+import { useUser } from "@clerk/nextjs"
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { Id } from "@/convex/_generated/dataModel"
+import AdminLayout from "../../../components/AdminLayout"
+import RejectCreatorDialog from "../../../components/RejectCreatorDialog"
+import {
+    ArrowLeft,
+    CheckCircle2,
+    XCircle,
+    Loader2,
+    Mail,
+    Phone,
+    UserCheck,
+    Users,
+    Clock,
+    Wallet,
+} from "lucide-react"
+import { toast } from "sonner"
+
+function timeAgo(ts?: number | null): string {
+    if (!ts) return "—"
+    const diff = Date.now() - ts
+    const mins = Math.floor(diff / 60000)
+    if (mins < 1) return "just now"
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    const days = Math.floor(hrs / 24)
+    return `${days}d ago`
+}
+
+function fmtDate(ts?: number | null): string {
+    if (!ts) return "—"
+    return new Date(ts).toLocaleString()
+}
+
+function fullName(c: { firstName?: string | null; middleName?: string | null; lastName?: string | null; email?: string }): string {
+    const parts = [c.firstName, c.middleName, c.lastName].filter(Boolean) as string[]
+    return parts.length > 0 ? parts.join(" ") : (c.email ?? "Unnamed creator")
+}
+
+export default function PendingCreatorOverviewPage() {
+    const params = useParams()
+    const router = useRouter()
+    const creatorId = params.id as string
+    const { user, isLoaded } = useUser()
+
+    const currentCreator = useQuery(
+        api.creators.getByClerkId,
+        user ? { clerkId: user.id } : "skip"
+    )
+    const isAdmin = currentCreator?.role === "admin"
+
+    const creator = useQuery(
+        api.creators.getById,
+        isAdmin && creatorId ? { id: creatorId as Id<"creators"> } : "skip"
+    )
+
+    const approveCreator = useMutation(api.creators.approveCreator)
+
+    const [approving, setApproving] = useState(false)
+    const [showReject, setShowReject] = useState(false)
+
+    const loading = !isLoaded || (user && currentCreator === undefined) || (isAdmin && creator === undefined)
+
+    async function handleApprove() {
+        if (!creator) return
+        setApproving(true)
+        try {
+            await approveCreator({ id: creator._id })
+            toast.success(`${fullName(creator)} approved — they're now a certified creator.`)
+            router.push("/admin/creators")
+        } catch (e: any) {
+            toast.error(e?.message ?? "Approval failed")
+        } finally {
+            setApproving(false)
+        }
+    }
+
+    if (loading) {
+        return (
+            <AdminLayout>
+                <div className="flex items-center justify-center h-64">
+                    <Loader2 className="w-6 h-6 animate-spin" style={{ color: "var(--ed-ink-3)" }} />
+                </div>
+            </AdminLayout>
+        )
+    }
+
+    if (!isAdmin) {
+        return <AdminLayout><p className="p-6 text-red-600">Forbidden: admin access required.</p></AdminLayout>
+    }
+
+    if (!creator) {
+        return (
+            <AdminLayout>
+                <div className="ed-card-xl text-center">
+                    <p className="ed-body" style={{ color: "var(--ed-ink-2)" }}>Creator not found.</p>
+                    <Link href="/admin/creators" className="ed-door ed-door-ghost inline-flex items-center mt-4" style={{ padding: "8px 14px" }}>
+                        <ArrowLeft className="w-4 h-4" /><span style={{ marginLeft: 8 }}>Back to creators</span>
+                    </Link>
+                </div>
+            </AdminLayout>
+        )
+    }
+
+    // Derive a human status for this creator.
+    const isPending = !!creator.quizPassedAt && !creator.certifiedAt && !creator.rejectedAt && !creator.isDeleted
+    const statusLabel = creator.certifiedAt ? "Approved"
+        : creator.rejectedAt ? "Rejected"
+        : creator.quizPassedAt ? "Pending approval"
+        : "In onboarding"
+
+    const InfoRow = ({ icon: Icon, label, value }: { icon: any; label: string; value: React.ReactNode }) => (
+        <div className="flex items-start gap-3 py-3" style={{ borderTop: "1px solid var(--ed-rule)" }}>
+            <Icon className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-ink-3)" }} />
+            <div className="min-w-0">
+                <div className="ed-label">{label}</div>
+                <div className="text-sm mt-0.5" style={{ color: "var(--ed-ink)", wordBreak: "break-word" }}>{value ?? "—"}</div>
+            </div>
+        </div>
+    )
+
+    return (
+        <AdminLayout>
+            <div className="max-w-4xl mx-auto space-y-6">
+                {/* Back */}
+                <Link
+                    href="/admin/creators"
+                    className="inline-flex items-center gap-2 text-sm"
+                    style={{ color: "var(--ed-ink-3)" }}
+                >
+                    <ArrowLeft className="w-4 h-4" /> Back to Pending Approvals
+                </Link>
+
+                {/* Header: identity + status */}
+                <div className="flex items-start justify-between gap-6 flex-wrap">
+                    <div className="flex items-center gap-4">
+                        <div
+                            className="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0"
+                            style={{ background: "var(--ed-paper-2)", border: "1px solid var(--ed-rule)" }}
+                        >
+                            {creator.profileImage ? (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={creator.profileImage} alt={fullName(creator)} className="w-full h-full object-cover" />
+                            ) : (
+                                <span style={{ fontFamily: "var(--ed-serif)", fontSize: 24, color: "var(--ed-ink-2)" }}>
+                                    {(creator.firstName?.[0] ?? creator.email[0]).toUpperCase()}
+                                </span>
+                            )}
+                        </div>
+                        <div>
+                            <span className="ed-eyebrow">Creator overview</span>
+                            <h1 className="ed-display-md mt-1" style={{ color: "var(--ed-ink)" }}>{fullName(creator)}</h1>
+                            <div className="ed-label mt-1">
+                                {statusLabel}{creator.quizPassedAt ? ` · quiz passed ${timeAgo(creator.quizPassedAt)}` : ""}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Approve / Reject — only meaningful while pending */}
+                    {isPending && (
+                        <div className="inline-flex items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setShowReject(true)}
+                                disabled={approving}
+                                className="ed-door ed-door-danger-ghost inline-flex items-center"
+                                style={{ minHeight: 40, padding: "9px 16px", fontSize: 14 }}
+                            >
+                                <XCircle className="w-4 h-4" /><span style={{ marginLeft: 8 }}>Reject</span>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleApprove}
+                                disabled={approving}
+                                className="ed-door ed-door-accent inline-flex items-center"
+                                style={{ minHeight: 40, padding: "9px 18px", fontSize: 14 }}
+                            >
+                                {approving ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle2 className="w-4 h-4" />}
+                                <span style={{ marginLeft: 8 }}>{approving ? "Approving…" : "Approve"}</span>
+                            </button>
+                        </div>
+                    )}
+                </div>
+
+                <hr className="ed-rule" />
+
+                {/* Detail grid */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10">
+                    {/* Contact */}
+                    <div>
+                        <h2 className="ed-display-sm mb-1" style={{ color: "var(--ed-ink)" }}>Contact</h2>
+                        <InfoRow icon={Mail} label="Email" value={creator.email} />
+                        <InfoRow icon={Phone} label="Phone" value={creator.phone ?? "—"} />
+                        <InfoRow icon={Wallet} label="Payout method" value={creator.payoutMethod ?? creator.wiseEmail ?? "—"} />
+                    </div>
+
+                    {/* Onboarding / referral */}
+                    <div>
+                        <h2 className="ed-display-sm mb-1" style={{ color: "var(--ed-ink)" }}>Onboarding</h2>
+                        <InfoRow icon={UserCheck} label="Quiz passed" value={fmtDate(creator.quizPassedAt)} />
+                        <InfoRow icon={Clock} label="Account created" value={fmtDate(creator.createdAt)} />
+                        <InfoRow icon={Users} label="Referred by" value={creator.referredByName ?? creator.referredByCode ?? "—"} />
+                    </div>
+                </div>
+
+                {/* Pending banner */}
+                {isPending && (
+                    <div
+                        className="ed-card p-4 flex items-start gap-3"
+                        style={{ background: "var(--ed-paper-2)", border: "1px solid var(--ed-rule)" }}
+                    >
+                        <UserCheck className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--ed-accent)" }} />
+                        <p className="ed-body" style={{ maxWidth: "60ch" }}>
+                            This creator passed the onboarding quiz and is waiting for certification.
+                            Approving releases the mobile Pending Review gate; rejecting sends them to the
+                            verification-rejected screen with your reason.
+                        </p>
+                    </div>
+                )}
+            </div>
+
+            <RejectCreatorDialog
+                creator={{ _id: creator._id, firstName: creator.firstName ?? null, lastName: creator.lastName ?? null }}
+                open={showReject}
+                onClose={() => setShowReject(false)}
+                onSuccess={({ displayName }) => {
+                    toast.success(`${displayName} rejected — they'll see the rejection screen on next app open.`)
+                    router.push("/admin/creators")
+                }}
+            />
+        </AdminLayout>
+    )
+}

--- a/app/admin/knowledge/page.tsx
+++ b/app/admin/knowledge/page.tsx
@@ -12,17 +12,27 @@ import { api } from "@/convex/_generated/api";
 import { useAdminAuth } from "@/hooks/useAdmin";
 import AdminLayout from "../components/AdminLayout";
 import { Loader2, Sparkles, CheckCircle2, AlertTriangle, Trash2, ArrowRight, KeyRound, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
 
 type Workspace = "help" | "wiki";
 type TrainResult = { question: string; answer: string; grounded: boolean };
 
 export default function AdminTrainAiPage() {
     const { isAdmin, loading } = useAdminAuth();
-    const train = useAction(api.knowledgeTraining.trainFromQuestions);
+    // Enqueue (fast) — server processes questions one at a time so a big batch
+    // can't time out the client ("Connection lost while action was in flight").
+    const enqueueTraining = useMutation(api.knowledgeTraining.enqueueTraining);
+    const trainQAPairs = useMutation(api.knowledgeTraining.trainQAPairs);
+    const resetDailyLimit = useMutation(api.knowledgeTraining.resetTrainingDailyLimit);
+    const trainingJobs = useQuery(api.knowledgeTraining.listTrainingJobs, isAdmin ? {} : "skip");
+    const clearJobs = useMutation(api.knowledgeTraining.clearFinishedTrainingJobs);
     const trained = useQuery(api.knowledgeTraining.listTrainingQA, isAdmin ? {} : "skip");
     const unanswered = useQuery(api.knowledgeTraining.listUnansweredQueries, isAdmin ? {} : "skip");
     const remove = useMutation(api.knowledgeTraining.deleteTrainingQA);
     const purgeAll = useMutation(api.knowledgeTraining.purgeAllTrainedQA);
+    const purgeUngrounded = useMutation(api.knowledgeTraining.purgeUngroundedQA);
+    const clearUnanswered = useMutation(api.knowledgeTraining.clearUnansweredQueries);
+    const reEmbedPending = useMutation(api.knowledgeTraining.reEmbedPendingQA);
 
     // AI-key health: the page can't run the AI without a usable Gemini key.
     const poolStats = useQuery(api.aiKeys.poolStats, isAdmin ? {} : "skip");
@@ -31,6 +41,9 @@ export default function AdminTrainAiPage() {
 
     const [text, setText] = useState("");
     const [workspace, setWorkspace] = useState<Workspace>("help");
+    // "pairs" = admin pastes "Question? Answer" lines, saved verbatim (no RAG, no
+    // daily limit). "generate" = paste questions, AI drafts answers from the KB.
+    const [mode, setMode] = useState<"pairs" | "generate">("pairs");
     const [running, setRunning] = useState(false);
     const [results, setResults] = useState<TrainResult[] | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -102,15 +115,42 @@ export default function AdminTrainAiPage() {
         setError(null);
         setResults(null);
         try {
-            const res = await train({ questions, workspace });
-            setResults(res);
-            setText("");
+            if (mode === "pairs") {
+                // Save admin-provided "Question? Answer" pairs verbatim. No RAG,
+                // no daily limit — instant, uses your exact answers.
+                const res = await trainQAPairs({ text, workspace });
+                if (res.saved === 0) {
+                    setError(res.skipped > 0
+                        ? `Nothing saved — all ${res.skipped} were duplicates.`
+                        : "No valid 'Question? Answer' pairs found. Each line needs a '?' then the answer.");
+                } else {
+                    setText("");
+                    toast.success(
+                        `${res.saved} answer${res.saved === 1 ? "" : "s"} learned!` +
+                        (res.skipped > 0 ? ` (${res.skipped} duplicate${res.skipped === 1 ? "" : "s"} skipped)` : ""),
+                        { description: "The AI is now studying them — they'll be ready to answer in a few seconds." }
+                    );
+                }
+            } else {
+                // Generate mode: enqueue questions; server drafts answers from the KB.
+                const res = await enqueueTraining({ questions, workspace });
+                setText("");
+                if (res.count === 0) {
+                    setError(res.note ?? "Nothing queued — all duplicates or a limit was hit.");
+                } else if (res.skipped > 0) {
+                    setError(`Queued ${res.count}. Skipped ${res.skipped} (duplicates or daily/queue limit).${res.note ? " " + res.note : ""}`);
+                }
+            }
         } catch (e) {
-            setError(e instanceof Error ? e.message : "Training failed.");
+            setError(e instanceof Error ? e.message : "Could not train.");
         } finally {
             setRunning(false);
         }
     };
+
+    // Live queue state derived from the jobs table.
+    const queuedCount = trainingJobs?.filter((j) => j.status === "queued" || j.status === "processing").length ?? 0;
+    const isProcessing = queuedCount > 0;
 
     return (
         <AdminLayout>
@@ -183,6 +223,26 @@ export default function AdminTrainAiPage() {
 
                 {/* Paste box */}
                 <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
+                    {/* Mode toggle */}
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={() => setMode("pairs")}
+                            className={`px-3 py-1.5 rounded-lg text-sm font-medium ${mode === "pairs" ? "bg-amber-500 text-white" : "bg-gray-100 text-gray-600"}`}
+                        >
+                            Q&A pairs (I provide answers)
+                        </button>
+                        <button
+                            onClick={() => setMode("generate")}
+                            className={`px-3 py-1.5 rounded-lg text-sm font-medium ${mode === "generate" ? "bg-amber-500 text-white" : "bg-gray-100 text-gray-600"}`}
+                        >
+                            AI generates answers
+                        </button>
+                    </div>
+                    <p className="text-xs text-gray-500">
+                        {mode === "pairs"
+                            ? "One per line: the question, a “?”, then your answer. Saved exactly as written — instant, no AI answer-generation, no daily limit."
+                            : "One question per line. The AI drafts a grounded answer from the existing knowledge base (uses the daily AI budget)."}
+                    </p>
                     <div className="flex items-center gap-3">
                         <label className="text-sm font-medium text-gray-700">Workspace</label>
                         <select
@@ -191,29 +251,76 @@ export default function AdminTrainAiPage() {
                             className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm"
                         >
                             <option value="help">Help Center (public + chatbot + Discord)</option>
-                            <option value="wiki">Internal Wiki (field agents only)</option>
                         </select>
+                        <button
+                            onClick={async () => { const r = await resetDailyLimit({}); setError(`Daily AI limit reset (${r.reset} cleared).`); }}
+                            className="ml-auto text-xs text-gray-500 hover:text-amber-600 underline"
+                            title="Reset the daily AI answer-generation limit"
+                        >
+                            Reset daily limit
+                        </button>
                     </div>
                     <textarea
                         value={text}
                         onChange={(e) => setText(e.target.value)}
                         rows={8}
-                        placeholder={"How do I get paid?\nHow long does a website take to build?\nCan I use my own domain?"}
+                        placeholder={mode === "pairs"
+                            ? "How much does a website cost? ₱999, with an optional custom domain add-on.\nWhere does the business pay? Via a Wise payment link sent by email."
+                            : "How do I get paid?\nHow long does a website take to build?\nCan I use my own domain?"}
                         className="w-full px-3 py-2 border border-gray-300 rounded-lg text-gray-900 font-mono text-sm"
                     />
                     <div className="flex items-center justify-between">
-                        <span className="text-xs text-gray-400">{questions.length} question{questions.length === 1 ? "" : "s"}</span>
+                        <span className="text-xs text-gray-400">{questions.length} line{questions.length === 1 ? "" : "s"}</span>
                         <button
                             onClick={handleTrain}
-                            disabled={running || questions.length === 0 || hasUsableKey === false}
-                            title={hasUsableKey === false ? "Add a Gemini key above first" : undefined}
+                            disabled={running || questions.length === 0 || (mode === "generate" && hasUsableKey === false)}
+                            title={mode === "generate" && hasUsableKey === false ? "Add a Gemini key above first" : undefined}
                             className="inline-flex items-center gap-2 h-11 px-6 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl disabled:opacity-50"
                         >
-                            {running ? <><Loader2 className="h-5 w-5 animate-spin" /> Teaching the AI…</> : <><Sparkles className="h-5 w-5" /> Train</>}
+                            {running
+                                ? <><Loader2 className="h-5 w-5 animate-spin" /> {mode === "pairs" ? "Saving…" : "Queuing…"}</>
+                                : <><Sparkles className="h-5 w-5" /> {mode === "pairs" ? "Save Q&A" : "Train"}</>}
                         </button>
                     </div>
                     {error && <p className="text-sm text-red-600">{error}</p>}
+                    {mode === "generate" && (
+                        <p className="text-xs text-gray-400">
+                            Questions are processed in the background one at a time — you can leave this page; results appear below as they finish.
+                        </p>
+                    )}
                 </div>
+
+                {/* Live processing queue */}
+                {trainingJobs && trainingJobs.length > 0 && (
+                    <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-3">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-sm font-semibold text-gray-700 flex items-center gap-2">
+                                {isProcessing ? <Loader2 className="h-4 w-4 animate-spin text-amber-500" /> : <CheckCircle2 className="h-4 w-4 text-green-600" />}
+                                {isProcessing ? `Processing… ${queuedCount} left in queue` : "Queue idle"}
+                            </h2>
+                            <button onClick={() => clearJobs({})} className="text-xs text-gray-500 hover:text-red-600">Clear finished</button>
+                        </div>
+                        <div className="space-y-1 max-h-72 overflow-y-auto">
+                            {trainingJobs.map((j) => (
+                                <div key={j._id} className="flex items-start gap-2 text-sm py-1">
+                                    {j.status === "done" && j.grounded ? <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />
+                                        : j.status === "done" ? <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+                                        : j.status === "error" ? <AlertTriangle className="h-4 w-4 text-red-500 shrink-0 mt-0.5" />
+                                        : <Loader2 className="h-4 w-4 text-gray-400 animate-spin shrink-0 mt-0.5" />}
+                                    <div className="min-w-0">
+                                        <p className="text-gray-900 truncate">{j.question}</p>
+                                        <p className="text-xs text-gray-500">
+                                            {j.status === "queued" ? "queued"
+                                                : j.status === "processing" ? "processing…"
+                                                : j.status === "error" ? `error: ${j.error}`
+                                                : j.grounded ? "learned ✓" : "not grounded — not saved"}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
 
                 {/* Results of the last run */}
                 {results && (
@@ -245,7 +352,15 @@ export default function AdminTrainAiPage() {
                 {/* Questions people asked that the AI couldn't answer */}
                 {unanswered && unanswered.length > 0 && (
                     <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
-                        <h2 className="text-sm font-semibold text-amber-800 mb-3">Questions the AI couldn&apos;t answer</h2>
+                        <div className="flex items-center justify-between mb-3">
+                            <h2 className="text-sm font-semibold text-amber-800">Questions the AI couldn&apos;t answer</h2>
+                            <button
+                                onClick={async () => { const r = await clearUnanswered({}); setError(`Cleared ${r.removed} unanswered question(s).`); }}
+                                className="inline-flex items-center gap-1.5 text-xs text-amber-700 hover:text-red-600"
+                            >
+                                <Trash2 className="h-3.5 w-3.5" /> Clear
+                            </button>
+                        </div>
                         <p className="text-xs text-amber-700 mb-3">Click to drop one into the box above, then Train.</p>
                         <div className="space-y-1">
                             {unanswered.map((u, i) => (
@@ -267,16 +382,43 @@ export default function AdminTrainAiPage() {
                     <div className="flex items-center justify-between mb-3">
                         <h2 className="text-sm font-semibold text-gray-700">Trained questions</h2>
                         {trained && trained.length > 0 && (
-                            <button
-                                onClick={async () => {
-                                    if (confirm("Delete ALL trained Q&A? This removes every question the AI learned here (hand-written articles are untouched). Use this to wipe a bad batch.")) {
-                                        await purgeAll({});
-                                    }
-                                }}
-                                className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-red-600"
-                            >
-                                <Trash2 className="h-3.5 w-3.5" /> Clear all
-                            </button>
+                            <div className="flex items-center gap-4">
+                                {/* Finish learning: retries any Q&A still stuck on "Learning…" */}
+                                {trained.some((t) => !t.embedded) && (
+                                    <button
+                                        onClick={async () => {
+                                            const r = await reEmbedPending({});
+                                            toast.success(`Resuming learning for ${r.retried} answer${r.retried === 1 ? "" : "s"}…`, {
+                                                description: "They'll be ready to answer shortly.",
+                                            });
+                                        }}
+                                        className="inline-flex items-center gap-1.5 text-xs text-amber-700 hover:text-amber-900"
+                                        title="Retry any answers still learning"
+                                    >
+                                        <RefreshCw className="h-3.5 w-3.5" /> Finish learning
+                                    </button>
+                                )}
+                                <button
+                                    onClick={async () => {
+                                        const r = await purgeUngrounded({});
+                                        toast.success(`Removed ${r.removed} unusable answer${r.removed === 1 ? "" : "s"}.`);
+                                    }}
+                                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-amber-600"
+                                    title="Delete answers the AI couldn't actually answer"
+                                >
+                                    <AlertTriangle className="h-3.5 w-3.5" /> Remove unusable
+                                </button>
+                                <button
+                                    onClick={async () => {
+                                        if (confirm("Delete ALL trained Q&A? This removes every question the AI learned here (hand-written articles are untouched). Use this to wipe a bad batch.")) {
+                                            await purgeAll({});
+                                        }
+                                    }}
+                                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-red-600"
+                                >
+                                    <Trash2 className="h-3.5 w-3.5" /> Clear all
+                                </button>
+                            </div>
                         )}
                     </div>
                     {trained === undefined ? (
@@ -291,7 +433,7 @@ export default function AdminTrainAiPage() {
                                         <p className="text-sm font-medium text-gray-900">{t.question}</p>
                                         <p className="text-xs text-gray-500 mt-0.5">{t.answer}</p>
                                         <span className="text-[11px] mt-1 inline-block" style={{ color: t.embedded ? "#16a34a" : "#a16207" }}>
-                                            {t.embedded ? "● learned (embedded)" : "○ embedding…"} · {t.workspace}
+                                            {t.embedded ? "● Ready to answer" : "○ Learning…"} · {t.workspace}
                                         </span>
                                     </div>
                                     <button onClick={() => remove({ id: t._id })} className="text-gray-400 hover:text-red-600 shrink-0">

--- a/convex/knowledgeTraining.ts
+++ b/convex/knowledgeTraining.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { action, query, mutation, internalMutation } from './_generated/server';
+import { action, query, mutation, internalMutation, internalAction } from './_generated/server';
 import { internal } from './_generated/api';
 import { requireAdmin } from './lib/auth';
 import type { Id } from './_generated/dataModel';
@@ -135,6 +135,434 @@ export const trainFromQuestions = action({
             results.push({ question, answer: rag.answer, grounded: rag.grounded });
         }
         return results;
+    },
+});
+
+// ============================================================================
+// QUEUED TRAINING (fixes "Connection lost while action was in flight")
+//
+// The old trainFromQuestions loops over every question inside ONE client-called
+// action — a big batch (RAG + embed per question) runs longer than the client
+// websocket keeps the call in flight, so the client drops it. Instead:
+//   1. enqueueTraining (fast mutation) writes one job row per question + kicks
+//      off the processor, then returns immediately — no long client wait.
+//   2. processNextTrainingJob (internalAction) processes ONE job server-side and
+//      schedules the next. Fully server-driven; nothing to time out.
+// The page watches listTrainingJobs / listTrainingQA reactively for progress.
+// ============================================================================
+
+// ---- Cost guardrails (protect Convex + Gemini billing) ----
+const MAX_PER_PASTE = 25;        // per single paste
+const MAX_QUEUE_BACKLOG = 60;    // refuse if the queue is already this deep
+const MAX_PER_DAY = 100;         // hard daily ceiling on questions processed
+const JOB_INTERVAL_MS = 3000;    // throttle: ~1 question every 3s (not a burst)
+
+export const enqueueTraining = mutation({
+    args: {
+        questions: v.array(v.string()),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        categorySlug: v.optional(v.string()),
+    },
+    handler: async (ctx, args): Promise<{ batchId: string; count: number; skipped: number; note?: string }> => {
+        await requireAdmin(ctx);
+
+        let cleaned = args.questions
+            .map((q) => q.trim())
+            .filter((q) => q.length > 0)
+            .slice(0, MAX_PER_PASTE);
+        if (cleaned.length === 0) return { batchId: '', count: 0, skipped: 0 };
+
+        // GUARD 1: backlog ceiling — don't let queued work pile up unbounded.
+        const backlog = (
+            await ctx.db
+                .query('knowledgeTrainingJobs')
+                .withIndex('by_status', (q) => q.eq('status', 'queued'))
+                .collect()
+        ).length;
+        if (backlog >= MAX_QUEUE_BACKLOG) {
+            return { batchId: '', count: 0, skipped: cleaned.length, note: `Queue is full (${backlog}). Wait for it to drain before adding more.` };
+        }
+
+        // GUARD 2: dedup — skip questions already trained (avoid paying to re-embed
+        // the same Q&A). Match on the exact question title of existing qa articles.
+        const existingQa = (await ctx.db.query('knowledgeArticles').collect())
+            .filter((a) => a.source === 'qa')
+            .map((a) => a.title.trim().toLowerCase());
+        const existingSet = new Set(existingQa);
+        // Also dedup within/against the current queue.
+        const queuedTitles = new Set(
+            (await ctx.db.query('knowledgeTrainingJobs').withIndex('by_status', (q) => q.eq('status', 'queued')).collect())
+                .map((j) => j.question.trim().toLowerCase()),
+        );
+        const before = cleaned.length;
+        cleaned = cleaned.filter((q) => {
+            const key = q.toLowerCase();
+            if (existingSet.has(key) || queuedTitles.has(key)) return false;
+            queuedTitles.add(key);
+            return true;
+        });
+        let skipped = before - cleaned.length;
+
+        // GUARD 3: daily cap — reuse the shared fixed-window rate limiter. Only
+        // enqueue up to whatever remains of today's budget.
+        const room = Math.min(cleaned.length, MAX_QUEUE_BACKLOG - backlog);
+        const allowedToday: string[] = [];
+        for (const q of cleaned.slice(0, room)) {
+            const { allowed } = await ctx.runMutation(internal.knowledge.consumeRateLimit, {
+                key: 'kb-training-daily',
+                limit: MAX_PER_DAY,
+                windowMs: 24 * 60 * 60 * 1000,
+            });
+            if (allowed) allowedToday.push(q);
+            else break; // daily budget exhausted
+        }
+        skipped += cleaned.length - allowedToday.length;
+
+        if (allowedToday.length === 0) {
+            return { batchId: '', count: 0, skipped, note: `Daily training limit (${MAX_PER_DAY}/day) reached, or all duplicates.` };
+        }
+
+        const now = Date.now();
+        const batchId = `batch_${now.toString(36)}_${allowedToday.length}`;
+        for (const question of allowedToday) {
+            await ctx.db.insert('knowledgeTrainingJobs', {
+                question,
+                workspace: args.workspace,
+                categorySlug: args.categorySlug,
+                status: 'queued',
+                batchId,
+                createdAt: now,
+                updatedAt: now,
+            });
+        }
+
+        // Kick the worker. It self-chains (throttled) through the queue.
+        await ctx.scheduler.runAfter(0, internal.knowledgeTraining.processNextTrainingJob, {});
+        return { batchId, count: allowedToday.length, skipped };
+    },
+});
+
+/**
+ * Train from authoritative Q&A PAIRS the admin provides directly, e.g.
+ *   "How much does a website cost? 999, with a custom domain add-on."
+ * Splits each line on the first '?' into question + answer and saves the answer
+ * VERBATIM (no RAG, no Gemini answer-generation) — so admin-provided facts are
+ * used exactly, and it doesn't touch the daily RAG budget. Still embeds each so
+ * the chatbot can retrieve it. Dedups against existing trained Q&A.
+ */
+export const trainQAPairs = mutation({
+    args: {
+        text: v.string(),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        categorySlug: v.optional(v.string()),
+    },
+    handler: async (ctx, args): Promise<{ saved: number; skipped: number }> => {
+        await requireAdmin(ctx);
+
+        // Parse "Question? Answer" per line (split on the FIRST '?').
+        const pairs: { question: string; answer: string }[] = [];
+        for (const line of args.text.split('\n')) {
+            const t = line.trim();
+            if (!t) continue;
+            const qi = t.indexOf('?');
+            if (qi === -1) continue; // no question mark → skip (can't split)
+            const question = t.slice(0, qi + 1).trim();
+            const answer = t.slice(qi + 1).trim();
+            if (question.length > 3 && answer.length > 1) pairs.push({ question, answer });
+        }
+        if (pairs.length === 0) return { saved: 0, skipped: 0 };
+
+        // Dedup against existing trained Q&A titles.
+        const existing = new Set(
+            (await ctx.db.query('knowledgeArticles').collect())
+                .filter((a) => a.source === 'qa')
+                .map((a) => a.title.trim().toLowerCase()),
+        );
+
+        // Resolve category once (requested, else first in workspace).
+        let category = args.categorySlug
+            ? await ctx.db.query('knowledgeCategories').withIndex('by_slug', (q) => q.eq('slug', args.categorySlug!)).first()
+            : null;
+        if (!category) {
+            category = await ctx.db.query('knowledgeCategories').withIndex('by_workspace', (q) => q.eq('workspace', args.workspace)).first();
+        }
+        if (!category) throw new Error('No knowledge category exists yet — seed the KB first.');
+
+        let saved = 0;
+        let skipped = 0;
+        for (const p of pairs.slice(0, MAX_PER_PASTE)) {
+            if (existing.has(p.question.toLowerCase())) { skipped++; continue; }
+            existing.add(p.question.toLowerCase());
+            const now = Date.now();
+            const slug = `qa-${slugify(p.question)}-${now.toString(36).slice(-4)}`;
+            const id = await ctx.db.insert('knowledgeArticles', {
+                slug,
+                title: p.question,
+                summary: p.answer.slice(0, 300),
+                categoryId: category._id,
+                workspace: args.workspace,
+                body: [{ t: 'p' as const, text: p.answer }],
+                keywords: [],
+                author: 'admin (Q&A)',
+                readMin: 1,
+                popular: false,
+                status: 'published',
+                source: 'qa',
+                createdAt: now,
+                updatedAt: now,
+            });
+            // Embed off the write path so the chatbot can retrieve it.
+            await ctx.scheduler.runAfter(0, internal.knowledgeAI.generateEmbeddingForArticle, { articleId: id });
+            saved++;
+        }
+        return { saved, skipped };
+    },
+});
+
+// Admin: reset the daily training rate-limit window (e.g. after a batch of
+// authoritative Q&A that shouldn't have counted against the RAG budget).
+export const resetTrainingDailyLimit = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const rows = (await ctx.db.query('rateLimits').collect())
+            .filter((r) => r.key === 'kb-training-daily');
+        for (const r of rows) await ctx.db.delete(r._id);
+        return { reset: rows.length };
+    },
+});
+
+// Internal variant (no auth) so it can be run from the CLI / dashboard for ops.
+export const resetTrainingDailyLimitInternal = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const rows = (await ctx.db.query('rateLimits').collect()).filter((r) => r.key === 'kb-training-daily');
+        for (const r of rows) await ctx.db.delete(r._id);
+        return { reset: rows.length };
+    },
+});
+
+// Re-run learning (embeddings) for any trained Q&A that hasn't finished learning
+// yet. The embedding is what lets the chatbot FIND an answer; it's generated in a
+// background job that can occasionally fail (e.g. the AI key was briefly busy).
+// This retries those so a stuck "Learning…" item finishes.
+export const reEmbedPendingQA = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const qa = (await ctx.db.query('knowledgeArticles').collect())
+            .filter((a) => a.source === 'qa' && (!a.embedding || a.embedding.length === 0));
+        for (const a of qa) {
+            await ctx.scheduler.runAfter(0, internal.knowledgeAI.generateEmbeddingForArticle, { articleId: a._id });
+        }
+        return { retried: qa.length };
+    },
+});
+
+// Clear the "Questions the AI couldn't answer" feed (ungrounded knowledgeQueries).
+// These are logged every time a chatbot/ask attempt can't be grounded; clearing
+// removes the current gap list (it repopulates as new unanswered asks come in).
+export const clearUnansweredQueries = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const rows = (await ctx.db.query('knowledgeQueries').collect())
+            .filter((q) => q.grounded === false);
+        for (const r of rows) await ctx.db.delete(r._id);
+        return { removed: rows.length };
+    },
+});
+
+// No-auth variant for CLI/ops.
+export const clearUnansweredQueriesInternal = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const rows = (await ctx.db.query('knowledgeQueries').collect())
+            .filter((q) => q.grounded === false);
+        for (const r of rows) await ctx.db.delete(r._id);
+        return { removed: rows.length };
+    },
+});
+
+// Delete trained Q&A rows whose answer is an ungrounded fallback ("I don't have
+// information in the knowledge base…") — these were saved before the guard and
+// poison retrieval. Matches the tell-tale phrasings in the summary/body.
+const UNGROUNDED_MARKERS = [
+    "i don't have information",
+    'i do not have information',
+    "i couldn't find",
+    'no information in the knowledge',
+    'please contact tendso support',
+    'ask in discord',
+    'ask in the discord',
+];
+
+function looksUngrounded(text: string): boolean {
+    const t = (text || '').toLowerCase();
+    return UNGROUNDED_MARKERS.some((m) => t.includes(m));
+}
+
+export const purgeUngroundedQA = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const qa = (await ctx.db.query('knowledgeArticles').collect()).filter((a) => a.source === 'qa');
+        let removed = 0;
+        for (const a of qa) {
+            const bodyText = Array.isArray(a.body)
+                ? a.body.map((b: any) => ('text' in b ? b.text : '')).join(' ')
+                : '';
+            if (looksUngrounded(a.summary || '') || looksUngrounded(bodyText)) {
+                await ctx.db.delete(a._id);
+                removed += 1;
+            }
+        }
+        return { removed, total: qa.length };
+    },
+});
+
+// No-auth variant for CLI/ops.
+export const purgeUngroundedQAInternal = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const qa = (await ctx.db.query('knowledgeArticles').collect()).filter((a) => a.source === 'qa');
+        let removed = 0;
+        for (const a of qa) {
+            const bodyText = Array.isArray(a.body)
+                ? a.body.map((b: any) => ('text' in b ? b.text : '')).join(' ')
+                : '';
+            if (looksUngrounded(a.summary || '') || looksUngrounded(bodyText)) {
+                await ctx.db.delete(a._id);
+                removed += 1;
+            }
+        }
+        return { removed, total: qa.length };
+    },
+});
+
+// Claim the oldest queued job (mark processing). SINGLE-WORKER guard: if a job is
+// already 'processing', refuse — this stops two self-chains (from two pastes) from
+// running Gemini calls concurrently and doubling burn. Mutations are transactional,
+// so this claim is atomic.
+export const claimNextTrainingJob = internalMutation({
+    args: {},
+    handler: async (ctx): Promise<{ jobId: Id<'knowledgeTrainingJobs'>; question: string; workspace: 'help' | 'wiki'; categorySlug?: string } | null> => {
+        const inFlight = await ctx.db
+            .query('knowledgeTrainingJobs')
+            .withIndex('by_status', (q) => q.eq('status', 'processing'))
+            .first();
+        if (inFlight) return null; // another worker is active; don't run in parallel
+
+        const job = await ctx.db
+            .query('knowledgeTrainingJobs')
+            .withIndex('by_status', (q) => q.eq('status', 'queued'))
+            .first();
+        if (!job) return null;
+        await ctx.db.patch(job._id, { status: 'processing', updatedAt: Date.now() });
+        return {
+            jobId: job._id,
+            question: job.question,
+            workspace: job.workspace,
+            categorySlug: job.categorySlug,
+        };
+    },
+});
+
+export const finishTrainingJob = internalMutation({
+    args: {
+        jobId: v.id('knowledgeTrainingJobs'),
+        status: v.string(),
+        grounded: v.optional(v.boolean()),
+        answer: v.optional(v.string()),
+        error: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.jobId, {
+            status: args.status,
+            grounded: args.grounded,
+            answer: args.answer,
+            error: args.error,
+            updatedAt: Date.now(),
+        });
+    },
+});
+
+// Process ONE queued job, then schedule itself again for the next. Runs entirely
+// server-side (scheduler), so no client connection can time out.
+export const processNextTrainingJob = internalAction({
+    args: {},
+    handler: async (ctx): Promise<void> => {
+        const job = await ctx.runMutation(internal.knowledgeTraining.claimNextTrainingJob, {});
+        if (!job) return; // queue drained
+
+        try {
+            const rag = await ctx.runAction(internal.knowledgeAI.answerQuery, {
+                query: job.question,
+                workspace: job.workspace,
+                source: 'web',
+            });
+            // Only save + embed grounded answers (same rule as trainFromQuestions).
+            if (rag.grounded) {
+                await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
+                    question: job.question,
+                    answer: rag.answer,
+                    workspace: job.workspace,
+                    categorySlug: job.categorySlug,
+                    grounded: true,
+                });
+            }
+            await ctx.runMutation(internal.knowledgeTraining.finishTrainingJob, {
+                jobId: job.jobId,
+                status: 'done',
+                grounded: rag.grounded,
+                answer: rag.answer,
+            });
+        } catch (e) {
+            await ctx.runMutation(internal.knowledgeTraining.finishTrainingJob, {
+                jobId: job.jobId,
+                status: 'error',
+                error: e instanceof Error ? e.message : 'processing failed',
+            });
+        }
+
+        // Chain to the next job — THROTTLED (JOB_INTERVAL_MS) so training never
+        // bursts Gemini quota or Convex action-compute. Each job runs in its own
+        // action so a single failure never takes down the batch.
+        await ctx.scheduler.runAfter(JOB_INTERVAL_MS, internal.knowledgeTraining.processNextTrainingJob, {});
+    },
+});
+
+// Live batch/queue status for the page.
+export const listTrainingJobs = query({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const jobs = await ctx.db
+            .query('knowledgeTrainingJobs')
+            .withIndex('by_createdAt')
+            .order('desc')
+            .take(50);
+        return jobs.map((j) => ({
+            _id: j._id,
+            question: j.question,
+            status: j.status,
+            grounded: j.grounded ?? null,
+            answer: j.answer ?? null,
+            error: j.error ?? null,
+            batchId: j.batchId,
+        }));
+    },
+});
+
+// Clear finished/errored jobs (housekeeping — the trained Q&A live in articles).
+export const clearFinishedTrainingJobs = mutation({
+    args: {},
+    handler: async (ctx) => {
+        await requireAdmin(ctx);
+        const done = (await ctx.db.query('knowledgeTrainingJobs').collect())
+            .filter((j) => j.status === 'done' || j.status === 'error');
+        for (const j of done) await ctx.db.delete(j._id);
+        return { removed: done.length };
     },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1004,4 +1004,24 @@ export default defineSchema({
     })
         .index('by_source', ['source'])
         .index('by_createdAt', ['createdAt']),
+
+    // ==================== KNOWLEDGE TRAINING JOBS ====================
+    // One row per pasted question. The admin "Train AI" page enqueues these
+    // (fast mutation) and the scheduler processes them one at a time server-side,
+    // so a large batch can't time out the client action ("Connection lost").
+    knowledgeTrainingJobs: defineTable({
+        question: v.string(),
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        categorySlug: v.optional(v.string()),
+        status: v.string(),                 // 'queued' | 'processing' | 'done' | 'error'
+        grounded: v.optional(v.boolean()),  // set when processed
+        answer: v.optional(v.string()),     // the drafted answer (for the UI)
+        error: v.optional(v.string()),
+        batchId: v.string(),                // groups a paste; lets the UI show batch progress
+        createdAt: v.number(),
+        updatedAt: v.number(),
+    })
+        .index('by_status', ['status'])
+        .index('by_batch', ['batchId'])
+        .index('by_createdAt', ['createdAt']),
 });


### PR DESCRIPTION
## Summary

Overhauls the admin **Train AI** page and adds a **pending-creator overview**. The training page previously ran a large batch inside one client-called action, which dropped on big pastes (*"Connection lost while action was in flight"*), had no cost controls, and only supported AI-generated answers. This makes training reliable, bounded, and usable for non-technical admins.

## Training (Train AI page)

**Reliability — queue instead of a long client action**
- `enqueueTraining` writes one job per question and returns immediately; a self-chaining scheduler (`processNextTrainingJob`) processes them **server-side, one at a time**, so nothing times out. New `knowledgeTrainingJobs` table + a live queue panel showing per-question progress.

**Cost guardrails** (protect Convex + Gemini spend)
- Per-paste cap (25), backlog ceiling (60), daily cap (100/day via the shared rate limiter), a throttled worker (~1 question / 3s), a single-worker guard (no two chains running Gemini concurrently), and dedup against existing/queued questions.

**Authoritative Q&A pairs mode**
- Admins can paste `Question? Answer` lines saved **verbatim** — no RAG call, no daily budget — so provided facts are used exactly. Toggle between this and AI-generated answers.

**Housekeeping + UX**
- Reset daily limit, remove unusable (ungrounded) Q&A, clear the "questions the AI couldn't answer" feed, and **Finish learning** (retry embeddings stuck from a transient failure).
- Non-technical wording: **"Learning…" / "Ready to answer"** instead of "embedding", plus success toasts on save/learn.
- Removed the Internal Wiki workspace option (Help Center only).

## Creators

- New **pending-creator overview** page at `/admin/creators/pending/[id]` — high-level profile (identity, contact, referral, quiz/waiting status) with inline **Approve / Reject** (reusing the existing mutations + reject dialog). Pending-queue creator names now link to it.

## Schema

- `knowledgeTrainingJobs` (queued training work). Additive; no index or breaking changes.

## Notes

- Convex functions in this PR are already deployed to the prod deployment; the Next.js UI (page changes) goes live on the normal Vercel deploy for this branch.
