### PR TITLE
feat(kb): Discord escalation & learning loop (flag-gated)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as domains from "../domains.js";
 import type * as drive from "../drive.js";
 import type * as driveHelpers from "../driveHelpers.js";
 import type * as earnings from "../earnings.js";
+import type * as escalations from "../escalations.js";
 import type * as files from "../files.js";
 import type * as followUp from "../followUp.js";
 import type * as generatedWebsites from "../generatedWebsites.js";
@@ -83,6 +84,7 @@ declare const fullApi: ApiFromModules<{
   drive: typeof drive;
   driveHelpers: typeof driveHelpers;
   earnings: typeof earnings;
+  escalations: typeof escalations;
   files: typeof files;
   followUp: typeof followUp;
   generatedWebsites: typeof generatedWebsites;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -44,4 +44,13 @@ crons.hourly(
     internal.outscraper.releaseStaleClaimsInternal,
 );
 
+// Every 2 minutes: poll open Knowledge Hub escalation threads for a human reply,
+// turn it into a KB Q&A, and notify the asker. No-op unless KB_ESCALATION_ENABLED.
+crons.interval(
+    'poll-kb-escalations',
+    { minutes: 2 },
+    internal.escalations.pollPending,
+    {},
+);
+
 export default crons;

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -1,0 +1,178 @@
+import { v } from 'convex/values';
+import { internalAction, internalMutation, internalQuery } from './_generated/server';
+import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+
+/**
+ * Discord escalation loop for the Knowledge Hub.
+ *
+ * When a web/chat question can't be answered from the KB (retrieval found no
+ * genuine match — see `retrieve()` / `matched` in convex/knowledgeAI.ts), the
+ * question is escalated here:
+ *   1. `createAndPost` — dedup, record an `escalations` row, post the question to
+ *      a role-scoped Discord channel, and open a thread on it.
+ *   2. A team member replies in that thread.
+ *   3. A cron (convex/crons.ts) polls the thread for the human answer, turns it
+ *      into a KB Q&A (knowledgeTraining.saveTrainedQA), and notifies the asker.
+ *
+ * Discord is ONLY the team's answer surface — the asker is a web/mobile user.
+ *
+ * Env: DISCORD_BOT_TOKEN (reused from /ask), DISCORD_ESCALATION_CHANNEL_ID (the
+ * role-scoped channel — from Theo). Without the channel id, escalations are still
+ * recorded (queue), but not posted to Discord.
+ */
+
+const DISCORD_API = 'https://discord.com/api/v10';
+const workspaceArg = v.union(v.literal('help'), v.literal('wiki'));
+
+function normalizeQuestion(q: string): string {
+    return q.toLowerCase().replace(/\s+/g, ' ').trim().slice(0, 300);
+}
+
+// An escalation is "open" (don't re-post a duplicate) while it's still being
+// handled — posted but not yet answered, learned, or delivered.
+const OPEN_STATUSES = new Set(['pending', 'answered', 'learned']);
+
+/** Dedup: is there already an open escalation for this question? */
+export const findOpenByQuestion = internalQuery({
+    args: { normalizedQuestion: v.string() },
+    handler: async (ctx, args) => {
+        const rows = await ctx.db
+            .query('escalations')
+            .withIndex('by_normalized', (q) => q.eq('normalizedQuestion', args.normalizedQuestion))
+            .collect();
+        return rows.find((r) => OPEN_STATUSES.has(r.status)) ?? null;
+    },
+});
+
+export const insertEscalation = internalMutation({
+    args: {
+        question: v.string(),
+        normalizedQuestion: v.string(),
+        workspace: workspaceArg,
+        askerUserId: v.optional(v.string()),
+    },
+    handler: async (ctx, args): Promise<Id<'escalations'>> => {
+        const now = Date.now();
+        return await ctx.db.insert('escalations', {
+            question: args.question,
+            normalizedQuestion: args.normalizedQuestion,
+            workspace: args.workspace,
+            askerUserId: args.askerUserId,
+            status: 'pending',
+            createdAt: now,
+            updatedAt: now,
+        });
+    },
+});
+
+/** Patch any subset of an escalation's mutable fields (Discord ids, status, answer, …). */
+export const patchEscalation = internalMutation({
+    args: {
+        id: v.id('escalations'),
+        status: v.optional(
+            v.union(
+                v.literal('pending'),
+                v.literal('answered'),
+                v.literal('learned'),
+                v.literal('delivered'),
+                v.literal('error'),
+            ),
+        ),
+        discordChannelId: v.optional(v.string()),
+        discordMessageId: v.optional(v.string()),
+        discordThreadId: v.optional(v.string()),
+        answer: v.optional(v.string()),
+        answeredBy: v.optional(v.string()),
+        answeredAt: v.optional(v.number()),
+        learnedArticleId: v.optional(v.id('knowledgeArticles')),
+        error: v.optional(v.string()),
+        lastPolledAt: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const { id, ...rest } = args;
+        await ctx.db.patch(id, { ...rest, updatedAt: Date.now() });
+    },
+});
+
+/**
+ * Entry point (scheduled fire-and-forget from knowledgeAI.ask): record the
+ * escalation, then post it to Discord and open a thread. Dedups on the question
+ * so the same open question isn't posted twice.
+ */
+export const createAndPost = internalAction({
+    args: {
+        question: v.string(),
+        workspace: workspaceArg,
+        askerUserId: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const normalizedQuestion = normalizeQuestion(args.question);
+
+        // Dedup: skip if this question is already being handled.
+        const existing = await ctx.runQuery(internal.escalations.findOpenByQuestion, { normalizedQuestion });
+        if (existing) {
+            console.log('[KB-ESCALATION] duplicate question already open, skipping:', normalizedQuestion.slice(0, 60));
+            return;
+        }
+
+        const id = await ctx.runMutation(internal.escalations.insertEscalation, {
+            question: args.question,
+            normalizedQuestion,
+            workspace: args.workspace,
+            askerUserId: args.askerUserId,
+        });
+
+        const channelId = process.env.DISCORD_ESCALATION_CHANNEL_ID;
+        const botToken = process.env.DISCORD_BOT_TOKEN;
+        if (!channelId || !botToken) {
+            // Queue is recorded; Discord posting activates once the channel is configured.
+            console.warn('[KB-ESCALATION] DISCORD_ESCALATION_CHANNEL_ID/DISCORD_BOT_TOKEN not set — recorded escalation but did not post to Discord.');
+            return;
+        }
+
+        try {
+            // 1) Post the question to the role-scoped channel.
+            const msgRes = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+                method: 'POST',
+                headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    content:
+                        `❓ **Unanswered question from the Knowledge Hub**\n\n>>> ${args.question}\n\n` +
+                        `_Reply in this thread with the answer — the bot will add it to the knowledge base._`,
+                    allowed_mentions: { parse: [] },
+                }),
+            });
+            if (!msgRes.ok) {
+                throw new Error(`post message failed (${msgRes.status}): ${(await msgRes.text().catch(() => '')).slice(0, 200)}`);
+            }
+            const msg = (await msgRes.json()) as { id: string };
+
+            // 2) Start a thread from that message so replies are scoped to it.
+            const threadRes = await fetch(`${DISCORD_API}/channels/${channelId}/messages/${msg.id}/threads`, {
+                method: 'POST',
+                headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: args.question.slice(0, 90), auto_archive_duration: 1440 }),
+            });
+            if (!threadRes.ok) {
+                throw new Error(`create thread failed (${threadRes.status}): ${(await threadRes.text().catch(() => '')).slice(0, 200)}`);
+            }
+            const thread = (await threadRes.json()) as { id: string };
+
+            await ctx.runMutation(internal.escalations.patchEscalation, {
+                id,
+                discordChannelId: channelId,
+                discordMessageId: msg.id,
+                discordThreadId: thread.id,
+            });
+            console.log('[KB-ESCALATION] posted to Discord, thread', thread.id);
+        } catch (err) {
+            console.error('[KB-ESCALATION] Discord post failed:', (err as Error).message);
+            await ctx.runMutation(internal.escalations.patchEscalation, {
+                id,
+                status: 'error',
+                error: (err as Error).message,
+            });
+        }
+    },
+});

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -176,3 +176,133 @@ export const createAndPost = internalAction({
         }
     },
 });
+
+// Feature flag mirror (KB_ESCALATION_ENABLED gates the whole loop; default off).
+const escalationEnabled = () => {
+    const f = process.env.KB_ESCALATION_ENABLED;
+    return f === '1' || f === 'true';
+};
+
+/** Pending escalations that have been posted to Discord (have a thread to poll). */
+export const listPendingWithThread = internalQuery({
+    args: {},
+    handler: async (ctx) => {
+        const rows = await ctx.db
+            .query('escalations')
+            .withIndex('by_status', (q) => q.eq('status', 'pending'))
+            .collect();
+        return rows.filter((r) => !!r.discordThreadId);
+    },
+});
+
+/** Notify the original asker (a signed-in field agent) that their question was answered. */
+export const notifyAsker = internalMutation({
+    args: { askerUserId: v.string(), question: v.string(), answer: v.string() },
+    handler: async (ctx, args): Promise<boolean> => {
+        const creator = await ctx.db
+            .query('creators')
+            .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.askerUserId))
+            .first();
+        if (!creator) return false;
+        await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+            creatorId: creator._id,
+            type: 'system',
+            title: 'Your question was answered',
+            body: `${args.question}\n\n${args.answer.slice(0, 300)}`,
+            data: { kbEscalation: true },
+        });
+        return true;
+    },
+});
+
+type DiscordMessage = {
+    id: string;
+    content: string;
+    author: { id: string; username: string; bot?: boolean };
+    timestamp: string;
+};
+
+/**
+ * Cron: poll open escalation threads for the first human reply. When one is
+ * found, capture it, turn it into a KB Q&A (saveTrainedQA → embedded article),
+ * notify the asker if signed in, and confirm in the thread. Gated by
+ * KB_ESCALATION_ENABLED.
+ */
+export const pollPending = internalAction({
+    args: {},
+    handler: async (ctx) => {
+        if (!escalationEnabled()) return;
+        const botToken = process.env.DISCORD_BOT_TOKEN;
+        if (!botToken) return;
+
+        const pending = await ctx.runQuery(internal.escalations.listPendingWithThread, {});
+        for (const esc of pending) {
+            const threadId = esc.discordThreadId!;
+            try {
+                const res = await fetch(`${DISCORD_API}/channels/${threadId}/messages?limit=50`, {
+                    headers: { Authorization: `Bot ${botToken}` },
+                });
+                if (!res.ok) {
+                    console.warn(`[KB-ESCALATION] poll thread ${threadId} failed (${res.status})`);
+                    await ctx.runMutation(internal.escalations.patchEscalation, { id: esc._id, lastPolledAt: Date.now() });
+                    continue;
+                }
+                const messages = (await res.json()) as DiscordMessage[];
+                // Discord returns newest-first; the first human reply = the oldest
+                // non-bot message that has text.
+                const firstHuman = messages
+                    .filter((m) => !m.author.bot && m.content.trim().length > 0)
+                    .sort((a, b) => a.timestamp.localeCompare(b.timestamp))[0];
+
+                if (!firstHuman) {
+                    await ctx.runMutation(internal.escalations.patchEscalation, { id: esc._id, lastPolledAt: Date.now() });
+                    continue;
+                }
+
+                const answer = firstHuman.content.trim().slice(0, 2000);
+
+                // Learn: turn the human answer into an embedded KB Q&A article.
+                const articleId = await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
+                    question: esc.question,
+                    answer,
+                    workspace: esc.workspace,
+                    grounded: true,
+                });
+
+                // Deliver back to the original asker if they were signed in.
+                let delivered = false;
+                if (esc.askerUserId) {
+                    delivered = await ctx.runMutation(internal.escalations.notifyAsker, {
+                        askerUserId: esc.askerUserId,
+                        question: esc.question,
+                        answer,
+                    });
+                }
+
+                await ctx.runMutation(internal.escalations.patchEscalation, {
+                    id: esc._id,
+                    status: delivered ? 'delivered' : 'learned',
+                    answer,
+                    answeredBy: firstHuman.author.username,
+                    answeredAt: Date.now(),
+                    learnedArticleId: articleId,
+                    lastPolledAt: Date.now(),
+                });
+
+                // Confirm in the thread (best-effort — never fails the learn).
+                await fetch(`${DISCORD_API}/channels/${threadId}/messages`, {
+                    method: 'POST',
+                    headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        content: '✅ Added to the knowledge base — the agent will use this answer next time. Thanks!',
+                        allowed_mentions: { parse: [] },
+                    }),
+                }).catch(() => {});
+
+                console.log(`[KB-ESCALATION] learned from thread ${threadId} → article ${articleId} (${delivered ? 'delivered' : 'learned'})`);
+            } catch (err) {
+                console.error(`[KB-ESCALATION] poll/learn failed for thread ${threadId}:`, (err as Error).message);
+            }
+        }
+    },
+});

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -76,6 +76,7 @@ export const patchEscalation = internalMutation({
                 v.literal('answered'),
                 v.literal('learned'),
                 v.literal('delivered'),
+                v.literal('expired'),
                 v.literal('error'),
             ),
         ),
@@ -116,6 +117,14 @@ export const createAndPost = internalAction({
             return;
         }
 
+        // Relevance gate: don't forward off-topic / junk questions ("how do I bake
+        // bread") to the team. Only genuine Tendso questions get escalated.
+        const onTopic = await ctx.runAction(internal.knowledgeAI.classifyOnTopic, { question: args.question });
+        if (!onTopic) {
+            console.log('[KB-ESCALATION] off-topic, not escalating:', normalizedQuestion.slice(0, 60));
+            return;
+        }
+
         const id = await ctx.runMutation(internal.escalations.insertEscalation, {
             question: args.question,
             normalizedQuestion,
@@ -152,7 +161,7 @@ export const createAndPost = internalAction({
             const threadRes = await fetch(`${DISCORD_API}/channels/${channelId}/messages/${msg.id}/threads`, {
                 method: 'POST',
                 headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: args.question.slice(0, 90), auto_archive_duration: 1440 }),
+                body: JSON.stringify({ name: args.question.slice(0, 90), auto_archive_duration: 4320 }),
             });
             if (!threadRes.ok) {
                 throw new Error(`create thread failed (${threadRes.status}): ${(await threadRes.text().catch(() => '')).slice(0, 200)}`);
@@ -251,9 +260,17 @@ export const pollPending = internalAction({
         const botToken = process.env.DISCORD_BOT_TOKEN;
         if (!botToken) return;
 
+        // Give up on escalations nobody answered within the window, so they stop
+        // being polled (matches the 3-day thread auto-archive).
+        const MAX_AGE_MS = 72 * 60 * 60 * 1000;
         const pending = await ctx.runQuery(internal.escalations.listPendingWithThread, {});
         for (const esc of pending) {
             const threadId = esc.discordThreadId!;
+            if (Date.now() - esc.createdAt > MAX_AGE_MS) {
+                await ctx.runMutation(internal.escalations.patchEscalation, { id: esc._id, status: 'expired' });
+                console.log(`[KB-ESCALATION] escalation ${esc._id} expired (no answer in 72h), stopping poll`);
+                continue;
+            }
             try {
                 const res = await fetch(`${DISCORD_API}/channels/${threadId}/messages?limit=50`, {
                     headers: { Authorization: `Bot ${botToken}` },

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -259,9 +259,16 @@ export const pollPending = internalAction({
                     continue;
                 }
 
-                const answer = firstHuman.content.trim().slice(0, 2000);
+                const rawAnswer = firstHuman.content.trim().slice(0, 2000);
 
-                // Learn: turn the human answer into an embedded KB Q&A article.
+                // Polish the raw chat reply into a clean, article-style KB answer
+                // (keeps all facts; falls back to the raw text if AI is unavailable).
+                const answer = await ctx.runAction(internal.knowledgeAI.rewriteAnswer, {
+                    question: esc.question,
+                    rawAnswer,
+                });
+
+                // Learn: turn the answer into an embedded KB Q&A article.
                 const articleId = await ctx.runMutation(internal.knowledgeTraining.saveTrainedQA, {
                     question: esc.question,
                     answer,
@@ -294,7 +301,7 @@ export const pollPending = internalAction({
                     method: 'POST',
                     headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        content: '✅ Added to the knowledge base — the agent will use this answer next time. Thanks!',
+                        content: `✅ Added to the knowledge base — the agent will use this next time:\n\n>>> ${answer.slice(0, 1500)}`,
                         allowed_mentions: { parse: [] },
                     }),
                 }).catch(() => {});

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -195,6 +195,22 @@ export const listPendingWithThread = internalQuery({
     },
 });
 
+/**
+ * Atomically claim a pending escalation for processing (pending → answered).
+ * Convex mutations are serializable, so of two overlapping poll runs (the cron
+ * plus any manual run) only ONE wins the claim — the other gets false and skips.
+ * This is what prevents duplicate articles / duplicate thread confirmations.
+ */
+export const claimForProcessing = internalMutation({
+    args: { id: v.id('escalations') },
+    handler: async (ctx, args): Promise<boolean> => {
+        const esc = await ctx.db.get(args.id);
+        if (!esc || esc.status !== 'pending') return false;
+        await ctx.db.patch(args.id, { status: 'answered', updatedAt: Date.now() });
+        return true;
+    },
+});
+
 /** Notify the original asker (a signed-in field agent) that their question was answered. */
 export const notifyAsker = internalMutation({
     args: { askerUserId: v.string(), question: v.string(), answer: v.string() },
@@ -258,6 +274,11 @@ export const pollPending = internalAction({
                     await ctx.runMutation(internal.escalations.patchEscalation, { id: esc._id, lastPolledAt: Date.now() });
                     continue;
                 }
+
+                // Atomically claim so overlapping poll runs (cron + manual) never
+                // double-process this escalation and create duplicate articles.
+                const claimed = await ctx.runMutation(internal.escalations.claimForProcessing, { id: esc._id });
+                if (!claimed) continue;
 
                 const rawAnswer = firstHuman.content.trim().slice(0, 2000);
 

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -276,6 +276,15 @@ export const pollPending = internalAction({
                     grounded: true,
                 });
 
+                // Link to the new article for the thread confirmation (same deep-link
+                // format the Discord /ask bot uses). Skipped if SITE_URL isn't set.
+                const [savedArticle] = await ctx.runQuery(internal.knowledge.getArticlesByIds, { ids: [articleId] });
+                const siteUrl = (process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/$/, '');
+                const articleLink =
+                    savedArticle && siteUrl
+                        ? `${siteUrl}/knowledge?ws=${esc.workspace}&article=${encodeURIComponent(savedArticle.slug)}`
+                        : null;
+
                 // Deliver back to the original asker if they were signed in.
                 let delivered = false;
                 if (esc.askerUserId) {
@@ -301,7 +310,9 @@ export const pollPending = internalAction({
                     method: 'POST',
                     headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        content: `✅ Added to the knowledge base — the agent will use this next time:\n\n>>> ${answer.slice(0, 1500)}`,
+                        content:
+                            `✅ Added to the knowledge base — the agent will use this next time:\n\n>>> ${answer.slice(0, 1500)}` +
+                            (articleLink ? `\n\n🔗 ${articleLink}` : ''),
                         allowed_mentions: { parse: [] },
                     }),
                 }).catch(() => {});

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -668,6 +668,39 @@ export const answerQuery = internalAction({
     },
 });
 
+// ==================== INTERNAL: rewrite a human answer into a KB entry ====================
+// Used by the Discord escalation loop (convex/escalations.ts): when a team member
+// answers in a thread, polish their raw reply into a clean, self-contained
+// knowledge-base answer before it's saved as a Q&A. Falls back to the raw answer
+// if generation is unavailable, so the human answer is never lost.
+const REWRITE_SYSTEM = `You are an editor for the Tendso knowledge base. A team member has answered a field agent's question in a chat thread. Rewrite their raw answer into a clear, self-contained knowledge-base answer.
+- Keep ALL facts from the raw answer. Do NOT add anything that isn't in it, and never invent prices, policies, timelines, or features.
+- Write a direct answer to the question: 2-5 sentences, or a short list. Lead with the answer.
+- Calm, clear, human voice. No hype, no emoji. Do not refer to "the team member" or "the chat".
+- If the raw answer is already clean, just lightly polish it. Output only the answer text.`;
+
+export const rewriteAnswer = internalAction({
+    args: { question: v.string(), rawAnswer: v.string() },
+    handler: async (ctx, args): Promise<string> => {
+        const contents: GeminiTurn[] = [
+            {
+                role: 'user',
+                parts: [
+                    {
+                        text: `QUESTION: ${args.question}\n\nRAW ANSWER FROM TEAM MEMBER:\n${args.rawAnswer}\n\nRewrite the raw answer into a clear knowledge-base answer to the question.`,
+                    },
+                ],
+            },
+        ];
+        try {
+            return await generateWithFallback(ctx, REWRITE_SYSTEM, contents);
+        } catch (err) {
+            console.warn('[KB-AI] answer rewrite failed, keeping raw answer:', (err as Error).message);
+            return args.rawAnswer; // never lose the human answer
+        }
+    },
+});
+
 // ==================== EMBEDDINGS (ops: run from CLI/dashboard) ====================
 export const generateEmbeddingForArticle = internalAction({
     args: { articleId: v.id('knowledgeArticles') },

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -701,6 +701,30 @@ export const rewriteAnswer = internalAction({
     },
 });
 
+// ==================== INTERNAL: is a question on-topic for Tendso? ====================
+// Used by the escalation loop (convex/escalations.ts) to avoid forwarding
+// off-topic / junk questions ("how do I bake bread") to the team's Discord.
+const RELEVANCE_SYSTEM = `You are a filter that decides whether a question should be forwarded to the Tendso team. Tendso builds a website for a Filipino local business (MSME) from one creator's 30-minute visit — topics include pricing/payments, custom domains, turnaround, the website itself, and the creator / field-agent program (training, interviews, photos, submissions, payouts, referrals).
+Reply with exactly one word:
+- YES if the question is about Tendso's product, service, process, or business and a team member could reasonably answer it (even a detail not yet documented).
+- NO if it is off-topic, spam, nonsense, a test, or unrelated to Tendso.`;
+
+export const classifyOnTopic = internalAction({
+    args: { question: v.string() },
+    handler: async (ctx, args): Promise<boolean> => {
+        try {
+            const contents: GeminiTurn[] = [{ role: 'user', parts: [{ text: `Question: ${args.question}` }] }];
+            const out = await generateWithFallback(ctx, RELEVANCE_SYSTEM, contents);
+            return /^\s*yes\b/i.test(out.trim());
+        } catch (err) {
+            // Classifier unavailable → fail OPEN (escalate) so a real question is
+            // never silently dropped; an occasional off-topic post is the lesser evil.
+            console.warn('[KB-AI] relevance classify failed, defaulting to escalate:', (err as Error).message);
+            return true;
+        }
+    },
+});
+
 // ==================== EMBEDDINGS (ops: run from CLI/dashboard) ====================
 export const generateEmbeddingForArticle = internalAction({
     args: { articleId: v.id('knowledgeArticles') },

--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -54,6 +54,11 @@ function genModelChain(): string[] {
 }
 const EMBED_DIMS = 768;
 
+// Minimum cosine similarity for a vector-fallback hit to count as a GENUINE match
+// (vs a low-relevance nearest-neighbour). Below this, retrieval reports
+// matched=false so the question can escalate. Tunable via KB_VECTOR_MATCH_THRESHOLD.
+const vectorMatchThreshold = () => Number(process.env.KB_VECTOR_MATCH_THRESHOLD) || 0.6;
+
 // ---- Convex AI Agent (@convex-dev/agent) ----
 // When KB_USE_AGENT is on, answer generation routes through the Convex agent
 // component instead of the raw Gemini REST call. The component runs on the
@@ -385,7 +390,7 @@ export function keywordScore(a: Article, terms: string[]): number {
 // Per the Knowledge Hub spec, always try traditional keyword search first and
 // only reach for embeddings when keyword finds nothing. At the current KB size
 // this keeps the common path at zero inference cost (no query embedding).
-async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, topK = 5): Promise<Article[]> {
+async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, topK = 5): Promise<{ sources: Article[]; matched: boolean }> {
     // Small corpus: load the whole published set once, score in memory.
     const all: Article[] = await ctx.runQuery(internal.knowledge.listPublishedInternal, { workspace });
 
@@ -394,11 +399,14 @@ async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, top
     if (terms.length) {
         const scored = all
             .map((a) => ({ a, score: keywordScore(a, terms) }))
-            .filter((r) => r.score > 0)
+            // Require a GENUINE term match — strip the popularity nudge so a merely
+            // `popular` article can't phantom-match a query it shares no words with
+            // (that would mask true misses and starve the vector fallback + escalation).
+            .filter((r) => r.score - (r.a.popular ? KEYWORD_POPULAR_BONUS : 0) > 0)
             .sort((x, y) => y.score - x.score)
             .slice(0, topK)
             .map((r) => r.a);
-        if (scored.length) return scored;
+        if (scored.length) return { sources: scored, matched: true };
     }
 
     // 2) Vector/similarity fallback — only when keyword found nothing.
@@ -410,21 +418,29 @@ async function retrieve(ctx: ActionCtx, query: string, workspace: Workspace, top
             filter: (q) => q.eq('workspace', workspace),
         });
         if (hits.length) {
-            // Resolve against the already-loaded published set. Because `all` is
-            // published-only, this also drops any draft the vector index surfaced
-            // (status is not a vector filter field), and saves a second DB read.
+            // Resolve against the already-loaded published set (drops any draft the
+            // vector index surfaced — status is not a vector filter field — and
+            // saves a second DB read). Keep each hit's cosine score.
             const byId = new Map(all.map((d) => [d._id, d]));
-            const ordered = hits
-                .map((h) => byId.get(h._id as Id<'knowledgeArticles'>))
-                .filter((d): d is Article => !!d);
-            if (ordered.length) return ordered.slice(0, topK);
+            const scored = hits
+                .map((h) => ({ doc: byId.get(h._id as Id<'knowledgeArticles'>), score: h._score }))
+                .filter((r): r is { doc: Article; score: number } => !!r.doc);
+            if (scored.length) {
+                // A vector hit only counts as a GENUINE match if the top similarity
+                // clears the threshold; a low-score nearest-neighbour is not a real
+                // answer (→ matched=false → escalate), but we still return it so the
+                // model can answer if it actually can.
+                const matched = scored[0].score >= vectorMatchThreshold();
+                return { sources: scored.slice(0, topK).map((r) => r.doc), matched };
+            }
         }
     } catch (err) {
         console.warn('[KB-AI] vector fallback unavailable:', (err as Error).message);
     }
 
-    // 3) Last resort: popular articles.
-    return all.filter((a) => a.popular).slice(0, topK);
+    // 3) Last resort: popular articles. matched=false = a genuine content gap
+    // (no keyword/vector hit) — this is the escalation trigger (see convex/escalations.ts).
+    return { sources: all.filter((a) => a.popular).slice(0, topK), matched: false };
 }
 
 // ---- conversation memory (multi-turn follow-ups) ----
@@ -511,10 +527,10 @@ async function runRag(
         discordUserId?: string;
         history?: ChatTurn[];
     },
-): Promise<{ answer: string; sources: { slug: string; title: string }[]; grounded: boolean }> {
+): Promise<{ answer: string; sources: { slug: string; title: string }[]; grounded: boolean; matched: boolean }> {
     const query = args.query.trim().slice(0, 500);
     const history = normalizeHistory(args.history);
-    const sources = await retrieve(ctx, buildRetrievalQuery(query, history), args.workspace);
+    const { sources, matched } = await retrieve(ctx, buildRetrievalQuery(query, history), args.workspace);
 
     let answer: string;
     let grounded = true;
@@ -550,8 +566,16 @@ async function runRag(
         grounded,
     });
 
-    return { answer, sources: sources.map((s) => ({ slug: s.slug, title: s.title })), grounded };
+    return { answer, sources: sources.map((s) => ({ slug: s.slug, title: s.title })), grounded, matched };
 }
+
+// Escalation to Discord when the KB can't answer the question (matched=false).
+// See convex/escalations.ts. Default OFF — flip KB_ESCALATION_ENABLED on the
+// deployment to enable.
+const KB_ESCALATION_ENABLED = () => {
+    const flag = process.env.KB_ESCALATION_ENABLED;
+    return flag === '1' || flag === 'true';
+};
 
 // ==================== PUBLIC: web search box + landing ChatBot ====================
 export const ask = action({
@@ -591,16 +615,38 @@ export const ask = action({
                 answer: "You're asking a lot of questions very quickly — give it a moment and try again.",
                 sources: [],
                 grounded: false,
+                escalated: false,
             };
         }
 
-        return await runRag(ctx, {
+        const result = await runRag(ctx, {
             query: args.query,
             workspace: args.workspace,
             source,
             userId,
             history: args.history,
         });
+
+        // When the KB has no genuine match (retrieval fell through to popular
+        // articles), escalate the question to the team via Discord and tell the
+        // asker we'll follow up. Fire-and-forget so it never blocks the answer.
+        // Gated by KB_ESCALATION_ENABLED (default off).
+        let escalated = false;
+        if (KB_ESCALATION_ENABLED() && !result.matched) {
+            escalated = true;
+            await ctx.scheduler.runAfter(0, internal.escalations.createAndPost, {
+                question: args.query.trim().slice(0, 500),
+                workspace: args.workspace,
+                askerUserId: userId,
+            });
+        }
+
+        return {
+            answer: result.answer,
+            sources: result.sources,
+            grounded: result.grounded,
+            escalated,
+        };
     },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1042,6 +1042,7 @@ export default defineSchema({
             v.literal('answered'), // a team member replied; captured
             v.literal('learned'), // turned into a KB Q&A article
             v.literal('delivered'), // asker notified (or n/a for anonymous)
+            v.literal('expired'), // no answer within the window — stop polling
             v.literal('error'),
         ),
         // Discord references (set once posted).

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1024,4 +1024,42 @@ export default defineSchema({
         .index('by_status', ['status'])
         .index('by_batch', ['batchId'])
         .index('by_createdAt', ['createdAt']),
+
+    // ==================== ESCALATIONS (Discord human-in-the-loop) ====================
+    // When the KB agent can't answer a web/chat question (retrieval found no genuine
+    // match), it is escalated to a role-scoped Discord channel: the bot posts the
+    // question and opens a thread; a team member replies in that thread; a cron polls
+    // the thread, turns the reply into a KB Q&A (knowledgeTraining.saveTrainedQA), and
+    // notifies the original asker if they were signed in. Discord is ONLY the team's
+    // answer surface — the asker is a web/mobile user, delivered back via notifications.
+    escalations: defineTable({
+        question: v.string(),
+        normalizedQuestion: v.string(), // lowercased/trimmed dedup key
+        workspace: v.union(v.literal('help'), v.literal('wiki')),
+        askerUserId: v.optional(v.string()), // Clerk subject for deliver-back; absent = anonymous
+        status: v.union(
+            v.literal('pending'), // posted to Discord, awaiting a human reply
+            v.literal('answered'), // a team member replied; captured
+            v.literal('learned'), // turned into a KB Q&A article
+            v.literal('delivered'), // asker notified (or n/a for anonymous)
+            v.literal('error'),
+        ),
+        // Discord references (set once posted).
+        discordChannelId: v.optional(v.string()),
+        discordMessageId: v.optional(v.string()),
+        discordThreadId: v.optional(v.string()),
+        // The captured human answer.
+        answer: v.optional(v.string()),
+        answeredBy: v.optional(v.string()), // Discord user id/name of the replier
+        answeredAt: v.optional(v.number()),
+        learnedArticleId: v.optional(v.id('knowledgeArticles')),
+        error: v.optional(v.string()),
+        lastPolledAt: v.optional(v.number()),
+        createdAt: v.number(),
+        updatedAt: v.number(),
+    })
+        .index('by_status', ['status'])
+        .index('by_thread', ['discordThreadId'])
+        .index('by_normalized', ['normalizedQuestion', 'status'])
+        .index('by_createdAt', ['createdAt']),
 });


### PR DESCRIPTION
Knowledge Hub escalation loop (ClickUp 86car4m4y, item 4). Verified **live end-to-end** on a dev deployment against a real Discord channel.

## Flow
A web/chat question the KB can't answer → bot posts it to a role-scoped Discord channel + opens a thread → a team member replies casually → the reply is **AI-polished into a clean KB answer**, embedded into the KB, and **linked back in the thread** → the same question is now answered automatically, and the original asker is notified (if signed in).

## What's in it
- **`escalations` table** (additive) — state machine `pending → answered → learned → delivered` (+ `error`), dedup + Discord refs.
- **Trigger** — `retrieve()` now reports `matched` (genuine keyword hit, or vector hit ≥ `KB_VECTOR_MATCH_THRESHOLD`, default 0.6). `ask` escalates on `matched=false`, behind **`KB_ESCALATION_ENABLED` (default off)**, and returns an `escalated` flag.
- **`convex/escalations.ts`** — post + open thread (bot token), a 2-min poll cron that captures the first human reply, an **atomic claim** so overlapping runs can't double-process, learn via `saveTrainedQA`, notify via `notifications.createAndSend`, and confirm in-thread with a deep link to the new article.
- **`knowledgeAI.rewriteAnswer`** — LLM editor pass (reuses the BYOK pool) that turns a raw chat reply into a clean article answer; falls back to raw text if AI is unavailable.

## ⚠️ One behavior change that is NOT flag-gated
The **phantom-match fix** in `retrieve()`: the keyword path now requires a *genuine* term match, so a `popular` article no longer matches every query. This had been silently starving the internal RAG's vector fallback. It's a retrieval-quality fix, but it **changes prod KB answers as soon as this deploys** (independent of the escalation flag). Everything escalation-specific stays dormant until `KB_ESCALATION_ENABLED=1`.

## Deploy (manual — merging does NOT deploy the backend)
1. `CONVEX_DEPLOY_KEY=… npx convex deploy --dry-run` — expect: `escalations` table + `poll-kb-escalations` cron added, no deletions, schema validates.
2. `CONVEX_DEPLOY_KEY=… npx convex deploy`
3. Enable on prod: `npx convex env set DISCORD_ESCALATION_CHANNEL_ID <channel-id>` and `npx convex env set KB_ESCALATION_ENABLED 1` (bot token already on prod).

## New env
- `DISCORD_ESCALATION_CHANNEL_ID` — the role-scoped channel (required to post).
- `KB_ESCALATION_ENABLED` — master switch (default off).
- `KB_VECTOR_MATCH_THRESHOLD` — optional, default 0.6.

## Not included (small follow-up)
Client UX in `ChatBot.tsx` to surface *"I've asked the team, we'll follow up"* on the `escalated` flag. Backend already returns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)