### PR TITLE
fix(kb): stop the chatbot answer being cut off mid-sentence

### DIFF
--- a/convex/knowledgeAI.ts
+++ b/convex/knowledgeAI.ts
@@ -54,6 +54,16 @@ function genModelChain(): string[] {
 }
 const EMBED_DIMS = 768;
 
+// Ceiling for a generated answer. Deliberately far above what a 2-4 sentence
+// grounded answer needs (~200 tokens): the strongest models in the chain
+// (gemini-3.5-flash, gemini-2.5-flash) are THINKING models whose internal
+// reasoning is billed against maxOutputTokens BEFORE any visible text. At the
+// old 700 cap, thinking could eat most of the budget and the answer came back
+// truncated mid-sentence. The SYSTEM_INSTRUCTION — not this ceiling — keeps
+// answers short; this just guarantees the visible answer is never cut off.
+// Override with KB_GEN_MAX_OUTPUT_TOKENS if a future model needs more headroom.
+const GEN_MAX_OUTPUT_TOKENS = () => Number(process.env.KB_GEN_MAX_OUTPUT_TOKENS) || 2048;
+
 // Minimum cosine similarity for a vector-fallback hit to count as a GENUINE match
 // (vs a low-relevance nearest-neighbour). Below this, retrieval reports
 // matched=false so the question can escalate. Tunable via KB_VECTOR_MATCH_THRESHOLD.
@@ -165,7 +175,7 @@ async function geminiGenerate(
         body: JSON.stringify({
             systemInstruction: { parts: [{ text: systemInstruction }] },
             contents,
-            generationConfig: { temperature: 0.2, maxOutputTokens: 700, topP: 0.9 },
+            generationConfig: { temperature: 0.2, maxOutputTokens: GEN_MAX_OUTPUT_TOKENS(), topP: 0.9 },
         }),
     });
     if (!res.ok) throw geminiError('generate', res.status, await res.text().catch(() => ''));
@@ -205,7 +215,7 @@ async function agentGenerate(
             system: systemInstruction,
             messages,
             temperature: 0.2,
-            maxOutputTokens: 700,
+            maxOutputTokens: GEN_MAX_OUTPUT_TOKENS(),
             topP: 0.9,
         },
         {


### PR DESCRIPTION
## What

The Help Center chatbot (`knowledgeAI.ask` → landing `ChatBot`) was truncating answers **mid-sentence** — e.g. asking "Can you show me the process?" cut off at *"…visits your business for a 3"*.

## Root cause

Answer generation was capped at `maxOutputTokens: 700`. The model chain leads with **thinking models** (`gemini-3.5-flash`, `gemini-2.5-flash`) whose internal reasoning is billed against `maxOutputTokens` **before** any visible text. On those models the thinking budget could swallow most of the 700-token allowance, leaving the visible answer to be cut off. The non-thinking floor model (`gemini-2.0-flash`) didn't show it — which is why it was intermittent.

## Fix

Raise the ceiling to **2048** (env-overridable via `KB_GEN_MAX_OUTPUT_TOKENS`), applied in **both** generation paths so it holds regardless of the `KB_USE_AGENT` flag:
- `geminiGenerate` (raw-fetch REST path)
- `agentGenerate` (`@convex-dev/agent` path)

Answer *length* is still governed by the system instruction (2–4 sentences); this only guarantees the visible answer is never truncated. Uses the same `() => Number(process.env.X) || default` idiom already used by `vectorMatchThreshold` / `EMBED_MODEL` in the same file.

I deliberately did **not** disable thinking via `thinkingConfig.thinkingBudget: 0` — the floor model `gemini-2.0-flash` rejects it, which would silently knock models out of the fallback chain. Raising the cap is cross-model safe.

## Testing

- `tsc --noEmit` clean across the project.
- Deployed to the dev deployment and ran the exact reported query. It now returns the full 4-step answer with citations, ending cleanly — generated by `gemini-3.5-flash` (the same thinking model that was truncating) on the `@convex-dev/agent` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
