### PR TITLE
feat(kb): re-ping stale escalations + lock resolved threads

### DIFF
--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -23,6 +23,9 @@ import type { Id } from './_generated/dataModel';
  */
 
 const DISCORD_API = 'https://discord.com/api/v10';
+// How often to re-ping the team role about an escalation nobody has answered.
+// Tunable via KB_ESCALATION_REPING_HOURS (default 8; fractional values allowed).
+const repingEveryMs = () => Number(process.env.KB_ESCALATION_REPING_HOURS || 8) * 60 * 60 * 1000;
 const workspaceArg = v.union(v.literal('help'), v.literal('wiki'));
 
 function normalizeQuestion(q: string): string {
@@ -89,6 +92,7 @@ export const patchEscalation = internalMutation({
         learnedArticleId: v.optional(v.id('knowledgeArticles')),
         error: v.optional(v.string()),
         lastPolledAt: v.optional(v.number()),
+        lastPingedAt: v.optional(v.number()),
     },
     handler: async (ctx, args) => {
         const { id, ...rest } = args;
@@ -288,7 +292,28 @@ export const pollPending = internalAction({
                     .sort((a, b) => a.timestamp.localeCompare(b.timestamp))[0];
 
                 if (!firstHuman) {
-                    await ctx.runMutation(internal.escalations.patchEscalation, { id: esc._id, lastPolledAt: Date.now() });
+                    // Still unanswered — nudge the team role every REPING_EVERY_MS
+                    // (first nudge measured from when the escalation was created).
+                    const roleId = process.env.DISCORD_ESCALATION_ROLE_ID;
+                    const lastNudge = esc.lastPingedAt ?? esc.createdAt;
+                    const due = !!roleId && Date.now() - lastNudge >= repingEveryMs();
+                    if (due) {
+                        const hoursOpen = Math.round((Date.now() - esc.createdAt) / 3_600_000);
+                        await fetch(`${DISCORD_API}/channels/${threadId}/messages`, {
+                            method: 'POST',
+                            headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                content: `⏰ <@&${roleId}> still no answer on this one (${hoursOpen}h open). Reply in this thread and I'll add it to the knowledge base.`,
+                                allowed_mentions: { roles: [roleId] },
+                            }),
+                        }).catch(() => {});
+                        console.log(`[KB-ESCALATION] re-pinged role on thread ${threadId} (${hoursOpen}h open)`);
+                    }
+                    await ctx.runMutation(internal.escalations.patchEscalation, {
+                        id: esc._id,
+                        lastPolledAt: Date.now(),
+                        lastPingedAt: due ? Date.now() : undefined,
+                    });
                     continue;
                 }
 
@@ -354,6 +379,17 @@ export const pollPending = internalAction({
                         allowed_mentions: { parse: [] },
                     }),
                 }).catch(() => {});
+
+                // Resolved: lock + archive the thread so the captured answer stands
+                // and no further replies pile up. Best-effort — needs MANAGE_THREADS.
+                const lockRes = await fetch(`${DISCORD_API}/channels/${threadId}`, {
+                    method: 'PATCH',
+                    headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ locked: true, archived: true }),
+                }).catch(() => null);
+                if (!lockRes || !lockRes.ok) {
+                    console.warn(`[KB-ESCALATION] could not lock thread ${threadId} (needs MANAGE_THREADS)`);
+                }
 
                 console.log(`[KB-ESCALATION] learned from thread ${threadId} → article ${articleId} (${delivered ? 'delivered' : 'learned'})`);
             } catch (err) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1056,6 +1056,7 @@ export default defineSchema({
         learnedArticleId: v.optional(v.id('knowledgeArticles')),
         error: v.optional(v.string()),
         lastPolledAt: v.optional(v.number()),
+        lastPingedAt: v.optional(v.number()), // last reminder ping to the team role
         createdAt: v.number(),
         updatedAt: v.number(),
     })


### PR DESCRIPTION
Two escalation-loop improvements requested by Paul.

## 1. Re-ping the team on stale escalations
When an escalation still has no answer, the bot nudges the team role **in its thread** every `KB_ESCALATION_REPING_HOURS` (default **8**).

- Tracked with a new `lastPingedAt` field, so it nudges **once per interval** — not on every 2-minute poll.
- Role comes from **`DISCORD_ESCALATION_ROLE_ID`**; if unset, re-pinging is skipped entirely (no behavior change).
- Message includes how long it's been open, and pings via `allowed_mentions.roles`.
- Plays nicely with the existing 72h expiry → nudges at ~8h, 16h, 24h… then the escalation expires and polling stops.

**Verified on dev:** a genuinely stale escalation (65h open, never answered) was re-pinged exactly once.

## 2. Lock the thread once answered
After the answer is captured, learned, and confirmed in-thread, the bot **locks + archives** the thread so no further replies pile up on a resolved question.

- Best-effort: needs **MANAGE_THREADS**. If the bot lacks it, the lock is skipped and a warning is logged — the learn still succeeds.

## New env
| Var | Purpose |
|---|---|
| `DISCORD_ESCALATION_ROLE_ID` | Role to nudge about unanswered escalations (required for re-ping) |
| `KB_ESCALATION_REPING_HOURS` | Optional, default `8`; fractional values allowed |

## Prod prerequisites
1. Set `DISCORD_ESCALATION_ROLE_ID` on prod, or re-pinging stays off.
2. Grant the Tendso bot **MANAGE_THREADS** in the escalation channel, or thread-locking silently no-ops.
3. Backend-only — needs a manual `npx convex deploy`.

## Not included
Editing an existing KB article from the bot. Confirmed during this work that there is currently **no article-edit UI** (the admin page is the Train AI page: train / delete / purge / re-embed). `upsertArticle` exists in the backend but has no caller. Tracked as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
