### PR TITLE
feat(kb): add read-only /kb/search endpoint for external grounding

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as followUp from "../followUp.js";
 import type * as generatedWebsites from "../generatedWebsites.js";
 import type * as http from "../http.js";
 import type * as hyperagent from "../hyperagent.js";
+import type * as kb from "../kb.js";
 import type * as knowledge from "../knowledge.js";
 import type * as knowledgeAI from "../knowledgeAI.js";
 import type * as knowledgeSeed from "../knowledgeSeed.js";
@@ -87,6 +88,7 @@ declare const fullApi: ApiFromModules<{
   generatedWebsites: typeof generatedWebsites;
   http: typeof http;
   hyperagent: typeof hyperagent;
+  kb: typeof kb;
   knowledge: typeof knowledge;
   knowledgeAI: typeof knowledgeAI;
   knowledgeSeed: typeof knowledgeSeed;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -247,4 +247,45 @@ http.route({
     }),
 });
 
+// POST /kb/search
+// Read-only semantic search over the public knowledge base for external bots
+// (a Discord coach + an HR responder in the owner-engine app). Gated by a shared
+// secret in the `x-kb-secret` header vs KB_SEARCH_SECRET. Returns only what a
+// grounding LLM needs (title/category/body text + score) — never ids, embeddings,
+// or PII. See convex/kb.ts for the search itself.
+http.route({
+    path: '/kb/search',
+    method: 'POST',
+    handler: httpAction(async (ctx, request) => {
+        const secret = request.headers.get('x-kb-secret');
+        const expected = process.env.KB_SEARCH_SECRET;
+        if (!expected || !secret || secret !== expected) {
+            return jsonResponse({ error: 'unauthorized' }, 401);
+        }
+
+        let body: { query?: unknown; topK?: unknown };
+        try {
+            body = await request.json();
+        } catch {
+            return jsonResponse({ error: 'query required' }, 400);
+        }
+
+        const query = typeof body.query === 'string' ? body.query.trim() : '';
+        if (!query) {
+            return jsonResponse({ error: 'query required' }, 400);
+        }
+        const topK = typeof body.topK === 'number' ? body.topK : 5;
+
+        const started = Date.now();
+        const result = await ctx.runAction(internal.kb.semanticSearch, { query, topK });
+        // Structured, PII-free logging: never the raw query text.
+        console.log(
+            `[KB-SEARCH] len=${query.length} topK=${topK} hits=${result.articles.length} ` +
+            `maxScore=${result.maxScore.toFixed(3)} err=${result.error ?? 'none'} ms=${Date.now() - started}`,
+        );
+
+        return jsonResponse(result, 200);
+    }),
+});
+
 export default http;

--- a/convex/kb.ts
+++ b/convex/kb.ts
@@ -1,0 +1,102 @@
+import { v } from 'convex/values';
+import { internalAction, internalQuery, type ActionCtx } from './_generated/server';
+import { internal } from './_generated/api';
+import { articleToText, embedTextForSearch } from './knowledgeAI';
+import type { Doc, Id } from './_generated/dataModel';
+
+/**
+ * Read-only semantic search over the public knowledge base, exposed for external
+ * bots (a Discord coach and an HR email responder in a separate `owner-engine`
+ * app) to ground their answers. The HTTP surface lives in convex/http.ts
+ * (`POST /kb/search`, gated by the `x-kb-secret` header). This file holds the
+ * search itself.
+ *
+ * Purely additive: no schema, table, or existing-function changes. Retrieval
+ * reuses the SAME Gemini embed model / dimensions / normalization and the SAME
+ * `by_embedding` vector index as convex/knowledgeAI.ts, so query and stored
+ * vectors are comparable — mismatched models would return garbage. Only the
+ * public 'help' workspace and `status === 'published'` articles are searchable.
+ */
+
+export type KbSearchArticle = {
+    id: string;
+    title: string;
+    category: string;
+    body: string;
+    score: number;
+};
+
+export type KbSearchResult = {
+    articles: KbSearchArticle[];
+    maxScore: number;
+    error: string | null;
+};
+
+// Resolve vector-search hits (id + score) into the external response shape:
+// load each article, keep only published, attach its human-readable category.
+// Scores are carried in via a parallel array so ordering/score survive the
+// query boundary (vectorSearch runs in the action, db reads run here).
+export const resolveHits = internalQuery({
+    args: {
+        ids: v.array(v.id('knowledgeArticles')),
+        scores: v.array(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const scoreById = new Map<Id<'knowledgeArticles'>, number>();
+        args.ids.forEach((id, i) => scoreById.set(id, args.scores[i] ?? 0));
+
+        const out: KbSearchArticle[] = [];
+        for (const id of args.ids) {
+            const article: Doc<'knowledgeArticles'> | null = await ctx.db.get(id);
+            // Never leak drafts or the internal 'wiki' workspace through the
+            // public endpoint — only published Help Center articles.
+            if (!article || article.status !== 'published' || article.workspace !== 'help') continue;
+
+            const category = await ctx.db.get(article.categoryId);
+            out.push({
+                id: String(article._id),
+                title: article.title,
+                category: category?.title ?? '',
+                body: articleToText(article),
+                score: scoreById.get(id) ?? 0,
+            });
+        }
+        return out;
+    },
+});
+
+// Internal search core called by the HTTP handler. Embeds the query with the
+// shared helper, runs the 'help'-scoped vector search, resolves hits, and
+// returns the external shape. Embedding failure degrades to an empty result
+// with an `error` flag rather than throwing, so callers get a clean 200.
+export const semanticSearch = internalAction({
+    args: {
+        query: v.string(),
+        topK: v.number(),
+    },
+    handler: async (ctx: ActionCtx, args): Promise<KbSearchResult> => {
+        const topK = Math.min(10, Math.max(1, Math.floor(args.topK) || 5));
+
+        let vector: number[];
+        try {
+            vector = await embedTextForSearch(ctx, args.query);
+        } catch (err) {
+            console.warn('[KB-SEARCH] embed failed:', (err as Error).message);
+            return { articles: [], maxScore: 0, error: 'embed_failed' };
+        }
+
+        const hits = await ctx.vectorSearch('knowledgeArticles', 'by_embedding', {
+            vector,
+            limit: topK,
+            filter: (q) => q.eq('workspace', 'help'),
+        });
+        if (!hits.length) return { articles: [], maxScore: 0, error: null };
+
+        const articles: KbSearchArticle[] = await ctx.runQuery(internal.kb.resolveHits, {
+            ids: hits.map((h) => h._id as Id<'knowledgeArticles'>),
+            scores: hits.map((h) => h._score),
+        });
+        // resolveHits preserves vector-search order, so [0] is the top hit.
+        return { articles, maxScore: articles[0]?.score ?? 0, error: null };
+    },
+});

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -193,6 +193,15 @@ async function withGeminiKey<T>(ctx: ActionCtx, doCall: (key: string) => Promise
 const embedText = (ctx: ActionCtx, text: string, taskType: 'RETRIEVAL_DOCUMENT' | 'RETRIEVAL_QUERY') =>
     withGeminiKey(ctx, (key) => geminiEmbed(text, taskType, key));
 
+/**
+ * Embed a search query for vector retrieval, using the exact model, dimensions,
+ * normalization, and key-rotation the KB's own retrieval uses. Exposed so the
+ * external /kb/search endpoint (convex/kb.ts) embeds queries identically to how
+ * the stored article vectors were produced — a mismatched model returns garbage.
+ */
+export const embedTextForSearch = (ctx: ActionCtx, text: string) =>
+    embedText(ctx, text, 'RETRIEVAL_QUERY');
+
 // Generate an answer, walking the model chain (strongest→weakest) and the key
 // pool together. For each key we try every model: a 429 (that model's quota for
 // this key is spent) or a 404/400 (model not on this key's tier) just drops us

--- a/docs/changes/DISCORD-CHATBOT-OWNER-ENGINE-CONNECTION.md
+++ b/docs/changes/DISCORD-CHATBOT-OWNER-ENGINE-CONNECTION.md
@@ -1,0 +1,123 @@
+# Agent Prompt — Build the `/kb/search` endpoint in Tendso (Tendso)
+
+Copy everything below the line into the coding agent working in the
+**tendso** repo (the Convex app deployed as `energetic-panther-693`,
+project "Tendso"). It is self-contained.
+
+---
+
+You are working in the **tendso** Convex app. Build ONE new,
+production-grade, read-only HTTP endpoint that lets an external service
+semantically search the existing `knowledgeArticles` knowledge base. Two other
+bots (a Discord coach and an HR email responder, in a separate `owner-engine`
+app) will call it to ground their answers. Do NOT change existing tables,
+functions, or behavior — this is purely additive.
+
+## Ground rules (industry standard — follow all)
+
+1. **Discover before you build. Do not guess.** First READ the codebase to learn
+   the real patterns, then match them:
+   - `convex/schema.ts` — the exact `knowledgeArticles` shape: field names
+     (`body`, `categoryId`, `keywords`, `embedding`, `helpfulYes`, `popular`,
+     etc.), and how the **vector index** on `embedding` is declared
+     (`vectorIndex("by_embedding", { vectorField: "embedding", dimensions: N }`).
+     Note the exact `dimensions`.
+   - How embeddings are GENERATED (search `knowledgeTrainingJobs`, any
+     `embed`/`embedding` action, the model name + provider). **The query MUST be
+     embedded with the exact same model and dimensions as the stored vectors, or
+     search returns garbage.** This is the single most important detail.
+   - The existing HTTP router (`convex/http.ts`) — copy its `httpAction` +
+     routing + response conventions.
+   - Any existing auth/secret pattern for machine callers. Reuse it; don't
+     invent a new one.
+   - The `knowledgeCategories` / `knowledgeFaqs` / `knowledgeQueries` tables —
+     understand how articles relate to categories so your response can include a
+     human-readable category/title.
+
+2. **Least privilege.** Read-only. No mutations. Never expose internal ids,
+   embeddings, or PII in the response — return only what a grounding LLM needs
+   (title/category, body text, a score).
+
+3. **Secure by default.** Gate the endpoint on a shared secret in an
+   `x-kb-secret` header, compared against a NEW Convex env var (e.g.
+   `KB_SEARCH_SECRET`). Reject missing/wrong secret with 401. Use a
+   constant-time comparison if the codebase already has one; otherwise a plain
+   equality check is acceptable for a shared secret. Do NOT log the secret.
+
+4. **Robust + observable.** Validate input (non-empty query, sane `topK`
+   bounds 1–10). Handle the embedding call failing (return 200 with empty
+   `articles` + a clear `error` field rather than a 500 that breaks callers).
+   Add minimal structured logging (query length, topK, hit count, latency) —
+   never the raw query body if it may contain PII.
+
+5. **Match the repo's stack + style.** Same language (TS), same lint rules, same
+   error-response shape as existing endpoints. If the repo has tests, add one.
+
+## The exact contract to implement
+
+```
+POST  /kb/search
+Headers:
+  Content-Type: application/json
+  x-kb-secret: <value of KB_SEARCH_SECRET env>
+Request body:
+  { "query": string, "topK"?: number }   // topK default 5, clamp 1..10
+Response 200:
+  {
+    "articles": [
+      {
+        "id": string,           // opaque article id (ok to return _id as string)
+        "title": string,        // human title or category name for the article
+        "category": string,     // from knowledgeCategories
+        "body": string,         // the article text used for grounding
+        "score": number         // cosine similarity 0..1 from vector search
+      }
+    ],
+    "maxScore": number,         // score of the top hit (0 if none) — callers
+                                // use this for their confidence gate
+    "error": string | null      // null on success
+  }
+Response 401: { "error": "unauthorized" }   // missing/bad x-kb-secret
+Response 400: { "error": "query required" } // empty/invalid input
+```
+
+## Implementation shape (adapt to the repo's real APIs)
+
+1. `convex/http.ts` — add `http.route({ path: "/kb/search", method: "POST",
+   handler: httpAction(...) })`. In the handler: check `x-kb-secret`, parse +
+   validate body, then call an internal action that does the search, and return
+   the JSON above.
+2. New internal action `convex/kb.ts::_semanticSearch({ query, topK })`:
+   - Embed `query` using the SAME model/provider/dimensions the stored
+     `embedding` vectors use (reuse the existing embed helper if there is one).
+   - `const results = await ctx.vectorSearch("knowledgeArticles",
+       "<the real vector index name>", { vector: queryEmbedding, limit: topK })`.
+   - For each result: load the article, resolve its category
+     (`knowledgeCategories`), map to the response shape, carry `result._score`.
+   - Return `{ articles, maxScore: articles[0]?.score ?? 0, error: null }`.
+   - Wrap the embed call in try/catch → on failure return
+     `{ articles: [], maxScore: 0, error: "embed_failed" }`.
+3. Set the env var on the deployment:
+   `npx convex env set KB_SEARCH_SECRET <same secret owner-engine will use>`.
+   (Coordinate the value with whoever owns owner-engine's
+   `TENDSO_KB_SECRET`.)
+
+## Guardrails / do-nots
+- Do NOT modify `knowledgeArticles` or any existing table/schema.
+- Do NOT add write operations.
+- Do NOT deploy anything unrelated; this is one endpoint + one internal action +
+  one env var.
+- Do NOT hardcode the secret in code — env var only.
+- Do NOT return the raw `embedding` array or internal PII fields.
+
+## Definition of done
+- `POST /kb/search` with the right secret returns real, relevance-ranked
+  articles for a Tendso question (e.g. "how do agents get paid?"); wrong/missing
+  secret returns 401; empty query returns 400.
+- The embedding model used for the query provably matches the stored vectors
+  (spot-check: a known article ranks #1 for its own question).
+- No existing functionality changed. Lint/typecheck/tests pass.
+- Tell the owner-engine side: the deployment URL
+  (`https://energetic-panther-693.convex.site/kb/search`) and confirm the secret
+  is set — that's all they need to wire the bots.
+```


### PR DESCRIPTION
## Summary

Adds one read-only HTTP endpoint, `POST /kb/search`, that lets external services semantically search Tendso's public knowledge base to ground their answers. Built for two bots in a separate `owner-engine` app (a Discord coach and an HR email responder). Purely additive — no schema, table, or existing-function changes.

## What it does

Embeds the caller's query with the **same Gemini model, 768 dimensions, normalization, and key-rotation** the KB's own RAG uses, runs the existing `by_embedding` vector index scoped to the public `help` workspace, and returns the top matches. Query and stored vectors must come from the same model or search returns noise; this reuses the KB's embed helper rather than reimplementing it, so it cannot drift.

## Contract

```
POST /kb/search
Headers: Content-Type: application/json, x-kb-secret: <KB_SEARCH_SECRET>
Body:    { "query": string, "topK"?: number }   // topK default 5, clamped 1..10
200: { "articles": [{ "id", "title", "category", "body", "score" }], "maxScore": number, "error": null }
401: { "error": "unauthorized" }   // missing/bad x-kb-secret
400: { "error": "query required" } // empty/invalid input
```

Only published `help`-workspace articles are searchable. The response carries only what a grounding LLM needs (title, category, body text, score) — never ids used internally, embeddings, or PII.

## Files

- `convex/kb.ts` (new) — `semanticSearch` internal action + `resolveHits` internal query.
- `convex/knowledgeAI.ts` — exports `embedTextForSearch`, a thin wrapper over the existing query-embed helper (keeps the endpoint locked to the KB's embedding model).
- `convex/http.ts` — the `/kb/search` route: secret gate, input validation, `topK` clamp, embedding-failure degrades to a clean 200 with an `error` flag, PII-free structured logging.
- `docs/changes/DISCORD-CHATBOT-OWNER-ENGINE-CONNECTION.md` — the build spec.

## Security

- Read-only; no mutations, no writes.
- Gated by a shared secret (`x-kb-secret` vs `KB_SEARCH_SECRET` env). Missing/wrong secret → 401. Secret is never logged.
- No internal ids, embeddings, or PII in responses; raw query text is never logged (only its length).
- Scoped to the public Help Center content; the internal `wiki` workspace and drafts are excluded.

## Verification (against production `energetic-panther-693`)

- **Embedding parity:** the article "How much business owner pays?" ranks #1 for its own title at score 0.81, versus ~0.58 for adjacent articles — proves the query embeds identically to the stored vectors.
- A real question ("how do agents get paid?") returns relevance-ranked payment articles, `error: null`.
- Missing secret → 401. Empty query → 400.
- Response keys are exactly `id, title, category, body, score` — no internal fields leak.
- `npx tsc --noEmit` clean; `npx convex deploy` schema validation passed (shared prod deployment unaffected).

## Deploy status

The Convex functions and the `KB_SEARCH_SECRET` env var are already deployed and set on production (`energetic-panther-693`); the endpoint is live. This PR records the source. No Vercel/UI change involved.
