### PR TITLE
fix(auth): resolve silent login redirect loop on successful sign-in

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -42,7 +42,22 @@ export default function LoginPage() {
 
             if (result.status === "complete" && result.createdSessionId) {
                 await setActive({ session: result.createdSessionId });
-                router.push("/dashboard");
+                // Hard navigation (not router.push): a soft client transition can
+                // race Clerk's session propagation, so /dashboard mounts before
+                // useUser() reports isSignedIn and its gate bounces back to
+                // /login — a silent redirect loop. A full load lands with the
+                // session cookie already set, so the gate sees a signed-in user.
+                window.location.assign("/dashboard");
+                return;
+            }
+
+            // Any non-complete status (needs_first_factor, needs_second_factor,
+            // etc.) previously fell through silently — no redirect, no error,
+            // leaving the user stuck on the page. Surface it instead.
+            if (result.status === "needs_second_factor") {
+                setError("This account needs a verification code. Please sign in from the app to finish two-factor setup.");
+            } else {
+                setError("We couldn't complete sign-in. Double-check your email and password, or reset your password.");
             }
         } catch (err: any) {
             setError(err.errors?.[0]?.longMessage || err.message || "Invalid email or password");


### PR DESCRIPTION
## Summary

Fixes a silent login failure where entering correct credentials showed the button's loading state and then returned to the login page with no error and no redirect.

## Root cause

On a successful password sign-in the handler called `setActive()` to activate the Clerk session and then navigated to `/dashboard` with a soft client transition (`router.push`). That soft transition can win the race against Clerk's session state propagating to the client: `/dashboard` mounts, its auth gate reads `useUser().isSignedIn` before it has flipped to `true`, concludes the user is signed out, and pushes them back to `/login`. The visible effect is a login → dashboard → login bounce with no error surfaced.

The browser console showed no auth error during the failure (only unrelated `manifest.json` warnings), consistent with a client-side redirect race rather than a rejected credential.

A second, latent gap: the handler only acted on `status === "complete"` and did nothing for any other sign-in status, so an edge case such as a required second factor would also dead-end silently.

## Changes

`app/login/page.tsx`:
- After `setActive`, navigate with a full-page load (`window.location.assign("/dashboard")`) instead of `router.push`. The app reloads with the session cookie already set, so the destination gate sees a signed-in user and does not bounce. This matches the existing Google OAuth path, which already uses a hard navigation.
- Surface a user-facing message for any non-complete sign-in status instead of falling through silently.

## Security

No authorization logic changed. The session is still established solely by Clerk via `setActive`; this only changes how the client navigates afterward. No secrets, tokens, or gating touched.

## Verification

- `npx tsc --noEmit` — clean.
- Behavioral: reproduced the loading-then-nothing loop on the deployed login; the hard navigation lands on `/dashboard` with the active session instead of bouncing.

## Deploy notes

UI-only — no Convex functions changed, so no `convex deploy` required. Ships with the normal Vercel deploy.
