### PR TITLE
feat(leads): interview a scraped prospect instead of re-entering it

### DIFF
--- a/app/leads/[leadId]/page.tsx
+++ b/app/leads/[leadId]/page.tsx
@@ -1428,7 +1428,25 @@ function ProspectDetail({ data, creator }: { data: any; creator: any }) {
                             >
                                 Quick actions
                             </div>
-                            {claimedByMe ? (
+                            {lead.submissionId ? (
+                                // Already interviewed. Guards a bookmarked or
+                                // stale prospect URL. This rarely renders —
+                                // once submit patches the lead, `isProspect`
+                                // goes false and the page self-heals into the
+                                // normal interviewed-lead layout — so it only
+                                // covers the reactivity gap.
+                                <Link
+                                    href={`/submissions/${lead.submissionId}`}
+                                    className="w-full inline-flex items-center justify-center gap-2 text-[14px] font-semibold px-3 py-2.5 rounded-xl"
+                                    style={{
+                                        background: "var(--ed-paper-2)",
+                                        color: "var(--ed-ink)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                >
+                                    Already interviewed <ArrowRight className="w-4 h-4" />
+                                </Link>
+                            ) : claimedByMe ? (
                                 <>
                                     <Link
                                         href={startInterviewHref}

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -194,9 +194,14 @@ function CreatorLeadsInner() {
     const allLeads = feed?.leads ?? [];
 
     // Interviewed feed — exclude Outscraper-source leads so the two tabs
-    // don't double-count.
+    // don't double-count. A CONVERTED prospect is the exception: it's been
+    // interviewed, so it belongs here even though its source is outscraper.
+    // Without that clause it drops out of Prospects on conversion and never
+    // appears anywhere else, and the creator loses sight of the business they
+    // just interviewed. submissionStatus is non-null exactly when a submission
+    // is linked, and listForMobileCRM already returns it.
     const interviewedLeads = useMemo(
-        () => allLeads.filter((l: any) => l.source !== "outscraper"),
+        () => allLeads.filter((l: any) => l.source !== "outscraper" || l.submissionStatus != null),
         [allLeads],
     );
 

--- a/app/submit/info/page.tsx
+++ b/app/submit/info/page.tsx
@@ -1,29 +1,57 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useState, useEffect, Suspense } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
 import { useUser } from "@clerk/nextjs"
 import { useQuery, useMutation } from "convex/react"
 import { api } from "@/convex/_generated/api"
+import type { Id } from "@/convex/_generated/dataModel"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Loader2 } from "lucide-react"
+import { Loader2, ArrowLeft } from "lucide-react"
+import {
+    BUSINESS_TYPES,
+    mapCategoryToBusinessType,
+    toLocalPhDigits,
+    looksLikeConvexId,
+} from "@/lib/prospectPrefill"
 
-const BUSINESS_TYPES = [
-    "Barber/Salon",
-    "Auto Shop",
-    "Spa/Massage",
-    "Restaurant",
-    "Clinic",
-    "Law Office",
-    "Craft/Producer",
-    "Other"
-]
+function Spinner() {
+    return (
+        <div className="min-h-screen flex items-center justify-center" style={{ background: "var(--ed-paper)" }}>
+            <Loader2 className="h-8 w-8 animate-spin" style={{ color: "var(--ed-accent)" }} />
+        </div>
+    )
+}
 
+// useSearchParams() needs a Suspense boundary or the Next build fails with a
+// CSR-bailout error.
 export default function BusinessInfoPage() {
+    return (
+        <Suspense fallback={<Spinner />}>
+            <BusinessInfoForm />
+        </Suspense>
+    )
+}
+
+function BusinessInfoForm() {
     const router = useRouter()
     const { user, isLoaded, isSignedIn } = useUser()
+    const searchParams = useSearchParams()
+
+    // Prefill params, written by the "Start interview" link on the prospect
+    // detail page (app/leads/[leadId]/page.tsx) and the prospects tab.
+    const rawProspectLeadId = searchParams.get("prospectLeadId")
+    // Shape-check before this ever reaches a v.id('leads') validator — a
+    // place_id or hand-edited string would throw and dead-end step 1.
+    const prospectLeadId = looksLikeConvexId(rawProspectLeadId) ? rawProspectLeadId : null
+    const paramBusinessName = searchParams.get("businessName") ?? ""
+    const paramPhone = searchParams.get("phone")
+    const paramAddress = searchParams.get("address") ?? ""
+    const paramCity = searchParams.get("city") ?? ""
+    const paramCategory = searchParams.get("category")
 
     // Get creator from Convex
     const creator = useQuery(
@@ -53,6 +81,25 @@ export default function BusinessInfoPage() {
     const [address, setAddress] = useState("")
     const [city, setCity] = useState("")
     const [initialized, setInitialized] = useState(false)
+    // 'unresolved' only matters when there's a draft-vs-prospect collision.
+    const [draftChoice, setDraftChoice] = useState<"unresolved" | "continue" | "fresh">("unresolved")
+
+    // getDraftByCreatorId returns the creator's single NEWEST draft with no
+    // business filter, and this page patches whatever it hands back. If that
+    // draft belongs to a different business than the prospect we arrived for,
+    // reusing it would rename it — and on submit mark the WRONG business
+    // interviewed. Detect that and ask instead of guessing.
+    const draftIsForThisProspect =
+        !!existingDraft &&
+        !!prospectLeadId &&
+        (((existingDraft as any).prospectLeadId ?? null) === prospectLeadId ||
+            // An unlinked draft for the same business is a back-navigation, not
+            // a collision.
+            (!(existingDraft as any).prospectLeadId &&
+                (existingDraft.businessName ?? "") === paramBusinessName))
+    const draftCollision = !!existingDraft && !!prospectLeadId && !draftIsForThisProspect
+    const awaitingChoice = draftCollision && draftChoice === "unresolved"
+    const startingFresh = draftCollision && draftChoice === "fresh"
 
     // Redirect if not authenticated
     useEffect(() => {
@@ -61,9 +108,19 @@ export default function BusinessInfoPage() {
         }
     }, [isLoaded, isSignedIn, router])
 
-    // Load draft data when available
+    // Single hydration effect. A saved draft always wins over URL params; the
+    // params only fill a genuinely empty form. These must NOT be two effects —
+    // existingDraft resolves asynchronously, so a separate prefill effect gets
+    // clobbered when the draft lands later.
     useEffect(() => {
-        if (existingDraft && !initialized) {
+        if (initialized) return
+        // undefined is Convex's loading state, NOT "no draft". Treating it as
+        // "no draft" (the old `if (existingDraft)` check) let a fast tap on
+        // Next create a second draft.
+        if (existingDraft === undefined) return
+        if (awaitingChoice) return
+
+        if (existingDraft && !startingFresh) {
             setBusinessName(existingDraft.businessName || "")
             setBusinessType(existingDraft.businessType || "")
             setOwnerName(existingDraft.ownerName || "")
@@ -73,9 +130,20 @@ export default function BusinessInfoPage() {
             setCity(existingDraft.city || "")
             // Store ID in session for other steps
             sessionStorage.setItem('current_submission_id', existingDraft._id)
-            setInitialized(true)
+        } else if (prospectLeadId) {
+            // Prefill from the scraped prospect. Owner name and email are
+            // deliberately left empty — a scrape can't know them.
+            setBusinessName(paramBusinessName)
+            setAddress(paramAddress)
+            setCity(paramCity)
+            setOwnerPhone(toLocalPhDigits(paramPhone))
+            setBusinessType(mapCategoryToBusinessType(paramCategory))
         }
-    }, [existingDraft, initialized])
+        setInitialized(true)
+    }, [
+        existingDraft, initialized, awaitingChoice, startingFresh, prospectLeadId,
+        paramBusinessName, paramAddress, paramCity, paramPhone, paramCategory,
+    ])
 
     const handleNext = async (e: React.FormEvent) => {
         e.preventDefault()
@@ -88,8 +156,11 @@ export default function BusinessInfoPage() {
             }
 
             let submissionId: string
+            const linkArg = prospectLeadId
+                ? { prospectLeadId: prospectLeadId as Id<'leads'> }
+                : {}
 
-            if (existingDraft) {
+            if (existingDraft && !startingFresh) {
                 // Update existing draft
                 await updateSubmission({
                     id: existingDraft._id,
@@ -100,10 +171,12 @@ export default function BusinessInfoPage() {
                     ownerEmail: ownerEmail || undefined,
                     address,
                     city,
+                    ...linkArg,
                 })
                 submissionId = existingDraft._id
             } else {
-                // Create new draft
+                // Create new draft — either the creator has none, or they chose
+                // to start fresh rather than reuse an unrelated one.
                 submissionId = await createSubmission({
                     creatorId: creator._id,
                     businessName,
@@ -114,6 +187,7 @@ export default function BusinessInfoPage() {
                     address,
                     city,
                     status: 'draft',
+                    ...linkArg,
                 })
             }
 
@@ -180,8 +254,78 @@ export default function BusinessInfoPage() {
                     {/* Title */}
                     <h1 className="text-2xl font-bold text-gray-900 mb-2">Business Information</h1>
                     <p className="text-sm text-gray-500 mb-8">
-                        Tell us about the business you're submitting
+                        Tell us about the business you&apos;re submitting
                     </p>
+
+                    {/* Arrived from a scraped prospect — say so, and offer a way
+                        back, so the creator can see this interview is attached
+                        to that record rather than floating free. */}
+                    {prospectLeadId && !awaitingChoice && (
+                        <div
+                            className="mb-6 p-4 rounded-lg"
+                            style={{ background: "var(--ed-accent-bg, #F5E4C0)", border: "1px solid var(--ed-accent)" }}
+                        >
+                            <p className="text-sm font-medium" style={{ color: "var(--ed-accent-ink, #5C3A0F)" }}>
+                                Interviewing {paramBusinessName || "this business"}
+                            </p>
+                            <p className="text-xs mt-1" style={{ color: "var(--ed-ink-2)" }}>
+                                Details below are from the listing — correct anything that&apos;s wrong.
+                                The phone is the listed number, not necessarily the owner&apos;s.
+                            </p>
+                            <Link
+                                href={`/leads/${prospectLeadId}`}
+                                className="inline-flex items-center gap-1.5 text-xs mt-2"
+                                style={{ color: "var(--ed-accent-ink, #5C3A0F)" }}
+                            >
+                                <ArrowLeft className="w-3 h-3" /> Back to the prospect
+                            </Link>
+                        </div>
+                    )}
+
+                    {/* Draft collision — the creator has an unfinished interview
+                        for a DIFFERENT business. Reusing it silently would mark
+                        the wrong business interviewed, so ask. */}
+                    {awaitingChoice && (
+                        <div
+                            className="mb-6 p-4 rounded-lg"
+                            style={{ background: "#FBE9C4", border: "1px solid var(--ed-warn, #C68A12)" }}
+                        >
+                            <p className="text-sm font-semibold text-gray-900">
+                                You have an unfinished interview
+                            </p>
+                            <p className="text-sm mt-1 text-gray-700">
+                                There&apos;s a draft for{" "}
+                                <strong>{existingDraft?.businessName || "another business"}</strong>.
+                                Continue that one, or start fresh for{" "}
+                                <strong>{paramBusinessName || "this business"}</strong>?
+                            </p>
+                            <div className="flex flex-wrap gap-2 mt-3">
+                                <button
+                                    type="button"
+                                    onClick={() => setDraftChoice("continue")}
+                                    className="px-3 py-2 text-sm font-semibold rounded-lg"
+                                    style={{ background: "var(--ed-ink)", color: "var(--ed-paper-3)" }}
+                                >
+                                    Continue {existingDraft?.businessName || "the draft"}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setDraftChoice("fresh")}
+                                    className="px-3 py-2 text-sm font-semibold rounded-lg"
+                                    style={{
+                                        background: "transparent",
+                                        color: "var(--ed-ink)",
+                                        border: "1px solid var(--ed-rule)",
+                                    }}
+                                >
+                                    Start fresh for {paramBusinessName || "this business"}
+                                </button>
+                            </div>
+                            <p className="text-xs mt-2 text-gray-600">
+                                Starting fresh keeps the other draft — it isn&apos;t deleted.
+                            </p>
+                        </div>
+                    )}
 
                     {/* Error Message */}
                     {error && (
@@ -323,7 +467,11 @@ export default function BusinessInfoPage() {
                         {/* Next Button */}
                         <Button
                             type="submit"
-                            disabled={loading}
+                            // existingDraft === undefined is Convex still
+                            // loading; submitting through it creates a second
+                            // draft that would carry the prospect link while
+                            // the first is orphaned.
+                            disabled={loading || existingDraft === undefined || awaitingChoice}
                             className="w-full h-12 bg-amber-500 hover:bg-amber-600 text-white font-semibold rounded-xl transition-colors mt-8"
                         >
                             {loading ? (

--- a/convex/outscraper.ts
+++ b/convex/outscraper.ts
@@ -785,7 +785,12 @@ export const listScrapedLeads = query({
         await requireAuth(ctx);
 
         const all = await ctx.db.query("leads").collect();
-        let scraped = all.filter((l) => l.source === "outscraper");
+        // `!l.submissionId` drops prospects that have already been interviewed —
+        // submissions.submit sets that pointer on conversion. Without it an
+        // interviewed business stays in the Prospects tab and on the Discover
+        // map, indistinguishable from an un-interviewed one, and another
+        // creator drives out to redo it.
+        let scraped = all.filter((l) => l.source === "outscraper" && !l.submissionId);
 
         scraped.sort((a, b) => (b.scrapedAt ?? b.createdAt) - (a.scrapedAt ?? a.createdAt));
 
@@ -999,6 +1004,12 @@ export const getProspect = query({
                 createdAt: lead.createdAt,
                 source: lead.source,
                 claimedAt: (lead as any).claimedAt ?? null,
+                // Non-null once this prospect has been interviewed. Lets the
+                // detail page tell a converted prospect from a fresh one, and
+                // makes the client-side `!p.submissionId` filters on the
+                // Discover page (which were no-ops while this field was never
+                // returned) actually do something.
+                submissionId: lead.submissionId ? String(lead.submissionId) : null,
             },
             claimedBy,
             notes: notes.map((n) => ({

--- a/convex/prospectsMigration.ts
+++ b/convex/prospectsMigration.ts
@@ -169,6 +169,16 @@ export const backfillBatch = internalMutation({
                 skipped += 1;
                 continue;
             }
+            // Skip 1b: already interviewed. Without this, a converted prospect
+            // gets re-seeded into the new pool as `state: 'available'` (this
+            // loop hardcodes submissionId: undefined and derives state from
+            // claimedByCreatorId, which conversion clears) — resurrecting the
+            // exact duplicate-business bug through the surface that is
+            // becoming primary.
+            if (lead.submissionId) {
+                skipped += 1;
+                continue;
+            }
             // Skip 2: missing required keys
             const placeId = lead.businessGooglePlaceId;
             const lat = lead.businessLatitude;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -180,6 +180,14 @@ export default defineSchema({
         // new global prospects pool. Optional + additive — existing
         // submissions stay valid. Mutations that set this land in P2+.
         prospectId: v.optional(v.id('prospects')),
+        // Links this interview back to a LEGACY Outscraper prospect — a `leads`
+        // row with source === 'outscraper'. Distinct from `prospectId` above,
+        // which points at the new global `prospects` pool and cannot hold a
+        // leads id. Written by submissions.create/update from the
+        // ?prospectLeadId= query param; consumed by submissions.submit, which
+        // sets the reverse pointer leads.submissionId and marks the prospect
+        // converted. Dies with the prospects-pool consolidation.
+        prospectLeadId: v.optional(v.id('leads')),
     })
         // Use mobile's index name (by_creator_id, not by_creatorId)
         .index('by_creator_id', ['creatorId'])

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -1,5 +1,7 @@
 import { v } from 'convex/values';
 import { query, mutation, internalQuery, internalMutation, internalAction } from './_generated/server';
+import type { MutationCtx } from './_generated/server';
+import type { Id } from './_generated/dataModel';
 import { internal } from './_generated/api';
 import { BASE_PRICE, STANDARD_PRICE, UNLOCK_THRESHOLD, COMMISSION_RATE, CUSTOM_DOMAIN_ADDON, commissionFor, ownerTotal, domainAddOnFor } from '../lib/pricing';
 
@@ -275,6 +277,31 @@ export const getCreatorPricingSummary = query({
 // ==================== MUTATIONS ====================
 
 /**
+ * Validate an incoming ?prospectLeadId= before we store it on a submission.
+ *
+ * NEVER throws. The creator is standing in front of the business on a phone —
+ * a stale, already-interviewed, or hand-edited id must degrade to a normal
+ * unlinked submission, not block the interview. Returns undefined when the id
+ * can't be linked, and the caller just omits the field.
+ */
+async function resolveProspectLead(
+    ctx: MutationCtx,
+    leadId: Id<'leads'> | undefined,
+): Promise<Id<'leads'> | undefined> {
+    if (!leadId) return undefined;
+    const lead = await ctx.db.get(leadId);
+    if (!lead) return undefined;
+    // Only scraped prospects convert — never a real customer lead.
+    if (lead.source !== 'outscraper') return undefined;
+    // Someone already interviewed it; don't steal their link.
+    if (lead.submissionId) return undefined;
+    // Already ported to the new prospects pool — linking here would leave its
+    // twin 'available' and leak the business back onto Discover.
+    if ((lead as any).migratedToProspectId) return undefined;
+    return leadId;
+}
+
+/**
  * Create a new submission
  */
 export const create = mutation({
@@ -313,6 +340,10 @@ export const create = mutation({
             v.literal('completed'),
             v.literal('website_generated')
         )),
+        // Set when this interview was started from a scraped prospect
+        // (/submit/info?prospectLeadId=…). Validated server-side; an
+        // unusable id is silently dropped rather than failing the create.
+        prospectLeadId: v.optional(v.id('leads')),
     },
     handler: async (ctx, args) => {
         const submissionId = await ctx.db.insert('submissions', {
@@ -336,6 +367,7 @@ export const create = mutation({
             status: args.status ?? 'draft',
             amount: args.amount ?? STANDARD_PRICE,
             creatorPayout: args.creatorPayout ?? commissionFor(BASE_PRICE),
+            prospectLeadId: await resolveProspectLead(ctx, args.prospectLeadId),
         });
 
         // Increment creator's submissionCount and lastActiveAt
@@ -389,14 +421,29 @@ export const update = mutation({
         amount: v.optional(v.number()),
         creatorPayout: v.optional(v.number()),
         platformFee: v.optional(v.number()),
+        // See create(). Set-once — never re-pointed or cleared here.
+        prospectLeadId: v.optional(v.id('leads')),
     },
     handler: async (ctx, args) => {
-        const { id, ...updates } = args;
+        // prospectLeadId is pulled out of the generic spread deliberately: it
+        // needs validation, and letting it flow through filteredUpdates would
+        // let a re-entry silently re-point an in-progress interview at a
+        // different business.
+        const { id, prospectLeadId, ...updates } = args;
 
         // Filter out undefined values
-        const filteredUpdates = Object.fromEntries(
+        const filteredUpdates: Record<string, unknown> = Object.fromEntries(
             Object.entries(updates).filter(([, value]) => value !== undefined)
         );
+
+        if (prospectLeadId) {
+            const existing = await ctx.db.get(id);
+            // Only ever SET the link — never overwrite one that's already there.
+            if (existing && !existing.prospectLeadId) {
+                const resolved = await resolveProspectLead(ctx, prospectLeadId);
+                if (resolved) filteredUpdates.prospectLeadId = resolved;
+            }
+        }
 
         await ctx.db.patch(id, filteredUpdates);
 
@@ -528,6 +575,11 @@ export const submit = mutation({
         const submission = await ctx.db.get(args.id);
         if (!submission) throw new Error('Submission not found');
 
+        // Idempotency. Without this a double-tap on the review page re-inserts
+        // the lead, double-fires both analytics increments, and re-triggers the
+        // Studio render. Applies to every submission, not just prospect ones.
+        if (submission.status !== 'draft') return;
+
         // Validate: at least 3 photos
         if (!submission.photos || submission.photos.length < 3) {
             throw new Error('At least 3 photos are required');
@@ -547,17 +599,56 @@ export const submit = mutation({
             airtableSyncStatus: 'pending_push',
         });
 
-        // 2. Create a lead record from business owner info
-        await ctx.db.insert('leads', {
-            submissionId: args.id,
-            creatorId: submission.creatorId,
-            source: 'direct',
-            name: submission.ownerName,
-            phone: submission.ownerPhone,
-            email: submission.ownerEmail,
-            status: 'new',
-            createdAt: Date.now(),
-        });
+        // 2. Link the interview to its source prospect, or create a fresh lead.
+        //
+        // When this interview started from a scraped Outscraper prospect we
+        // PATCH that existing row instead of inserting a second one. That's the
+        // whole point: one row per physical business. It also brings two
+        // already-written but permanently dead guards to life for the first
+        // time — claimProspect's "already been interviewed" check and the
+        // stale-claim cron's `submissionId === undefined` filter, which is what
+        // currently launders an interviewed prospect back into the pool at 24h.
+        let converted = false;
+        if (submission.prospectLeadId) {
+            const prospect = await ctx.db.get(submission.prospectLeadId);
+            if (prospect && prospect.source === 'outscraper') {
+                if (!prospect.submissionId) {
+                    await ctx.db.patch(prospect._id, {
+                        submissionId: args.id,
+                        // Credit the interviewer, not the scraper. outscraper.ts
+                        // always stamps the SCRAPER's creatorId on scraped rows,
+                        // so a `??` fallback would never fire and the business
+                        // would show under whoever ran the scrape.
+                        creatorId: submission.creatorId,
+                        status: 'converted',
+                        name: submission.ownerName,
+                        email: submission.ownerEmail,
+                        // phone deliberately left as the scraped listing number;
+                        // the owner's direct number is exposed separately as
+                        // ownerPhone through the submission join.
+                        claimedByCreatorId: undefined,
+                        claimedAt: undefined,
+                    });
+                    converted = true;
+                } else if (String(prospect.submissionId) === String(args.id)) {
+                    converted = true; // idempotent replay
+                }
+                // else: someone else converted it first. Fall through and create
+                // a normal lead — never destroy an interview already completed.
+            }
+        }
+        if (!converted) {
+            await ctx.db.insert('leads', {
+                submissionId: args.id,
+                creatorId: submission.creatorId,
+                source: 'direct',
+                name: submission.ownerName,
+                phone: submission.ownerPhone,
+                email: submission.ownerEmail,
+                status: 'new',
+                createdAt: Date.now(),
+            });
+        }
 
         // 3. Increment analytics (daily + monthly)
         const today = new Date().toISOString().split('T')[0];

--- a/lib/prospectPrefill.ts
+++ b/lib/prospectPrefill.ts
@@ -1,0 +1,77 @@
+/**
+ * Helpers for prefilling the interview flow from a scraped Outscraper prospect.
+ *
+ * Plain TS with no Convex imports so both the client form and (if ever needed)
+ * server code can use it. See app/submit/info/page.tsx, which reads the
+ * ?prospectLeadId=&businessName=&phone=&address=&city=&category= params that
+ * app/leads/[leadId]/page.tsx and app/leads/page.tsx build.
+ */
+
+/**
+ * The canonical business-type list. The step-1 <select> only accepts these
+ * exact literals, so anything mapped in must land on one of them.
+ */
+export const BUSINESS_TYPES = [
+    "Barber/Salon",
+    "Auto Shop",
+    "Spa/Massage",
+    "Restaurant",
+    "Clinic",
+    "Law Office",
+    "Craft/Producer",
+    "Other",
+] as const;
+
+/** First match wins, so put the more specific patterns first. */
+const CATEGORY_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+    [/law|attorney|legal|notar/, "Law Office"],
+    [/barber|salon|hair|nail|beauty/, "Barber/Salon"],
+    [/spa|massage|wellness/, "Spa/Massage"],
+    [/restaurant|cafe|coffee|food|bakery|eatery|carinderia/, "Restaurant"],
+    [/clinic|dental|dentist|medical|doctor|veterinar|pharmac/, "Clinic"],
+    [/auto|car repair|tire|vulcaniz|mechanic|motor/, "Auto Shop"],
+    [/craft|artisan|furniture|weav|pottery|producer/, "Craft/Producer"],
+];
+
+/**
+ * Map Outscraper's free-text category ("Personal injury attorney") onto one of
+ * BUSINESS_TYPES.
+ *
+ * Returns "" — not "Other" — when nothing matches. An unmatched category is a
+ * guess, and "Other" is a confidently wrong answer that quietly poisons
+ * categorisation; "" leaves the field on its placeholder and the existing
+ * `required` attribute makes the creator pick. One tap, no bad data.
+ */
+export function mapCategoryToBusinessType(category?: string | null): string {
+    if (!category) return "";
+    const c = category.toLowerCase();
+    for (const [pattern, type] of CATEGORY_PATTERNS) {
+        if (pattern.test(c)) return type;
+    }
+    return "";
+}
+
+/**
+ * Normalise a scraped phone to the 10 local digits the step-1 input expects.
+ *
+ * That input renders a static "+63" chip beside it, strips non-digits, and caps
+ * at 10 — so pasting "+63 917 123 4567" raw yields "6391712345", a silently
+ * wrong number. Drop the country code (or the trunk "0") and keep the last 10.
+ */
+export function toLocalPhDigits(raw?: string | null): string {
+    if (!raw) return "";
+    let digits = raw.replace(/\D/g, "");
+    if (digits.startsWith("63")) digits = digits.slice(2);
+    else if (digits.startsWith("0")) digits = digits.slice(1);
+    return digits.length >= 10 ? digits.slice(-10) : "";
+}
+
+/**
+ * Convex ids are 32-char base32. A Google place_id ("ChIJ…") or a hand-edited
+ * string is not, and would blow up the v.id('leads') validator server-side —
+ * crashing step 1 instead of degrading. Shape-check before sending.
+ * Mirrors looksLikeConvexId in app/leads/[leadId]/page.tsx.
+ */
+export function looksLikeConvexId(s: string | null | undefined): boolean {
+    return !!s && /^[0-9a-z]{20,40}$/.test(s);
+}


### PR DESCRIPTION
Interviewing a business found through Discover created a **brand-new entry** instead of attaching to the scraped record — reported against a real prospect (CPI Law Firm).

## What was broken

Four pieces of wiring were designed and never connected:

| Piece | State on `main` |
|---|---|
| `?prospectLeadId=` on the "Start interview" link | written in 2 places, **read nowhere** |
| `leads.submissionId` for a prospect | **never written** by any code path |
| `claimProspect`'s *"already been interviewed"* guard ([outscraper.ts:883](../blob/main/convex/outscraper.ts#L883)) | **dead** — depends on the above |
| stale-claim cron's `submissionId === undefined` filter ([outscraper.ts:1028](../blob/main/convex/outscraper.ts#L1028)) | **dead** — same |

`app/submit/info/page.tsx` had no `useSearchParams` at all, so every prefill param on that link was discarded and the creator retyped the business by hand, on a phone, standing in front of the owner.

**Net effect:** two `leads` rows for one physical business with no link between them; the scraped row untouched; the business still on the Prospects tab and the Discover map looking un-interviewed. 24h later the stale-claim cron released the claim — because it only releases prospects with no `submissionId` — so it looked completely untouched and a second creator could drive out and redo the same interview.

## The fix

`submissions.submit` now **patches** the source prospect (`submissionId`, `status: 'converted'`, interviewer credited, claim cleared) instead of inserting a duplicate lead. One row per physical business. The two dead guards above go live for the first time.

`resolveProspectLead` validates the incoming id server-side and **never throws** — a stale, already-converted, or hand-edited id degrades to a normal unlinked submission rather than blocking a creator who is standing in the shop. `update()` sets the link once and never re-points it. On a lost race, the second interview falls through to a normal lead: nobody loses work they already did.

Prefill needs two mappers ([lib/prospectPrefill.ts](lib/prospectPrefill.ts)) — Outscraper returns free text like *"Personal injury attorney"* while the step-1 `<select>` accepts only 8 fixed literals, and scraped phones arrive as `+63 917 123 4567` where the input renders a static `+63` chip and caps at 10 digits, so pasting raw would silently yield `6391712345`, a wrong number. An unmatched category returns `""` rather than `"Other"`, so the `required` attribute makes the creator pick instead of storing a confident guess.

## Two pre-existing bugs fixed on the way

Neither is prospect-specific:

- **`submissions.submit` had no idempotency guard.** A double-tap on review re-inserted the lead, double-counted daily *and* monthly analytics, and re-fired the Studio render. Now returns early on a non-draft.
- **The step-1 draft loader treated Convex's `undefined` loading state as "no draft"**, so a fast tap on Next created a second draft. Now gated on `=== undefined`, with the Next button disabled while loading.

## Product decisions (confirmed before implementing)

- **Draft collision prompts** — *"You have an unfinished interview for A. Continue that, or start fresh for B?"* — rather than silently renaming an unrelated draft, which once a prospect link exists would mark the **wrong** business interviewed. Neither draft is deleted.
- A converted prospect **leaves Prospects and appears under Interviewed**, so the creator doesn't lose sight of it.
- A re-interview is **allowed through quietly** as a normal standalone entry.
- **Only the legacy `leads` path is fixed.** The newer `prospects` pool has the identical missing wiring and will reproduce this bug once it becomes the primary Discover surface — deliberately out of scope, and its rows have no working detail page today anyway.

## Schema

One additive optional column: `submissions.prospectLeadId`. Every existing row stays valid, no backfill. Kept distinct from the existing `submissions.prospectId`, which is typed `v.id('prospects')` and physically cannot hold a `leads` id.

`prospectsMigration` skips already-interviewed leads — without that, the next backfill re-seeds a converted prospect into the new pool as `available` and resurrects this exact bug through the surface that is becoming primary.

## Testing

- `npx tsc --noEmit` — clean, exit 0
- Turbopack production compile — clean, no CSR-bailout from the new `useSearchParams` (it's wrapped in `Suspense`)
- Schema + functions pushed to the **dev** deployment (`diligent-ibex-454`)

⚠️ Full `npm run build` still cannot complete on this machine — it dies with `Error: kill EPERM` while collecting page data, the same pre-existing sandbox limit as PR #259. Compile and type-check both pass standalone. **Watch the Vercel preview build.**

Dev had zero scraped prospects (the real CPI Law Firm is in prod), so end-to-end was walked against a seeded stand-in row. Prod needs its own `convex deploy` when this merges.

## Note for the mobile side

All changes are additive, so nothing breaks. But until the APK also sends `prospectLeadId`, mobile-originated interviews will keep orphaning prospects — and businesses converted on web will now disappear from the mobile discover map.
