### PR TITLE
fix(auth): allowlist internal API routes in the proxy middleware (fixes 405 email failures)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -26,6 +26,15 @@ const isPublicRoute = createRouteMatcher([
     // The route handler enforces either a valid Clerk session OR a matching
     // X-Internal-Secret itself, so bypassing middleware is safe.
     '/api/transcribe',
+    // Same pattern: called server-to-server from Convex crons/actions with the
+    // X-Internal-Secret header. Without these entries clerkMiddleware redirects
+    // the POST to /login (307), it lands on the GET-only login page as a 405,
+    // and the email silently never sends. Each handler verifies the secret
+    // itself — the two /api/internal routes require it outright, the other two
+    // accept "valid admin Clerk session OR secret" — so bypassing here is safe.
+    '/api/internal(.*)', // send-withdrawal-status-email, send-domain-live-email
+    '/api/send-payment-followup-email',
+    '/api/send-completed-website-email',
 ]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
Fixes the `405` we traced from the Convex logs — and the same silent failure in two other email flows.

## The bug
Convex crons/actions call several Next API routes **server-to-server** with an `X-Internal-Secret` header (no Clerk cookie). Only `/api/transcribe` was in `proxy.ts`'s `isPublicRoute` allowlist, so the rest were caught by `clerkMiddleware` and **redirected to `/login` (307)**. The POST then landed on the GET-only login page as a **405**, and the email silently never sent.

Reproduced against production:
```
POST https://www.tendso.com/api/internal/send-withdrawal-status-email
  -> 307  https://www.tendso.com/login?redirect_url=%2Fapi%2Finternal%2F...
```
This is the source of `[WITHDRAWAL-FOLLOWUP] Email send failed: 405` in the Convex logs.

## The fix
Add the remaining internal routes to the allowlist:

| Route | Caller | Auth it enforces |
|---|---|---|
| `/api/internal(.*)` | `withdrawals.sendStatusEmailAction`, `domains.sendDomainLiveEmailAction` | Requires `X-Internal-Secret` (401 otherwise) |
| `/api/send-payment-followup-email` | `followUp.checkAndSendFollowUps` | Admin Clerk session **or** secret |
| `/api/send-completed-website-email` | Convex action | Admin Clerk session **or** secret |

## Why bypassing middleware is safe
Every one of these handlers verifies its own auth — I checked each before allowlisting. The two `/api/internal` routes reject outright without a matching secret; the other two accept "valid admin session **or** secret." That's exactly the rationale already documented on the existing `/api/transcribe` entry, which this follows.

Allowlisting only skips the middleware *redirect* — `auth()` still works inside the handlers, so the admin-session path is unaffected.

## Impact
Unbreaks three production email flows: **withdrawal status follow-ups**, **payment follow-ups**, and **domain-live notifications**.

## Note
Frontend-only change (`proxy.ts`), so it ships with the normal Vercel deploy on merge — no `convex deploy` needed.

Related, separate (env, not code): prod `SITE_URL` is still `https://negosyo-digital.com/` and should be `https://www.tendso.com` — that's what makes the bot's article links point at the old domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
