### PR TITLE
feat(landing): polish the sticky CTA, rebuild the Process section, drop decorative section markers

### DIFF
--- a/app/connect-ai/page.tsx
+++ b/app/connect-ai/page.tsx
@@ -62,7 +62,7 @@ export default function ConnectAiPage() {
                             </svg>
                             Field agents
                         </Link>
-                        <div className="eyebrow">§ Tendso AI — bring your own key</div>
+                        <div className="eyebrow">Tendso AI — bring your own key</div>
                         <h1 className="display-2">
                             Power <em>Tendso AI</em> with a free key.
                         </h1>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -37,7 +37,7 @@ export default function ContactPage() {
                         </Link>
 
                         <div className="sect-h">
-                            <div className="eyebrow">§ Contact</div>
+                            <div className="eyebrow">Contact</div>
                             <div>
                                 <h1 className="display">
                                     Let&apos;s <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>talk</em>.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -429,7 +429,7 @@ export default function DashboardPage() {
                 <div>
                     <div className="flex items-center justify-between mb-3">
                         <div>
-                            <p className="ed-label">§ Recent activity</p>
+                            <p className="ed-label">Recent activity</p>
                             <h2
                                 className="mt-1"
                                 style={{

--- a/app/for-creators/page.tsx
+++ b/app/for-creators/page.tsx
@@ -147,7 +147,7 @@ function HowToApplySection() {
         <section style={{ background: "var(--neo-paper-2)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ How to apply</div>
+                    <div className="eyebrow">How to apply</div>
                     <div>
                         <h2 className="display-2">
                             From this page <em>to your first payout</em>.

--- a/app/for-field-agents/page.tsx
+++ b/app/for-field-agents/page.tsx
@@ -232,7 +232,7 @@ function TrustSection() {
         <section style={{ background: "var(--neo-paper-2)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ Is this legit?</div>
+                    <div className="eyebrow">Is this legit?</div>
                     <div>
                         <h2 className="display-2">
                             A real job, <em>not a scam</em>.
@@ -267,7 +267,7 @@ function FieldStepsSection() {
         <section>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ How it works</div>
+                    <div className="eyebrow">How it works</div>
                     <div>
                         <h2 className="display-2">
                             From the street <em>to your wallet</em>.

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -185,7 +185,7 @@ export default function ForgotPasswordPage() {
                         className="text-[10px] uppercase tracking-[0.4em] font-medium text-[var(--rust)]"
                         style={{ fontFamily: "var(--font-mono)" }}
                     >
-                        § ACCESS — RECOVERY
+                        ACCESS — RECOVERY
                     </p>
                     <span className="h-px w-10 bg-[var(--rust)]/40" />
                 </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -571,17 +571,207 @@ body {
 .neo .pill[aria-pressed="true"]:hover { color: var(--neo-paper); }
 
 /* Sticky bottom CTA */
+/* Sticky door CTA — a compact centred pill, not a full-bleed bar.
+   Colour identifies each door with a dot rather than filling the button, so the
+   two choices sit at equal weight without competing with the page behind them. */
 .neo .sticky-cta {
-  position: fixed; left: 16px; right: 16px; bottom: 16px; z-index: 1200;
-  transform: translateY(calc(100% + 32px));
-  transition: transform .35s cubic-bezier(.2,.8,.2,1);
+  position: fixed; left: 50%; bottom: 20px; z-index: 1200;
+  transform: translate(-50%, calc(100% + 32px));
+  opacity: 0;
+  pointer-events: none;
+  transition: transform .38s cubic-bezier(.2,.8,.2,1), opacity .28s ease;
+}
+.neo .sticky-cta.visible { transform: translate(-50%, 0); opacity: 1; pointer-events: auto; }
+
+.neo .sticky-cta-pill {
+  display: flex; align-items: stretch;
+  padding: 4px;
+  background: oklch(from var(--neo-paper-3) l c h / .92);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--neo-rule);
+  border-radius: 999px;
+  box-shadow: var(--neo-shadow-2);
+}
+
+/* Brand mark anchors the left of the pill. Sized down to sit with the 13.5px
+   labels rather than dominate them. */
+.neo .sticky-cta-brand {
+  display: inline-flex; align-items: center; flex: none;
+  padding: 0 13px 0 15px;
+}
+.neo .sticky-cta-brand img { width: 74px; height: auto; }
+/* Logo sets an inline filter tuned for light paper; flip it back on the dark
+   "ink" theme so the mark stays legible. Inline styles need !important. */
+.neo[data-theme="ink"] .sticky-cta-brand img { filter: none !important; }
+
+.neo .sticky-cta-seg {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  font-family: var(--neo-sans);
+  font-size: 13.5px; font-weight: 500; letter-spacing: -0.01em; line-height: 1;
+  color: var(--neo-ink);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background .18s ease, color .18s ease;
+}
+.neo .sticky-cta-div { width: 1px; flex: none; margin: 8px 2px; background: var(--neo-rule); }
+
+.neo .sticky-cta-dot {
+  width: 7px; height: 7px; border-radius: 50%; flex: none;
+  transition: transform .18s ease;
+}
+.neo .sticky-cta-seg.is-business .sticky-cta-dot { background: var(--neo-business); }
+.neo .sticky-cta-seg.is-creator  .sticky-cta-dot { background: var(--neo-creator); }
+.neo .sticky-cta-seg:hover .sticky-cta-dot { transform: scale(1.3); }
+
+.neo .sticky-cta-arrow {
+  width: 14px; height: 14px; flex: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  opacity: 0; transform: translate(-4px, 4px);
+  transition: opacity .18s ease, transform .18s ease;
+}
+.neo .sticky-cta-seg:hover .sticky-cta-arrow,
+.neo .sticky-cta-seg:focus-visible .sticky-cta-arrow { opacity: .55; transform: translate(0, 0); }
+
+.neo .sticky-cta-seg.is-business:hover,
+.neo .sticky-cta-seg.is-business.is-current { background: var(--neo-business-bg); color: var(--neo-business-ink); }
+.neo .sticky-cta-seg.is-creator:hover,
+.neo .sticky-cta-seg.is-creator.is-current  { background: var(--neo-creator-bg);  color: var(--neo-creator-ink); }
+
+.neo .sticky-cta-seg:focus-visible { outline: 2px solid var(--neo-ink); outline-offset: 2px; }
+
+/* Long label by default, short label on narrow phones. */
+.neo .sticky-cta-short { display: none; }
+
+@media (max-width: 440px) {
+  .neo .sticky-cta { left: 12px; right: 12px; transform: translateY(calc(100% + 32px)); }
+  .neo .sticky-cta.visible { transform: translateY(0); }
+  .neo .sticky-cta-seg { flex: 1; justify-content: center; padding: 10px 12px; }
+  .neo .sticky-cta-full { display: none; }
+  .neo .sticky-cta-short { display: inline; }
+  /* Give the two labels the full width on phones — the topbar still shows the mark. */
+  .neo .sticky-cta-brand,
+  .neo .sticky-cta-brand + .sticky-cta-div { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neo .sticky-cta { transition: opacity .2s ease; }
+  .neo .sticky-cta-dot, .neo .sticky-cta-arrow, .neo .sticky-cta-seg { transition: none; }
+}
+
+/* ── Process pipeline ──────────────────────────────────────────────
+   Four ordered steps. The <ol> and the bare mono ordinals carry the sequence —
+   the same way HowItWorks' Track does directly above this section. An earlier
+   pass drew a hairline connector rail between numbered pill badges; it was cut
+   because it invented a vocabulary the house doesn't have, and it had to be
+   switched off entirely below 600px, which proved it wasn't load-bearing.
+   The last step inverts to ink: it's the terminus, not a recommended option. */
+.neo .process-track {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  /* Duplicates Tailwind preflight deliberately: without it, a preflight config
+     change would restore UA list padding and break this grid. Not redundant. */
+  list-style: none; padding: 0; margin: 0;
+}
+.neo .process-step { display: flex; flex-direction: column; }
+
+/* The ordinal carries the sequence on its own, at display scale. A 12px mono
+   ordinal works in HowItWorks because that list is stacked VERTICALLY inside one
+   card — reading order is free. This grid is horizontal and its cards are
+   detached, so the numerals have to do the work typographically or the section
+   reads as four unrelated boxes. Set in the display serif at --neo-ink-3 so it
+   is large but quiet, and never competes with the 22px heading below it. */
+.neo .process-node {
+  font-family: var(--neo-serif); font-size: 44px; line-height: 1;
+  letter-spacing: -.02em; font-variant-numeric: tabular-nums;
+  color: var(--neo-ink-3);
+}
+.neo .process-step.is-final .process-node { color: var(--neo-creator); }
+
+/* Ordinal left, the owner's time cost right, sharing a baseline. Because the
+   four cards are side by side, the costs land on one horizontal line and can be
+   compared at a glance — which is the whole argument this section is making. */
+.neo .process-node-row {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
+}
+/* Icon + ordinal read as one lockup, so the card has a single anchor rather
+   than two competing ones. The icon is optically centred on the numeral's body
+   rather than sat on its baseline. */
+.neo .process-mark { display: flex; align-items: center; gap: 11px; }
+.neo .process-icon {
+  width: 26px; height: 26px; flex: none;
+  color: var(--neo-ink-3);
+}
+.neo .process-icon svg { width: 100%; height: 100%; display: block; }
+.neo .process-step.is-final .process-icon { color: var(--neo-creator); }
+.neo .process-cost {
+  font-family: var(--neo-mono); font-size: 12px; letter-spacing: .02em;
+  font-variant-numeric: tabular-nums; text-align: right;
+  color: var(--neo-ink);
+}
+/* The final card inverts, so this has to flip with it (see .process-sub below). */
+.neo .process-step.is-final .process-cost { color: var(--neo-paper-2); }
+
+/* The ordinal sits inside the card as its opening element, so it reads as that
+   step's chapter number rather than as a label floating above a box. */
+.neo .process-card {
+  flex: 1;
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 20px 22px 22px;
   background: var(--neo-paper-3);
   border: 1px solid var(--neo-rule);
-  border-radius: var(--neo-r-xl);
-  box-shadow: 0 12px 40px -12px oklch(0% 0 0 / .25);
-  overflow: hidden;
+  border-radius: var(--neo-r-lg);
 }
-.neo .sticky-cta.visible { transform: translateY(0); }
+.neo .process-node + .process-h { margin-top: 2px; }
+.neo .process-step.is-final .process-card {
+  background: var(--neo-ink); border-color: var(--neo-ink); color: var(--neo-paper);
+}
+.neo .process-h {
+  font-family: var(--neo-serif); font-size: 22px;
+  line-height: 1.15; letter-spacing: -.015em;
+}
+/* 14/1.55 matches ManifestoSection's Beat sub — the closest structural twin. */
+.neo .process-sub {
+  font-size: 14px; line-height: 1.55; color: var(--neo-ink-2);
+  text-wrap: pretty;
+}
+/* --neo-ink flips 15%→97% under [data-theme="ink"], so this card inverts to a
+   light slab in dark. --neo-paper-2 flips with it (~12.6:1 either way); a
+   hardcoded literal here was invisible in dark and is why this rule exists. */
+.neo .process-step.is-final .process-sub { color: var(--neo-paper-2); }
+
+/* What an Online Kit includes + the turnaround. Subordinate to the four steps,
+   so it takes a border-top and no fill — the house pattern for a footnote
+   block. A filled card here read as a fifth step. */
+.neo .process-kit {
+  margin-top: 32px; padding-top: 20px;
+  border-top: 1px solid var(--neo-rule);
+  display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between;
+  gap: 20px;
+}
+.neo .process-kit-list { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; }
+.neo .process-kit-tags { display: flex; flex-wrap: wrap; gap: 8px; }
+.neo .process-turnaround { display: flex; align-items: baseline; gap: 9px; }
+.neo .process-turnaround b {
+  font-family: var(--neo-serif); font-weight: 500; font-size: 26px;
+  letter-spacing: -.02em; font-variant-numeric: tabular-nums;
+  color: var(--neo-creator-ink);
+}
+/* --neo-creator-ink (38% L) is NOT redefined under [data-theme="ink"], so on a
+   flipped dark ground it lands ~1.8:1. Step up to the 62% L accent in dark only
+   — a flat swap would drop light mode to ~2.8:1. Do not collapse these rules. */
+.neo[data-theme="ink"] .process-turnaround b { color: var(--neo-creator); }
+
+@media (max-width: 1000px) {
+  .neo .process-track { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .neo .process-track { grid-template-columns: 1fr; }
+  /* 1-col gives the card ~508px of text (~77ch). Cap it; 62ch is the house band. */
+  .neo .process-sub { max-width: 62ch; }
+}
 
 /* Counters */
 .neo .counter-num {

--- a/app/help-faq/page.tsx
+++ b/app/help-faq/page.tsx
@@ -190,7 +190,7 @@ export default function HelpFaqPage() {
                         </Link>
 
                         <div className="sect-h">
-                            <div className="eyebrow">§ Help</div>
+                            <div className="eyebrow">Help</div>
                             <div>
                                 <h1 className="display-2">
                                     Questions, <em style={{ fontStyle: "italic" }}>answered.</em>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ const playfair = Playfair_Display({
   display: "swap",
 });
 
-// Monospace for editorial section markers (§ 01 — THE VISION)
+// Monospace for eyebrows and the legal section markers (§ 01)
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-mono",
   subsets: ["latin"],

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -145,7 +145,7 @@ export default function LoginPage() {
                         className="text-[10px] uppercase tracking-[0.4em] font-medium text-[var(--rust)]"
                         style={{ fontFamily: "var(--font-mono)" }}
                     >
-                        § ACCESS — RETURNING
+                        ACCESS — RETURNING
                     </p>
                     <span className="h-px w-10 bg-[var(--rust)]/40" />
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,34 +35,34 @@ export default function Home() {
             <Navbar />
 
             <main>
-                {/* § 01 — Hero with counters + two doors */}
+                {/* Hero with counters + two doors */}
                 <HeroSection />
 
-                {/* § 02 — Live map (Convex listPublished → falls back to 4 known sites) */}
+                {/* Live map (Convex listPublished → falls back to 4 known sites) */}
                 <ShowcaseSection
                     onSelectCreator={setSelectedCreator}
                     onSelectBusiness={setSelectedBusiness}
                 />
 
-                {/* § 03 — How it works (two tracks side-by-side) */}
+                {/* How it works (two tracks side-by-side) */}
                 <HowItWorks />
 
-                {/* § Process — Online Kit pipeline */}
+                {/* Process — Online Kit pipeline */}
                 <ProcessSection />
 
-                {/* § Manifesto — the 99% statement */}
+                {/* Manifesto — the 99% statement */}
                 <ManifestoSection />
 
-                {/* § 06 — Directory (rails of creators + businesses) */}
+                {/* Directory (rails of creators + businesses) */}
                 <DirectorySection
                     onSelectCreator={setSelectedCreator}
                     onSelectBusiness={setSelectedBusiness}
                 />
 
-                {/* § 08 — FAQ */}
+                {/* FAQ */}
                 <FaqSection />
 
-                {/* § 10 — Final CTA (the two doors, big) */}
+                {/* Final CTA (the two doors, big) */}
                 <CtaSection />
             </main>
 

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -237,7 +237,7 @@ export default function PrivacyPolicy() {
                             className="text-[10px] sm:text-[11px] uppercase tracking-[0.45em] font-medium text-[var(--rust)]"
                             style={{ fontFamily: "var(--font-mono)" }}
                         >
-                            § DOC — PRIVACY · UPDATED FEB 2026
+                            DOC — PRIVACY · UPDATED FEB 2026
                         </p>
                         <span className="h-px w-12 bg-[var(--rust)]/40" />
                     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -244,7 +244,7 @@ export default function ProfilePage() {
                 </div>
 
                 {/* Editorial eyebrow */}
-                <p className="ed-label mt-2">§ Your Profile</p>
+                <p className="ed-label mt-2">Your Profile</p>
 
                 {/* Profile Header — avatar + serif name */}
                 <div className="flex flex-col items-center mt-4 mb-8">

--- a/app/referrals/page.tsx
+++ b/app/referrals/page.tsx
@@ -133,7 +133,7 @@ export default function ReferralsPage() {
 
                 {/* Editorial header */}
                 <div className="mb-6 mt-2">
-                    <p className="ed-label">§ Referral Program</p>
+                    <p className="ed-label">Referral Program</p>
                     <h1
                         className="mt-2"
                         style={{
@@ -285,7 +285,7 @@ export default function ReferralsPage() {
 
                 {/* Referred Creators */}
                 <div className="mb-6">
-                    <p className="ed-label">§ Your tree</p>
+                    <p className="ed-label">Your tree</p>
                     <h2
                         className="mt-1 mb-3"
                         style={{
@@ -386,7 +386,7 @@ export default function ReferralsPage() {
 
                 {/* How it Works */}
                 <div>
-                    <p className="ed-label">§ How it works</p>
+                    <p className="ed-label">How it works</p>
                     <h2
                         className="mt-1 mb-4"
                         style={{

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -50,7 +50,7 @@ export default function SignupPage() {
                         className="text-[10px] uppercase tracking-[0.4em] font-medium text-[var(--rust)]"
                         style={{ fontFamily: "var(--font-mono)" }}
                     >
-                        § ACCESS — NEW CREATOR
+                        ACCESS — NEW CREATOR
                     </p>
                     <span className="h-px w-10 bg-[var(--rust)]/40" />
                 </div>

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -87,7 +87,7 @@ export default function TermsOfServicePage() {
                             className="text-[10px] sm:text-[11px] uppercase tracking-[0.45em] font-medium text-[var(--rust)]"
                             style={{ fontFamily: "var(--font-mono)" }}
                         >
-                            § DOC — LEGAL
+                            DOC — LEGAL
                         </p>
                         <span className="h-px w-12 bg-[var(--rust)]/40" />
                     </div>
@@ -184,7 +184,7 @@ export default function TermsOfServicePage() {
                                 className="text-[10px] uppercase tracking-[0.45em] font-medium text-[var(--rust-soft)]"
                                 style={{ fontFamily: "var(--font-mono)" }}
                             >
-                                § INQUIRY — LEGAL HQ
+                                INQUIRY — LEGAL HQ
                             </p>
                             <span className="h-px w-10 bg-[var(--rust-soft)]/50" />
                         </div>

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -239,7 +239,7 @@ export default function WalletPage() {
 
                 {/* Editorial header */}
                 <div className="mb-6 mt-2">
-                    <p className="ed-label">§ Wallet · Withdrawals</p>
+                    <p className="ed-label">Wallet · Withdrawals</p>
                     <h1
                         className="mt-2"
                         style={{
@@ -376,7 +376,7 @@ export default function WalletPage() {
 
                 {/* Recent Earnings */}
                 <div className="mb-6">
-                    <p className="ed-label">§ History</p>
+                    <p className="ed-label">History</p>
                     <h2
                         className="mt-1 mb-3"
                         style={{

--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -20,7 +20,7 @@ export default function CtaSection() {
                         className="eyebrow"
                         style={{ marginBottom: 24, color: "var(--neo-creator)" }}
                     >
-                        § 10 — The vision
+                        The vision
                     </div>
                     <h2
                         className="display"

--- a/components/landing/DirectorySection.tsx
+++ b/components/landing/DirectorySection.tsx
@@ -112,7 +112,7 @@ export default function DirectorySection({
         <section id="directory">
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ 06 — Directory</div>
+                    <div className="eyebrow">Directory</div>
                     <div>
                         <h2 className="display-2">
                             Proof, <em style={{ fontStyle: "italic" }}>at scale</em>.

--- a/components/landing/EarningsSection.tsx
+++ b/components/landing/EarningsSection.tsx
@@ -17,7 +17,7 @@ export default function EarningsSection() {
         >
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow" style={{ color: "var(--neo-creator)" }}>§ 05 — For creators</div>
+                    <div className="eyebrow" style={{ color: "var(--neo-creator)" }}>For creators</div>
                     <div>
                         <h2 className="display-2" style={{ color: "var(--neo-paper)" }}>
                             Earn while bringing them <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>online</em>.

--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -17,7 +17,7 @@ export default function FaqSection() {
         <section id="faq">
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ 08 — Questions</div>
+                    <div className="eyebrow">Questions</div>
                     <div>
                         <h2 className="display-2">
                             Questions <em>worth asking.</em>

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -87,7 +87,7 @@ export default function HowItWorks({ door = null }: { door?: "business" | "creat
         <section id="how-it-works" style={{ background: "var(--neo-paper-2)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ 03 — How It Works</div>
+                    <div className="eyebrow">How It Works</div>
                     <div>
                         <h2 className="display-2">
                             Two flows. <em style={{ color: "var(--neo-creator)", fontStyle: "italic" }}>Side by side.</em>

--- a/components/landing/ProcessSection.tsx
+++ b/components/landing/ProcessSection.tsx
@@ -1,153 +1,142 @@
 "use client";
 
+/* Headings are subject + verb on purpose: the old noun phrases ("A photo",
+   "A guided page") never said WHO does the step, which is the owner's first
+   question. Now every card answers "we" or "you" in its first two words.
+   `cost` is what the step takes out of the owner's day — the one fact neither
+   HowItWorks above nor the Manifesto below carries. 10 + 20 is the "30 minutes,
+   your shop" already promised in HowItWorks.tsx:75; keep the numbers in step if
+   either moves. Steps 03 and 04 take no fixed time, so they say so rather than
+   inventing a number we'd have to honour. */
 const STEPS = [
     {
         k: "01",
-        h: "A photo",
-        sub: "A trained Tendso creator visits your shop. They photograph what you'd photograph if you had time. The work, the hands, the place.",
+        h: "We take the photos",
+        cost: "10 min",
+        sub: "Someone from Tendso comes to your shop and takes pictures of your work, your place, and you. You don't need to prepare anything or tidy up.",
     },
     {
         k: "02",
-        h: "A few answers",
-        sub: "Short questions about your business, asked while you keep working. No essays, no design vocabulary. Just what you'd tell a customer.",
+        h: "You answer a few questions",
+        cost: "20 min",
+        sub: "They ask you simple questions while you keep working — the same things you'd tell a customer who walked in. No writing, no computer.",
     },
     {
         k: "03",
-        h: "A guided page",
-        sub: "Your photos, your words, your hours, your services — gathered, structured, drafted as a real coded page. You don't pick a template.",
+        h: "We build your page",
+        cost: "none of it yours",
+        sub: "We put your photos and your answers together into your own website. You don't design anything, and you don't pick from a list of layouts.",
     },
     {
         k: "04",
-        h: "Reviewed and live",
-        sub: "A quick review pass. You adjust one thing, or nothing. Your page goes live. The hands go back to work.",
+        h: "You check it, then it's live",
+        cost: "one look",
+        sub: "We show it to you first. Change something, or leave it exactly as it is. Then it goes online, and you get back to work.",
     },
 ];
 
+/* Plain words only. The step copy above promises "no design vocabulary", so the
+   list of what you get can't say SEO, hosting, or open-graph card. */
+const KIT = [
+    "Your own website",
+    "Your own web address",
+    "We keep it online",
+    "Easy to find on Google",
+    "Photos you can post",
+    "Your menu or price list",
+    "Looks right when shared",
+];
+
+/* Deliberately plain and literal — a camera means photos, a question mark means
+   questions. An earlier pass cut icons for restating their headings; that was a
+   designer's objection, not a reader's. These sit small beside the number so
+   they support it rather than take over the card. */
 const ICONS: Record<string, React.ReactElement> = {
     "01": (
-        <svg width="40" height="40" viewBox="0 0 48 48" fill="none">
-            <path d="M24 6 C16 6 10 12 10 20 C10 30 24 42 24 42 C24 42 38 30 38 20 C38 12 32 6 24 6 Z" stroke="currentColor" strokeWidth="1.5" />
-            <circle cx="24" cy="20" r="4" fill="currentColor" />
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="2" y="6" width="20" height="14" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M8 6 L9.5 3 L14.5 3 L16 6" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+            <circle cx="12" cy="13" r="4" stroke="currentColor" strokeWidth="1.5" />
         </svg>
     ),
     "02": (
-        <svg width="40" height="40" viewBox="0 0 48 48" fill="none">
-            <rect x="8" y="14" width="32" height="24" rx="3" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M16 14 L18 10 L30 10 L32 14" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
-            <circle cx="24" cy="26" r="6" stroke="currentColor" strokeWidth="1.5" />
-            <circle cx="24" cy="26" r="2" fill="currentColor" />
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 5.5 A2 2 0 0 1 5 3.5 H19 A2 2 0 0 1 21 5.5 V15 A2 2 0 0 1 19 17 H9 L4 21 V17 A2 2 0 0 1 3 15 Z"
+                  stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+            <path d="M9.6 8.4 A2.4 2.4 0 1 1 12 11.4 V12.4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <circle cx="12" cy="14.8" r="1" fill="currentColor" />
         </svg>
     ),
     "03": (
-        <svg width="40" height="40" viewBox="0 0 48 48" fill="none">
-            <path d="M10 12 H38" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M10 20 H32" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M10 28 H36" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M10 36 H22" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M28 32 L36 40" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M3 8 H21" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M6.5 12 H14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path d="M6.5 16 H17" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
         </svg>
     ),
     "04": (
-        <svg width="40" height="40" viewBox="0 0 48 48" fill="none">
-            <rect x="8" y="8" width="32" height="32" rx="2" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M8 16 H40" stroke="currentColor" strokeWidth="1.5" />
-            <circle cx="13" cy="12" r="1" fill="currentColor" />
-            <circle cx="17" cy="12" r="1" fill="currentColor" />
-            <path d="M14 24 H28" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M14 30 H34" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M14 36 H24" stroke="currentColor" strokeWidth="1.5" />
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M3.2 9.5 H20.8 M3.2 14.5 H20.8" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M12 3 C9 6.5 9 17.5 12 21 M12 3 C15 6.5 15 17.5 12 21"
+                  stroke="currentColor" strokeWidth="1.5" />
         </svg>
     ),
 };
 
 export default function ProcessSection() {
     return (
-        <section style={{ padding: "96px 0" }}>
+        <section>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ Process</div>
+                    <div className="eyebrow">Your part</div>
                     <div>
                         <h2 className="display-2">
-                            The page comes <em style={{ fontStyle: "italic" }}>from the work</em>.
+                            You keep working. <em style={{ fontStyle: "italic" }}>We build the page.</em>
                         </h2>
                         <p className="lede" style={{ marginTop: 12 }}>
-                            Four small moves. None of them require you to put the work down.
+                            Half an hour of your time, all together. We do the rest.
                         </p>
                     </div>
                 </div>
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 items-stretch">
-                    {STEPS.map((s, i) => {
-                        const highlight = i === 3;
-                        return (
-                            <div
-                                key={s.k}
-                                className="card"
-                                style={{
-                                    padding: 24,
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: 16,
-                                    background: highlight ? "var(--neo-ink)" : "var(--neo-paper-3)",
-                                    color: highlight ? "var(--neo-paper)" : "var(--neo-ink)",
-                                    borderColor: highlight ? "var(--neo-ink)" : "var(--neo-rule)",
-                                }}
-                            >
-                                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                                    <span
-                                        className="counter-num"
-                                        style={{
-                                            fontSize: 28,
-                                            color: highlight ? "var(--neo-creator)" : "var(--neo-ink-3)",
-                                        }}
-                                    >
-                                        {s.k}
+                {/* role="list" is explicit: list-style:none strips the list role in
+                    Safari/VoiceOver, which would drop the "1 of 4" announcement. */}
+                <ol className="process-track" role="list">
+                    {STEPS.map((s, i) => (
+                        <li
+                            key={s.k}
+                            className={`process-step${i === STEPS.length - 1 ? " is-final" : ""}`}
+                        >
+                            <div className="process-card">
+                                <div className="process-node-row">
+                                    <span className="process-mark">
+                                        <span className="process-icon">{ICONS[s.k]}</span>
+                                        <span className="process-node">{s.k}</span>
                                     </span>
-                                    <span style={{ color: highlight ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)" }}>
-                                        {ICONS[s.k]}
-                                    </span>
+                                    <span className="process-cost">{s.cost}</span>
                                 </div>
-                                <div
-                                    className="serif"
-                                    style={{ fontSize: 24, lineHeight: 1.15, letterSpacing: "-.015em" }}
-                                >
-                                    {s.h}
-                                </div>
-                                <div
-                                    style={{
-                                        fontSize: 13,
-                                        color: highlight ? "oklch(80% 0.008 85)" : "var(--neo-ink-2)",
-                                        lineHeight: 1.55,
-                                        marginTop: "auto",
-                                    }}
-                                >
-                                    {s.sub}
-                                </div>
+                                <h3 className="process-h">{s.h}</h3>
+                                <p className="process-sub">{s.sub}</p>
                             </div>
-                        );
-                    })}
-                </div>
+                        </li>
+                    ))}
+                </ol>
 
-                <div
-                    style={{
-                        marginTop: 32,
-                        padding: "20px 28px",
-                        border: "1px dashed var(--neo-rule-strong)",
-                        borderRadius: "var(--neo-r-lg)",
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                        gap: 16,
-                        flexWrap: "wrap",
-                    }}
-                >
-                    <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
-                        <span className="label">An Online Kit includes</span>
-                        {["Website", "Domain", "Hosting", "SEO", "Social assets", "Menu / pricelist", "Open-graph card"].map((t) => (
-                            <span key={t} className="tag">{t}</span>
-                        ))}
+                <div className="process-kit">
+                    <div className="process-kit-list">
+                        <span className="label">What you get</span>
+                        <div className="process-kit-tags">
+                            {KIT.map((t) => (
+                                <span key={t} className="tag">{t}</span>
+                            ))}
+                        </div>
                     </div>
-                    <span className="label" style={{ color: "var(--neo-creator)" }}>48 – 72 hours, end to end ↗</span>
+                    <div className="process-turnaround">
+                        <b>48–72h</b>
+                        <span className="label">from start to finish</span>
+                    </div>
                 </div>
             </div>
         </section>

--- a/components/landing/ShowcaseSection.tsx
+++ b/components/landing/ShowcaseSection.tsx
@@ -89,7 +89,7 @@ export default function ShowcaseSection({
         <section id="showcase" style={{ background: "var(--neo-paper-2)" }}>
             <div className="container-wide">
                 <div className="sect-h">
-                    <div className="eyebrow">§ 02 — Live map</div>
+                    <div className="eyebrow">Live map</div>
                     <div>
                         <h2 className="display-2">
                             Live businesses, <em style={{ fontStyle: "italic" }}>right now.</em>

--- a/components/landing/StickyCTA.tsx
+++ b/components/landing/StickyCTA.tsx
@@ -4,6 +4,14 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Logo, ArrowUpRightIcon } from "./landingPrimitives";
 
+/**
+ * The persistent "pick a door" CTA that appears once you've scrolled past the hero.
+ *
+ * Design note: this is a quiet, auto-width pill rather than a full-bleed bar. The
+ * two doors carry equal weight — colour identifies each one with a dot instead of
+ * filling the whole button, so neither shouts over the page content behind it.
+ * When `door` is set, that side reads as the current context via a soft tint.
+ */
 export default function StickyCTA({ door = null }: { door?: "business" | "creator" | null }) {
     const [visible, setVisible] = useState(false);
 
@@ -16,57 +24,43 @@ export default function StickyCTA({ door = null }: { door?: "business" | "creato
 
     return (
         <div className={`sticky-cta ${visible ? "visible" : ""}`}>
-            <div className="container-wide flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 py-3 sm:py-3.5">
-                {/* Logo + door badge — hide logo on phones to save room for the CTA buttons */}
-                <div className="hidden sm:flex items-center gap-3">
+            <nav className="sticky-cta-pill" aria-label="Choose your path">
+                <span className="sticky-cta-brand">
                     <Logo />
-                    {door && (
-                        <span className="label" style={{ color: "var(--neo-ink-3)" }}>
-                            You picked the{" "}
-                            <strong
-                                style={{
-                                    color: door === "creator" ? "var(--neo-creator)" : "var(--neo-business)",
-                                }}
-                            >
-                                {door}
-                            </strong>{" "}
-                            door.
-                        </span>
-                    )}
-                </div>
-                <div className="grid grid-cols-2 sm:flex gap-2 w-full sm:w-auto">
-                    <Link
-                        href="/for-business"
-                        className="door door-business justify-center sm:justify-start"
-                        style={{
-                            padding: "10px 14px",
-                            fontSize: 13,
-                            textDecoration: "none",
-                            display: "inline-flex",
-                            whiteSpace: "nowrap",
-                        }}
-                    >
-                        <span className="hidden md:inline">I own a business</span>
-                        <span className="md:hidden">Business</span>
-                        <span className="arrow"><ArrowUpRightIcon /></span>
-                    </Link>
-                    <Link
-                        href="/for-creators"
-                        className="door door-creator justify-center sm:justify-start"
-                        style={{
-                            padding: "10px 14px",
-                            fontSize: 13,
-                            textDecoration: "none",
-                            display: "inline-flex",
-                            whiteSpace: "nowrap",
-                        }}
-                    >
-                        <span className="hidden md:inline">I want to earn</span>
-                        <span className="md:hidden">Earn</span>
-                        <span className="arrow"><ArrowUpRightIcon /></span>
-                    </Link>
-                </div>
-            </div>
+                </span>
+
+                <span className="sticky-cta-div" aria-hidden="true" />
+
+                <Link
+                    href="/for-business"
+                    className={`sticky-cta-seg is-business${door === "business" ? " is-current" : ""}`}
+                    tabIndex={visible ? 0 : -1}
+                    aria-current={door === "business" ? "page" : undefined}
+                >
+                    <span className="sticky-cta-dot" aria-hidden="true" />
+                    <span className="sticky-cta-full">I own a business</span>
+                    <span className="sticky-cta-short">Business</span>
+                    <span className="sticky-cta-arrow" aria-hidden="true">
+                        <ArrowUpRightIcon />
+                    </span>
+                </Link>
+
+                <span className="sticky-cta-div" aria-hidden="true" />
+
+                <Link
+                    href="/for-creators"
+                    className={`sticky-cta-seg is-creator${door === "creator" ? " is-current" : ""}`}
+                    tabIndex={visible ? 0 : -1}
+                    aria-current={door === "creator" ? "page" : undefined}
+                >
+                    <span className="sticky-cta-dot" aria-hidden="true" />
+                    <span className="sticky-cta-full">I want to earn</span>
+                    <span className="sticky-cta-short">Earn</span>
+                    <span className="sticky-cta-arrow" aria-hidden="true">
+                        <ArrowUpRightIcon />
+                    </span>
+                </Link>
+            </nav>
         </div>
     );
 }

--- a/components/landing/i18n.tsx
+++ b/components/landing/i18n.tsx
@@ -57,7 +57,7 @@ const EN: Dict = {
     "hero.counterCountries": "countries",
 
     // Business pricing
-    "price.eyebrow": "§ 04 — The price",
+    "price.eyebrow": "The price",
     "price.liveForever": "Live forever.",
     "price.lede":
         "One-time payment. No monthly fees. No contracts. You only pay once your website is live and you've approved it.",
@@ -109,7 +109,7 @@ const TL: Dict = {
     "hero.counterCountries": "mga bansa",
 
     // Business pricing
-    "price.eyebrow": "§ 04 — Ang presyo",
+    "price.eyebrow": "Ang presyo",
     "price.liveForever": "Live habambuhay.",
     "price.lede":
         "Isang bayad lang. Walang buwanang bayad. Walang kontrata. Magbabayad ka lang kapag live na ang website mo at na-approve mo na.",


### PR DESCRIPTION
UI polish pass on the landing page: the sticky scroll CTA, the Process section, and a sweep of decorative section markers. No behaviour, data, or Convex changes — presentation only.

## Sticky CTA

The scroll strip was a full-bleed slab with two saturated fills competing against each other, and a hero-sized `door` component crammed in via inline overrides. It is now a centred auto-width pill: frosted paper surface, the Tendso logo, and two quiet segments that tint to the business/creator tokens only on hover. Short labels below 440px.

## Process section

The section was redundant rather than ugly — the third consecutive telling of the same four beats. `HowItWorks` (directly above) says **what the steps are**; the Manifesto (directly below) says **what it means**. This section now answers **"how much of my time does this cost me?"**, which is the question it exists for and the one neither neighbour answers.

| | | |
|---|---|---|
| 01 | We take the photos | `10 min` |
| 02 | You answer a few questions | `20 min` |
| 03 | We build your page | `none of it yours` |
| 04 | You check it, then it's live | `one look` |

10 + 20 matches the **"30 minutes, your shop"** already promised in `HowItWorks.tsx:75` — those two numbers now depend on each other, and there's a comment on `STEPS` saying so. Steps 3 and 4 take no fixed time, so they say that instead of inventing a duration we'd have to honour.

Alongside that:

- **Headings are subject + verb** ("We take the photos"). The old noun phrases — "A photo", "A guided page" — never said *who* does the step, which is an owner's first question.
- **Plain words in the deliverables.** Step 02 promises "no design vocabulary" and the list directly beneath it said *SEO*, *Hosting*, *Open-graph card*. Now "Easy to find on Google", "We keep it online", "Looks right when shared".
- **Icons are 26px, locked up with the ordinal**, rather than 40px alone at the top of the card, so each card has one anchor instead of three competing.
- **Removed the connector rail and pill badges** from an earlier iteration of this branch. They invented a vocabulary the house doesn't have, and the rail painted a hairline into empty space at the 2-column breakpoint.

## Two dark-theme contrast bugs fixed

Both were introduced by an earlier commit on this branch and were invisible in a light-mode check, which is how they got in:

- `.is-final .process-sub` was a hardcoded `oklch()` literal sitting on `--neo-ink` — which flips **15% → 97%** under `[data-theme="ink"]`, landing around **1.7:1**. Now `--neo-paper-2`, which flips with it.
- The turnaround figure used `--neo-creator-ink`, which is declared once and **never redefined for dark** (~1.8:1). Fixed with a theme-scoped override rather than a flat swap — a flat swap to `--neo-creator` would have dropped *light* mode to ~2.8:1.

Also drops an inline `padding: 96px 0` that beat the house `80px` **and** was immune to the `56px` mobile rule, making Process the one mid-page section that didn't shrink on phones. Plus small semantics fixes: explicit `role="list"` (`list-style:none` strips the list role in Safari/VoiceOver), `div` → `h3` for step titles, and 14px body copy to match ManifestoSection.

## Section markers

Removes 26 decorative `§` markers from numbered eyebrows across 23 files, including both the English and Tagalog strings in `i18n`. **Keeps** them in terms-of-service (`§ 01`–`§ 06`) and privacy-policy (`§ 01`–`§ 11`) — those are real legal clause references that get cited, not decoration.

## Testing

- `npx tsc --noEmit` — clean, exit 0
- Turbopack production compile — succeeded
- Rendering verified against the dev server across all four steps, both themes, and the 1000px / 600px breakpoints

⚠️ The **full** `npm run build` did not complete locally: at the default heap it OOMs in the TypeScript step, and with `--max-old-space-size=6144` it gets past TypeScript and then dies with `Error: kill EPERM` while collecting page data. Both look like limits of this Windows sandbox rather than the code — TypeScript passes standalone and the compile succeeds — but the full build has **not** been observed green end-to-end, so it's worth watching the Vercel preview build.

## Not addressed — needs a product decision

The turnaround figure reads **`48–72h`** in this section, while **"48 hours"** appears in the hero, the CTA, the page metadata, the OG and Twitter cards, and both locales — and `CreatorEarningFlow.tsx:20` says **"24–48 hours"**. Three different public promises. Pre-existing, not introduced here, and picking one is a product call rather than a design one.
