### PR TITLE
feat(kb): keyword-first knowledge base search with vector fallback

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -248,11 +248,12 @@ http.route({
 });
 
 // POST /kb/search
-// Read-only semantic search over the public knowledge base for external bots
-// (a Discord coach + an HR responder in the owner-engine app). Gated by a shared
-// secret in the `x-kb-secret` header vs KB_SEARCH_SECRET. Returns only what a
-// grounding LLM needs (title/category/body text + score) — never ids, embeddings,
-// or PII. See convex/kb.ts for the search itself.
+// Read-only KEYWORD-FIRST search over the public knowledge base for external
+// bots (a Discord coach + an HR responder in the owner-engine app). Gated by a
+// shared secret in the `x-kb-secret` header vs KB_SEARCH_SECRET. Returns only
+// what a grounding LLM needs (title/category/body text + score) plus a `mode`
+// ('keyword' | 'vector' | 'none') telling callers how to read `score`. See
+// convex/kb.ts for the search itself.
 http.route({
     path: '/kb/search',
     method: 'POST',
@@ -277,10 +278,10 @@ http.route({
         const topK = typeof body.topK === 'number' ? body.topK : 5;
 
         const started = Date.now();
-        const result = await ctx.runAction(internal.kb.semanticSearch, { query, topK });
+        const result = await ctx.runAction(internal.kb.search, { query, topK });
         // Structured, PII-free logging: never the raw query text.
         console.log(
-            `[KB-SEARCH] len=${query.length} topK=${topK} hits=${result.articles.length} ` +
+            `[KB-SEARCH] len=${query.length} topK=${topK} mode=${result.mode} hits=${result.articles.length} ` +
             `maxScore=${result.maxScore.toFixed(3)} err=${result.error ?? 'none'} ms=${Date.now() - started}`,
         );
 

--- a/convex/kb.ts
+++ b/convex/kb.ts
@@ -1,21 +1,32 @@
 import { v } from 'convex/values';
 import { internalAction, internalQuery, type ActionCtx } from './_generated/server';
 import { internal } from './_generated/api';
-import { articleToText, embedTextForSearch } from './knowledgeAI';
+import {
+    articleToText,
+    embedTextForSearch,
+    queryTerms,
+    keywordScore,
+    KEYWORD_MAX_PER_TERM,
+    KEYWORD_POPULAR_BONUS,
+} from './knowledgeAI';
 import type { Doc, Id } from './_generated/dataModel';
 
 /**
- * Read-only semantic search over the public knowledge base, exposed for external
- * bots (a Discord coach and an HR email responder in a separate `owner-engine`
- * app) to ground their answers. The HTTP surface lives in convex/http.ts
- * (`POST /kb/search`, gated by the `x-kb-secret` header). This file holds the
- * search itself.
+ * Read-only search over the public knowledge base, exposed for external bots (a
+ * Discord coach and an HR email responder in a separate `owner-engine` app) to
+ * ground their answers. The HTTP surface lives in convex/http.ts (`POST
+ * /kb/search`, gated by the `x-kb-secret` header). This file holds the search.
  *
- * Purely additive: no schema, table, or existing-function changes. Retrieval
- * reuses the SAME Gemini embed model / dimensions / normalization and the SAME
- * `by_embedding` vector index as convex/knowledgeAI.ts, so query and stored
- * vectors are comparable — mismatched models would return garbage. Only the
- * public 'help' workspace and `status === 'published'` articles are searchable.
+ * KEYWORD-FIRST (mirrors convex/knowledgeAI.ts): traditional term scoring over
+ * the published Help Center runs first and, at the current KB size, answers most
+ * queries at zero inference cost. Gemini embeddings + the `by_embedding` vector
+ * index are a fallback used ONLY when keyword finds nothing. The response's
+ * `mode` says which path served the hits so callers can calibrate `score`:
+ *   - 'keyword' → score is a normalized 0–1 lexical-match confidence
+ *   - 'vector'  → score is the raw cosine similarity (0–1) from the vector index
+ *   - 'none'    → no hits (articles empty)
+ * Only the public 'help' workspace and `status === 'published'` articles are
+ * ever searchable; drafts and the internal 'wiki' can never leak.
  */
 
 export type KbSearchArticle = {
@@ -30,18 +41,68 @@ export type KbSearchResult = {
     articles: KbSearchArticle[];
     maxScore: number;
     error: string | null;
+    mode: 'keyword' | 'vector' | 'none';
 };
 
+// Project a published Help Center article into the external response shape.
+async function toSearchArticle(
+    ctx: { db: { get: (id: Id<'knowledgeCategories'>) => Promise<Doc<'knowledgeCategories'> | null> } },
+    article: Doc<'knowledgeArticles'>,
+    score: number,
+): Promise<KbSearchArticle> {
+    const category = await ctx.db.get(article.categoryId);
+    return {
+        id: String(article._id),
+        title: article.title,
+        category: category?.title ?? '',
+        body: articleToText(article),
+        score,
+    };
+}
+
+// Keyword search over the published Help Center. Loads the (small) corpus,
+// scores each article with the SAME scorer the internal RAG uses, and returns
+// the top-K as external articles with a normalized 0–1 score. No embedding call.
+export const keywordSearch = internalQuery({
+    args: { query: v.string(), topK: v.number() },
+    handler: async (ctx, args): Promise<KbSearchArticle[]> => {
+        const terms = queryTerms(args.query);
+        if (!terms.length) return [];
+        const topK = Math.min(10, Math.max(1, Math.floor(args.topK) || 5));
+
+        const corpus = await ctx.db
+            .query('knowledgeArticles')
+            .withIndex('by_workspace_status', (q) => q.eq('workspace', 'help').eq('status', 'published'))
+            .collect();
+
+        const denom = KEYWORD_MAX_PER_TERM * terms.length; // normalize raw score → 0–1
+        const ranked = corpus
+            .map((a) => ({ a, raw: keywordScore(a, terms) }))
+            // Require a GENUINE term match: strip the popularity nudge so a merely
+            // `popular` article can't phantom-match a query it shares no words with
+            // (that would mask true misses and starve the vector fallback).
+            .filter((r) => r.raw - (r.a.popular ? KEYWORD_POPULAR_BONUS : 0) > 0)
+            .sort((x, y) => y.raw - x.raw)
+            .slice(0, topK);
+
+        const out: KbSearchArticle[] = [];
+        for (const { a, raw } of ranked) {
+            out.push(await toSearchArticle(ctx, a, Math.min(1, raw / denom)));
+        }
+        return out;
+    },
+});
+
 // Resolve vector-search hits (id + score) into the external response shape:
-// load each article, keep only published, attach its human-readable category.
-// Scores are carried in via a parallel array so ordering/score survive the
-// query boundary (vectorSearch runs in the action, db reads run here).
+// load each article, keep only published Help Center rows, attach the category.
+// Scores are carried in via a parallel array so ordering/score survive the query
+// boundary (vectorSearch runs in the action, db reads run here).
 export const resolveHits = internalQuery({
     args: {
         ids: v.array(v.id('knowledgeArticles')),
         scores: v.array(v.number()),
     },
-    handler: async (ctx, args) => {
+    handler: async (ctx, args): Promise<KbSearchArticle[]> => {
         const scoreById = new Map<Id<'knowledgeArticles'>, number>();
         args.ids.forEach((id, i) => scoreById.set(id, args.scores[i] ?? 0));
 
@@ -51,25 +112,18 @@ export const resolveHits = internalQuery({
             // Never leak drafts or the internal 'wiki' workspace through the
             // public endpoint — only published Help Center articles.
             if (!article || article.status !== 'published' || article.workspace !== 'help') continue;
-
-            const category = await ctx.db.get(article.categoryId);
-            out.push({
-                id: String(article._id),
-                title: article.title,
-                category: category?.title ?? '',
-                body: articleToText(article),
-                score: scoreById.get(id) ?? 0,
-            });
+            out.push(await toSearchArticle(ctx, article, scoreById.get(id) ?? 0));
         }
         return out;
     },
 });
 
-// Internal search core called by the HTTP handler. Embeds the query with the
-// shared helper, runs the 'help'-scoped vector search, resolves hits, and
-// returns the external shape. Embedding failure degrades to an empty result
-// with an `error` flag rather than throwing, so callers get a clean 200.
-export const semanticSearch = internalAction({
+// Search core called by the HTTP handler. Keyword-first: try term scoring over
+// the published Help Center; only when it finds nothing, embed the query and run
+// the 'help'-scoped vector search as a fallback. Embedding failure degrades to
+// an empty result with an `error` flag rather than throwing, so callers get a
+// clean 200.
+export const search = internalAction({
     args: {
         query: v.string(),
         topK: v.number(),
@@ -77,12 +131,22 @@ export const semanticSearch = internalAction({
     handler: async (ctx: ActionCtx, args): Promise<KbSearchResult> => {
         const topK = Math.min(10, Math.max(1, Math.floor(args.topK) || 5));
 
+        // 1) Keyword search first — no embedding call, zero inference cost.
+        const kw: KbSearchArticle[] = await ctx.runQuery(internal.kb.keywordSearch, {
+            query: args.query,
+            topK,
+        });
+        if (kw.length) {
+            return { articles: kw, maxScore: kw[0].score, error: null, mode: 'keyword' };
+        }
+
+        // 2) Vector/similarity fallback — only when keyword found nothing.
         let vector: number[];
         try {
             vector = await embedTextForSearch(ctx, args.query);
         } catch (err) {
             console.warn('[KB-SEARCH] embed failed:', (err as Error).message);
-            return { articles: [], maxScore: 0, error: 'embed_failed' };
+            return { articles: [], maxScore: 0, error: 'embed_failed', mode: 'none' };
         }
 
         const hits = await ctx.vectorSearch('knowledgeArticles', 'by_embedding', {
@@ -90,13 +154,14 @@ export const semanticSearch = internalAction({
             limit: topK,
             filter: (q) => q.eq('workspace', 'help'),
         });
-        if (!hits.length) return { articles: [], maxScore: 0, error: null };
+        if (!hits.length) return { articles: [], maxScore: 0, error: null, mode: 'none' };
 
         const articles: KbSearchArticle[] = await ctx.runQuery(internal.kb.resolveHits, {
             ids: hits.map((h) => h._id as Id<'knowledgeArticles'>),
             scores: hits.map((h) => h._score),
         });
-        // resolveHits preserves vector-search order, so [0] is the top hit.
-        return { articles, maxScore: articles[0]?.score ?? 0, error: null };
+        // resolveHits can drop hits (drafts/wiki); if nothing survives, report none.
+        if (!articles.length) return { articles: [], maxScore: 0, error: null, mode: 'none' };
+        return { articles, maxScore: articles[0]?.score ?? 0, error: null, mode: 'vector' };
     },
 });

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -7,8 +7,10 @@ import type { Doc, Id } from './_generated/dataModel';
 /**
  * Gemini-powered RAG for the Tendso knowledge base.
  *
- * Retrieval: Gemini embeddings (text-embedding-004, 768-dim) + Convex native
- * vector search, with a keyword fallback if embeddings are not yet generated.
+ * Retrieval: keyword search FIRST (traditional term scoring over the published
+ * corpus); Gemini embeddings + Convex native vector search are a fallback only
+ * when keyword finds nothing. At the current KB size this keeps the common path
+ * at zero inference cost (no query embedding).
  * Generation: Gemini generateContent, strictly grounded in the retrieved
  * sources, with multi-turn history for follow-ups. Answers walk a model chain
  * (strongest→weakest, see DEFAULT_GEN_CHAIN) so the best available model is
@@ -258,13 +260,21 @@ async function generateWithFallback(ctx: ActionCtx, system: string, contents: Ge
 const STOP = new Set(
     'the a an to my of for is in on at it as how do i can what where when why with your you our we and or but if'.split(' '),
 );
-function queryTerms(q: string): string[] {
+export function queryTerms(q: string): string[] {
     return (q || '')
         .toLowerCase()
         .split(/[^a-z0-9]+/)
         .filter((t) => t.length >= 2 && !STOP.has(t));
 }
-function keywordScore(a: Article, terms: string[]): number {
+// Max keywordScore a single query term can contribute (title 6 + title-prefix 3
+// + keywords 4 + summary 2 + body 1). Used to normalize raw scores into a 0–1
+// confidence for the external /kb/search contract (see convex/kb.ts).
+export const KEYWORD_MAX_PER_TERM = 16;
+// Tie-break nudge for popular articles among genuine matches. It is NOT a match
+// signal on its own — callers that need "did any term actually match?" must
+// subtract this from the raw score (the external endpoint does exactly that).
+export const KEYWORD_POPULAR_BONUS = 0.4;
+export function keywordScore(a: Article, terms: string[]): number {
     const title = a.title.toLowerCase();
     const summary = a.summary.toLowerCase();
     const kw = (a.keywords || []).join(' ').toLowerCase();
@@ -277,13 +287,31 @@ function keywordScore(a: Article, terms: string[]): number {
         if (summary.includes(t)) s += 2;
         if (body.includes(t)) s += 1;
     }
-    if (a.popular) s += 0.4;
+    if (a.popular) s += KEYWORD_POPULAR_BONUS;
     return s;
 }
 
-// ---- retrieval: vector search first, keyword fallback ----
+// ---- retrieval: keyword search first, vector/similarity fallback ----
+// Per the Knowledge Hub spec, always try traditional keyword search first and
+// only reach for embeddings when keyword finds nothing. At the current KB size
+// this keeps the common path at zero inference cost (no query embedding).
 async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, topK = 5): Promise<Article[]> {
-    // 1) Try semantic search.
+    // Small corpus: load the whole published set once, score in memory.
+    const all: Article[] = await ctx.runQuery(internal.knowledge.listPublishedInternal, { workspace });
+
+    // 1) Keyword search — no embedding call, zero inference cost.
+    const terms = queryTerms(query);
+    if (terms.length) {
+        const scored = all
+            .map((a) => ({ a, score: keywordScore(a, terms) }))
+            .filter((r) => r.score > 0)
+            .sort((x, y) => y.score - x.score)
+            .slice(0, topK)
+            .map((r) => r.a);
+        if (scored.length) return scored;
+    }
+
+    // 2) Vector/similarity fallback — only when keyword found nothing.
     try {
         const vector = await embedText(ctx, query, 'RETRIEVAL_QUERY');
         const hits = await ctx.vectorSearch('knowledgeArticles', 'by_embedding', {
@@ -292,30 +320,21 @@ async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, top
             filter: (q) => q.eq('workspace', workspace),
         });
         if (hits.length) {
-            const docs = await ctx.runQuery(internal.knowledge.getArticlesByIds, {
-                ids: hits.map((h) => h._id as Id<'knowledgeArticles'>),
-            });
-            // Preserve vector-search order; keep only published.
-            const byId = new Map(docs.map((d) => [d._id, d]));
+            // Resolve against the already-loaded published set. Because `all` is
+            // published-only, this also drops any draft the vector index surfaced
+            // (status is not a vector filter field), and saves a second DB read.
+            const byId = new Map(all.map((d) => [d._id, d]));
             const ordered = hits
                 .map((h) => byId.get(h._id as Id<'knowledgeArticles'>))
-                .filter((d): d is Article => !!d && d.status === 'published');
+                .filter((d): d is Article => !!d);
             if (ordered.length) return ordered.slice(0, topK);
         }
     } catch (err) {
-        console.warn('[KB-AI] vector search unavailable, falling back to keyword:', (err as Error).message);
+        console.warn('[KB-AI] vector fallback unavailable:', (err as Error).message);
     }
 
-    // 2) Keyword fallback over the published corpus.
-    const all: Article[] = await ctx.runQuery(internal.knowledge.listPublishedInternal, { workspace });
-    const terms = queryTerms(query);
-    if (!terms.length) return all.filter((a) => a.popular).slice(0, topK);
-    return all
-        .map((a) => ({ a, score: keywordScore(a, terms) }))
-        .filter((r) => r.score > 0)
-        .sort((x, y) => y.score - x.score)
-        .slice(0, topK)
-        .map((r) => r.a);
+    // 3) Last resort: popular articles.
+    return all.filter((a) => a.popular).slice(0, topK);
 }
 
 // ---- conversation memory (multi-turn follow-ups) ----


### PR DESCRIPTION
## What

Makes the knowledge base search **keyword-first**, per the Knowledge Hub spec (ClickUp 86car4m4y, item 2). Traditional term scoring over the published corpus runs first; Gemini embeddings + vector search are a fallback used **only when keyword finds no genuine match**. At the current KB size this keeps the common path at **zero inference cost**.

Applies to both retrieval paths:
- **Internal RAG** (`ask` / Discord `answerQuery`) — `retrieve()` inverted to keyword-first.
- **External `/kb/search`** endpoint — rewritten keyword-first with a vector fallback.

## Changes
- **`convex/knowledgeAI.ts`** — invert `retrieve()` to keyword-first; export the shared keyword scorer (`queryTerms`/`keywordScore`) + weight constants so `kb.ts` reuses identical logic (no drift). Also drops a stale `text-embedding-004` doc reference.
- **`convex/kb.ts`** — rewrite the `/kb/search` core keyword-first with vector fallback; **normalize keyword scores to 0–1**; add a **`mode`** field (`'keyword' | 'vector' | 'none'`) so callers know how to read `score`; require a genuine term match so a `popular` article no longer phantom-matches every query (which would starve the fallback).
- **`convex/http.ts`** — wire to `internal.kb.search`; log `mode`.

## API contract note (for the owner-engine app)
`/kb/search` responses now include `mode`, and `score` means different things per mode:
- `keyword` → normalized 0–1 lexical-match confidence
- `vector` → raw cosine similarity (0–1)

Consumers should read `mode` and threshold `maxScore` accordingly (e.g. reject low-confidence vector-only nearest-neighbours).

## Verification (against a dev deployment)
- Keyword hit: `"how much does a website cost"` → `mode: keyword`, correct top article.
- Paraphrase miss → fallback: `"is it expensive?"` → `mode: vector`, top hit a pricing article (0.686) — the fallback catches what keyword can't.
- Off-topic: `"how do I bake sourdough bread"` → `mode: vector`, low `maxScore` (0.517) for callers to threshold out.
- HTTP contract: **200** (valid secret, includes `mode`), **401** (missing secret), **400** (empty query).

## Deploy note
Backend-only change. ⚠️ This repo shares one Convex prod deployment with the mobile app, and `npx convex deploy` is **manual** (CI only deploys the Next.js app). Run `npx convex deploy --dry-run` first and confirm no function deletions / schema changes before `npx convex deploy`. No schema change here (functions only), so it should be low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)