### PR TITLE
feat(kb): let the Field Coach escalate through Tendso's Knowledge Hub

### DIFF
--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -110,6 +110,10 @@ export const createAndPost = internalAction({
         question: v.string(),
         workspace: workspaceArg,
         askerUserId: v.optional(v.string()),
+        // Where the question came from, for the team's context in Discord. 'coach'
+        // = owner-engine's Field Coach forwarded it after its own KB miss; absent
+        // = the web/chat Knowledge Hub. Purely cosmetic (labels the post).
+        origin: v.optional(v.union(v.literal('web'), v.literal('coach'))),
     },
     handler: async (ctx, args) => {
         const normalizedQuestion = normalizeQuestion(args.question);
@@ -146,12 +150,13 @@ export const createAndPost = internalAction({
 
         try {
             // 1) Post the question to the role-scoped channel.
+            const originLabel = args.origin === 'coach' ? ' (via the Field Coach)' : '';
             const msgRes = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
                 method: 'POST',
                 headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     content:
-                        `❓ **Unanswered question from the Knowledge Hub**\n\n>>> ${args.question}\n\n` +
+                        `❓ **Unanswered question from the Knowledge Hub${originLabel}**\n\n>>> ${args.question}\n\n` +
                         `_Reply in this thread with the answer — the bot will add it to the knowledge base._`,
                     allowed_mentions: { parse: [] },
                 }),

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -289,4 +289,82 @@ http.route({
     }),
 });
 
+// POST /kb/ask
+// Full Knowledge Hub answer for external bots (owner-engine's Field Coach). Runs
+// the SAME RAG the web Knowledge Hub uses — retrieval + Gemini generation over the
+// requested workspace — and, when the KB genuinely can't answer, fires the exact
+// same Discord escalation loop the web ask() uses (post → thread → re-ping →
+// learn-back). Secret-gated (x-kb-secret vs KB_SEARCH_SECRET, same as /kb/search).
+//
+// Body: { question: string, workspace?: 'help' | 'wiki' (default 'wiki'), discordUserId?: string }
+// Reply: { answer, answered, grounded, sources, escalated }
+//   answered=false  → the KB had no answer (and we escalated if enabled)
+//   escalated=true  → an escalation was scheduled (respects KB_ESCALATION_ENABLED)
+http.route({
+    path: '/kb/ask',
+    method: 'POST',
+    handler: httpAction(async (ctx, request) => {
+        const secret = request.headers.get('x-kb-secret');
+        const expected = process.env.KB_SEARCH_SECRET;
+        if (!expected || !secret || secret !== expected) {
+            return jsonResponse({ error: 'unauthorized' }, 401);
+        }
+
+        let body: { question?: unknown; workspace?: unknown; discordUserId?: unknown };
+        try {
+            body = await request.json();
+        } catch {
+            return jsonResponse({ error: 'question required' }, 400);
+        }
+
+        const question = typeof body.question === 'string' ? body.question.trim() : '';
+        if (!question) {
+            return jsonResponse({ error: 'question required' }, 400);
+        }
+        // Field-agent questions default to the internal 'wiki'; 'help' is the public
+        // Help Center. Anything else falls back to 'wiki'.
+        const workspace = body.workspace === 'help' ? 'help' : 'wiki';
+        const discordUserId = typeof body.discordUserId === 'string' ? body.discordUserId : undefined;
+
+        const started = Date.now();
+        const result = await ctx.runAction(internal.knowledgeAI.answerQuery, {
+            query: question,
+            workspace,
+            source: 'discord',
+            discordUserId,
+        });
+
+        // Escalate on a genuine content gap (never on a transient generation outage —
+        // runRag keeps answered=true in that case). Reuses the web Knowledge Hub's
+        // loop; createAndPost then dedups + drops off-topic questions on its own.
+        const escalationFlag = process.env.KB_ESCALATION_ENABLED;
+        const escalationEnabled = escalationFlag === '1' || escalationFlag === 'true';
+        let escalated = false;
+        if (!result.answered && escalationEnabled) {
+            escalated = true;
+            await ctx.scheduler.runAfter(0, internal.escalations.createAndPost, {
+                question: question.slice(0, 500),
+                workspace,
+                origin: 'coach',
+            });
+        }
+
+        console.log(
+            `[KB-ASK] len=${question.length} ws=${workspace} answered=${result.answered} ` +
+            `grounded=${result.grounded} escalated=${escalated} ms=${Date.now() - started}`,
+        );
+
+        return jsonResponse(
+            {
+                answer: result.answer,
+                answered: result.answered,
+                grounded: result.grounded,
+                sources: result.sources,
+                escalated,
+            },
+            200,
+        );
+    }),
+});
+
 export default http;


### PR DESCRIPTION
## What
Adds `POST /kb/ask` — a secret-gated endpoint that lets owner-engine's Discord **Field Coach** defer a KB miss to Tendso's *full* Knowledge Hub brain (internal wiki + Gemini generation), not just the read-only `/kb/search`. When Tendso also can't answer, it fires the **existing** Discord escalation loop (`createAndPost` → post → thread → re-ping → learn-back).

## Flow
```
Discord member → coach → (coach's own KB miss) → POST /kb/ask (this PR)
   Tendso runs full RAG:
     ├─ knows it  → returns answer → coach relays it to the member
     └─ doesn't   → Tendso posts the escalation to the team channel
```

## Changes
- **`convex/http.ts`** — new `POST /kb/ask`, gated by `x-kb-secret` vs `KB_SEARCH_SECRET` (same secret as `/kb/search`). Runs `answerQuery`; on a genuine content gap (`answered === false`) and when `KB_ESCALATION_ENABLED`, schedules `escalations.createAndPost`. Defaults to the internal `wiki` workspace.
- **`convex/escalations.ts`** — optional `origin` on `createAndPost` so coach-sourced questions post as *"Unanswered question from the Knowledge Hub (via the Field Coach)"*.

## Config
No new env vars — reuses `KB_SEARCH_SECRET`, `KB_ESCALATION_ENABLED`, `DISCORD_ESCALATION_CHANNEL_ID` (all already set on prod `energetic-panther-693`).

## Additive / safe
No existing behavior changed. `tsc --noEmit` clean. `/kb/ask` is a new route; `origin` is an optional arg (existing `ask()` callers unaffected).

## Deploy order
**Deploy this first.** Its sibling — DevFrmwrkd/owner-engine#PENDING — calls this endpoint. Until this ships, owner-engine's call 404s and gracefully degrades to the current "flagged for the team" reply (nothing breaks).

## Test
```bash
curl -s -X POST https://energetic-panther-693.convex.site/kb/ask \
  -H "x-kb-secret: <KB_SEARCH_SECRET>" -H "Content-Type: application/json" \
  -d '{"question":"how do agents get paid?"}'          # expect answered:true
curl -s -X POST https://energetic-panther-693.convex.site/kb/ask \
  -H "x-kb-secret: <KB_SEARCH_SECRET>" -H "Content-Type: application/json" \
  -d '{"question":"what is the wifi password at HQ"}'   # answered:false, escalated:true → check the channel
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)