### PR TITLE
fix(leads): prevent lead detail crash on non-lead route id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ deploy.log
 .astro/
 .vite-cache/
 astro-site-template/.vite-cache/
+
+credentials-passbolt.csv
+*.passbolt.csv
+FRMWRKD-DEV-CREDENTIALS.txt

--- a/app/leads/[leadId]/page.tsx
+++ b/app/leads/[leadId]/page.tsx
@@ -98,8 +98,18 @@ export default function CreatorLeadDetailPage({
 
 type PendingNote = { tempId: string; content: string; createdAt: number };
 
+// Convex ids are 32-char base32; a place_id (e.g. "ChIJ…") isn't and would
+// throw at the v.id('leads') validator, crashing the page. Reject up front.
+function looksLikeConvexId(s: string): boolean {
+    return /^[0-9a-z]{20,40}$/.test(s);
+}
+
 function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any }) {
-    const data = useQuery(api.leads.getDetailForMobileCRM, { id: leadId });
+    const validId = looksLikeConvexId(String(leadId));
+    const data = useQuery(
+        api.leads.getDetailForMobileCRM,
+        validId ? { id: leadId } : "skip",
+    );
     const updateStatus = useMutation(api.leads.updateStatus);
     // Spec contract: api.leadNotes.add({ leadId, content }) — creatorId is
     // derived server-side from the Clerk identity.
@@ -122,6 +132,10 @@ function DetailContent({ leadId, creator }: { leadId: Id<"leads">; creator: any 
         isProspect ? { leadId } : "skip",
     );
 
+    // Query skipped for a bad id — short-circuit instead of spinning forever.
+    if (!validId) {
+        return <NotFound />;
+    }
     if (data === undefined) {
         return (
             <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>

--- a/app/leads/discover/page.tsx
+++ b/app/leads/discover/page.tsx
@@ -267,6 +267,9 @@ function DiscoverInner() {
         if (!haveAnyResolved) return undefined;
 
         const byKey = new Map<string, any>();
+        // url-source rows carry a place_id as _id, not a real lead id — detect
+        // real ids so a dup with one wins the link target.
+        const hasRealId = (row: any) => /^[0-9a-z]{20,40}$/.test(String(row?._id ?? ""));
         const stash = (row: any) => {
             // Dedup key: prefer Google place_id (the only stable cross-source
             // identity), fall back to lat,lng,name when place_id is missing
@@ -274,7 +277,13 @@ function DiscoverInner() {
             const key =
                 row.businessGooglePlaceId
                 ?? `${row.businessLatitude},${row.businessLongitude},${row.businessName}`;
-            if (!byKey.has(key)) byKey.set(key, row);
+            const existing = byKey.get(key);
+            if (!existing) {
+                byKey.set(key, row);
+            } else if (!hasRealId(existing) && hasRealId(row)) {
+                // Keep existing fields but adopt the real _id for the link.
+                byKey.set(key, { ...existing, _id: row._id, __source: existing.__source });
+            }
         };
         if (urlBusinesses) urlBusinesses.forEach(stash);
         poolArray.forEach(stash);


### PR DESCRIPTION
## Summary

Fixes an uncaught client-side exception on the lead detail page (`/leads/[leadId]`) that produced a blank "Application error" screen when a creator opened a lead they had not scraped themselves.

## Root cause

The lead detail page passed the raw route segment straight into `api.leads.getDetailForMobileCRM`, whose argument is validated as `v.id("leads")`. On the Discover map, pins normalized from URL-imported businesses synthesize their row `_id` from the Google `place_id` (not a real document id). The source-merge dedup ranked those URL rows above `pool`/`legacy` rows, so when the same business existed as a real Convex lead, the `place_id` shadowed the real id and became the target of the "View detail" link.

Opening such a pin sent a non-id string (e.g. `ChIJ…`) to the query. Convex's argument validator **throws** on a malformed id rather than returning `null`, and the page had no handling for a thrown query, so React surfaced it as an uncaught exception and blanked the screen.

Leads a creator scraped themselves already resolved to a real document id, which is why the crash only reproduced on other creators' leads.

## Changes

- **Discover source merge** — when a duplicate business is seen across sources, the merge now keeps the higher-priority row's fields but adopts a real Convex `_id` from a lower-priority duplicate that has one, so the detail link resolves to the actual lead instead of a `place_id`.
- **Lead detail page** — guards the route id with a document-id shape check and renders the existing not-found state for anything that is not a valid id, rather than sending it to the query. Defense in depth against any other caller producing a bad id.
- **.gitignore** — ignores the Passbolt credential export files so they cannot be committed.

## Security

Client-side only; no authorization logic changed. The guard can only make access more restrictive (a rejected id never reaches the query), and the server query still enforces auth via `requireIdentity` + creator lookup. The grafted `_id` comes from results the viewer was already authorized to receive. The id-shape regex is a fixed, anchored, length-bounded whitelist (no ReDoS, no injection surface). Google `place_id`s are public identifiers; no secret was ever exposed by the original crash.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds, all routes compiled
- Regex partition confirmed against production data: real lead id `k576a2pejkadj1bzqn9x0tg8618a2q4t` passes; `place_id` `ChIJGURK1LCvvDMRona_m6EYDeM` (which was the crashing URL) is rejected.

## Deploy notes

UI-only — no Convex functions changed, so no `convex deploy` required. Ships with the normal Vercel deploy.
