### PR TITLE
feat(approvals): approve new creators from Discord with ✅/❌ reactions

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as aiKeys from "../aiKeys.js";
 import type * as airtable from "../airtable.js";
 import type * as analytics from "../analytics.js";
 import type * as analyticsJobs from "../analyticsJobs.js";
+import type * as approvals from "../approvals.js";
 import type * as auditLogs from "../auditLogs.js";
 import type * as businessOwners from "../businessOwners.js";
 import type * as creators from "../creators.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   airtable: typeof airtable;
   analytics: typeof analytics;
   analyticsJobs: typeof analyticsJobs;
+  approvals: typeof approvals;
   auditLogs: typeof auditLogs;
   businessOwners: typeof businessOwners;
   creators: typeof creators;

--- a/convex/approvals.ts
+++ b/convex/approvals.ts
@@ -1,0 +1,428 @@
+import { v } from 'convex/values';
+import { internalAction, internalMutation, internalQuery } from './_generated/server';
+import { internal } from './_generated/api';
+import type { Doc, Id } from './_generated/dataModel';
+
+/**
+ * Discord "new creator approval" loop.
+ *
+ * Mirrors the Knowledge-Hub escalation loop (convex/escalations.ts) but for
+ * creator sign-ups: when a field agent passes onboarding and is awaiting admin
+ * approval (quizPassedAt set, not yet certified/rejected), the bot posts them to
+ * the #pending-approvals channel with ✅ and ❌ reactions. A team member reacts,
+ * and the poll cron reads the reactions and certifies (✅) or rejects (❌) the
+ * creator — the same effect as the admin dashboard's Approve/Reject buttons
+ * (see creators.approveCreatorInternal / rejectCreatorInternal).
+ *
+ * Serverless, no gateway: reactions are POLLED via the REST API with the bot
+ * token, because Discord does NOT deliver MESSAGE_REACTION_ADD events to
+ * interaction webhooks — they require a persistent gateway connection.
+ *
+ * SECURITY: reacting approves/denies a REAL creator. Two gates:
+ *   1. Discord channel permissions — #pending-approvals MUST be visible/reactable
+ *      only to trusted team members.
+ *   2. OPTIONAL role gate — if BOTH DISCORD_APPROVALS_ROLE_ID and DISCORD_GUILD_ID
+ *      are set, only reactors who hold that role are honored (others are ignored).
+ *      If unset, every non-bot reactor in the channel counts.
+ *
+ * Env: DISCORD_BOT_TOKEN (reused), DISCORD_PENDING_APPROVALS_CHANNEL_ID (the new
+ * channel), DISCORD_APPROVALS_ENABLED (feature flag; default OFF),
+ * DISCORD_APPROVALS_ROLE_ID (optional — pinged on each post; also the role gate
+ * when DISCORD_GUILD_ID is set), DISCORD_GUILD_ID (optional — enables the gate).
+ */
+
+const DISCORD_API = 'https://discord.com/api/v10';
+const APPROVE_EMOJI = '✅';
+const DENY_EMOJI = '❌';
+// Stop polling a post nobody resolved after this long. The creator stays pending
+// in the dashboard; we just stop hitting Discord for it (safety backstop).
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+// A claimed row whose message never actually posted (action crashed between the
+// claim and the POST) is cleaned up after this long so the creator can re-post.
+const STALE_NO_MESSAGE_MS = 10 * 60 * 1000;
+
+const approvalsEnabled = () => {
+    const f = process.env.DISCORD_APPROVALS_ENABLED;
+    return f === '1' || f === 'true';
+};
+
+function displayName(creator: Pick<Doc<'creators'>, 'firstName' | 'lastName' | 'email'>): string {
+    return [creator.firstName, creator.lastName].filter(Boolean).join(' ') || creator.email || 'creator';
+}
+
+// ── DB helpers ──────────────────────────────────────────────────────
+
+/**
+ * Atomic dedup + claim: insert a fresh 'pending' row and return its id, UNLESS
+ * an OPEN (pending/conflict) row already exists for this creator, in which case
+ * return null. Doing the check + insert in one mutation (not a query then a
+ * separate insert) prevents two overlapping poll runs from double-posting.
+ */
+export const claimForPost = internalMutation({
+    args: { creatorId: v.id('creators'), quizPassedAt: v.number() },
+    handler: async (ctx, args): Promise<Id<'approvalRequests'> | null> => {
+        const rows = await ctx.db
+            .query('approvalRequests')
+            .withIndex('by_creator', (q) => q.eq('creatorId', args.creatorId))
+            .collect();
+        // Already handled THIS pending episode (any status — pending, resolved,
+        // expired, or errored) → don't re-post. Keying on quizPassedAt (not just
+        // 'open' statuses) means a deleted/expired post stays retired, while a
+        // re-certification (fresh quizPassedAt) has no matching row and re-posts.
+        if (rows.some((r) => r.quizPassedAt === args.quizPassedAt)) return null;
+        const now = Date.now();
+        return await ctx.db.insert('approvalRequests', {
+            creatorId: args.creatorId,
+            quizPassedAt: args.quizPassedAt,
+            status: 'pending',
+            createdAt: now,
+            updatedAt: now,
+        });
+    },
+});
+
+export const patchApproval = internalMutation({
+    args: {
+        id: v.id('approvalRequests'),
+        status: v.optional(
+            v.union(
+                v.literal('pending'),
+                v.literal('approved'),
+                v.literal('denied'),
+                v.literal('conflict'),
+                v.literal('expired'),
+                v.literal('error'),
+            ),
+        ),
+        discordChannelId: v.optional(v.string()),
+        discordMessageId: v.optional(v.string()),
+        resolvedBy: v.optional(v.string()),
+        resolvedAt: v.optional(v.number()),
+        error: v.optional(v.string()),
+        lastPolledAt: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const { id, ...rest } = args;
+        await ctx.db.patch(id, { ...rest, updatedAt: Date.now() });
+    },
+});
+
+/** All still-pending rows (with OR without a messageId — the poller handles both). */
+export const listOpen = internalQuery({
+    args: {},
+    handler: async (ctx) => {
+        return await ctx.db
+            .query('approvalRequests')
+            .withIndex('by_status', (q) => q.eq('status', 'pending'))
+            .collect();
+    },
+});
+
+/** Creators awaiting approval (quiz passed, not certified/rejected/deleted). */
+export const listPendingCreators = internalQuery({
+    args: {},
+    handler: async (ctx) => {
+        const all = await ctx.db.query('creators').collect();
+        return all
+            .filter((c) => c.quizPassedAt && !c.certifiedAt && !c.rejectedAt && !c.isDeleted)
+            .map((c) => ({ _id: c._id }));
+    },
+});
+
+// ── Discord REST ────────────────────────────────────────────────────
+
+function botHeaders(botToken: string) {
+    return { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' };
+}
+
+/**
+ * Users who reacted with `emoji` (up to 100). `gone` is true when the message or
+ * channel is 404/403 (deleted or access lost) so the caller can retire the row
+ * instead of throwing + re-polling forever. Bot accounts carry `bot: true`.
+ */
+async function getReactors(
+    channelId: string,
+    messageId: string,
+    emoji: string,
+    botToken: string,
+): Promise<{ users: Array<{ id: string; bot?: boolean }>; gone: boolean }> {
+    const res = await fetch(
+        `${DISCORD_API}/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}?limit=100`,
+        { headers: { Authorization: `Bot ${botToken}` } },
+    );
+    if (res.status === 404 || res.status === 403) return { users: [], gone: true };
+    if (!res.ok) throw new Error(`get reactions ${emoji} failed (${res.status})`);
+    return { users: (await res.json()) as Array<{ id: string; bot?: boolean }>, gone: false };
+}
+
+/** Does this Discord user hold the approvals role? Only called when gating is on. */
+async function reactorHasRole(guildId: string, userId: string, roleId: string, botToken: string): Promise<boolean> {
+    try {
+        const res = await fetch(`${DISCORD_API}/guilds/${guildId}/members/${userId}`, {
+            headers: { Authorization: `Bot ${botToken}` },
+        });
+        if (!res.ok) {
+            // 403/401 means the bot can't read members at all — the gate then
+            // fails closed for EVERYONE and decisions silently stall. Surface it.
+            if (res.status === 401 || res.status === 403) {
+                console.warn(`[APPROVALS] role gate can't read guild members (${res.status}) — check the bot is in the guild; approvals will stall`);
+            }
+            return false;
+        }
+        const member = (await res.json()) as { roles?: string[] };
+        return Array.isArray(member.roles) && member.roles.includes(roleId);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Non-bot reactor ids allowed to DECIDE. If DISCORD_APPROVALS_ROLE_ID and
+ * DISCORD_GUILD_ID are both set, only reactors holding that role are kept;
+ * otherwise every non-bot reactor counts (channel permissions are the gate).
+ */
+async function authorizedReactorIds(
+    reactors: Array<{ id: string; bot?: boolean }>,
+    botToken: string,
+): Promise<string[]> {
+    const humans = reactors.filter((u) => !u.bot).map((u) => u.id);
+    const roleId = process.env.DISCORD_APPROVALS_ROLE_ID;
+    const guildId = process.env.DISCORD_GUILD_ID;
+    if (!roleId || !guildId) return humans; // channel-permissions-only
+    const allowed: string[] = [];
+    for (const id of humans) {
+        if (await reactorHasRole(guildId, id, roleId, botToken)) allowed.push(id);
+    }
+    return allowed;
+}
+
+async function editMessage(channelId: string, messageId: string, content: string, botToken: string): Promise<void> {
+    await fetch(`${DISCORD_API}/channels/${channelId}/messages/${messageId}`, {
+        method: 'PATCH',
+        headers: botHeaders(botToken),
+        body: JSON.stringify({ content, allowed_mentions: { parse: [] } }),
+    }).catch(() => {});
+}
+
+// ── createAndPost ───────────────────────────────────────────────────
+
+/**
+ * Record + post one pending creator to #pending-approvals and seed the ✅/❌
+ * reactions. Atomically deduped so a still-pending creator is never posted twice.
+ */
+export const createAndPost = internalAction({
+    args: { creatorId: v.id('creators') },
+    handler: async (ctx, args) => {
+        if (!approvalsEnabled()) return;
+        const channelId = process.env.DISCORD_PENDING_APPROVALS_CHANNEL_ID;
+        const botToken = process.env.DISCORD_BOT_TOKEN;
+        // Don't record a row we can't post — a row with no message would block
+        // re-posting (dedup) yet never be pollable, stranding the creator.
+        if (!channelId || !botToken) {
+            console.warn('[APPROVALS] DISCORD_PENDING_APPROVALS_CHANNEL_ID/DISCORD_BOT_TOKEN not set — skipping post.');
+            return;
+        }
+
+        const creator = await ctx.runQuery(internal.creators.getByIdInternal, { id: args.creatorId });
+        if (!creator) return;
+        // Only post creators genuinely awaiting approval.
+        const quizPassedAt = creator.quizPassedAt;
+        if (!quizPassedAt || creator.certifiedAt || creator.rejectedAt || creator.isDeleted) return;
+
+        // Atomic dedup + claim — null means this pending episode was already posted.
+        const id = await ctx.runMutation(internal.approvals.claimForPost, { creatorId: args.creatorId, quizPassedAt });
+        if (!id) return;
+
+        try {
+            const name =
+                [creator.firstName, creator.middleName, creator.lastName].filter(Boolean).join(' ') ||
+                creator.email ||
+                'New creator';
+            const roleId = process.env.DISCORD_APPROVALS_ROLE_ID;
+            const siteUrl = (process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/$/, '');
+            const adminLink = siteUrl ? `\n🔗 ${siteUrl}/admin/creators/pending/${args.creatorId}` : '';
+            const referral = creator.referredByName ? `\n🤝 Referred by ${creator.referredByName}` : '';
+            const ping = roleId ? `<@&${roleId}> ` : '';
+
+            const content =
+                `${ping}🆕 **New creator awaiting approval**\n\n` +
+                `**${name}**\n` +
+                `📧 ${creator.email ?? '—'}\n` +
+                `📱 ${creator.phone ?? '—'}` +
+                referral +
+                adminLink +
+                `\n\nReact ${APPROVE_EMOJI} to **approve** · ${DENY_EMOJI} to **deny**.`;
+
+            const msgRes = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+                method: 'POST',
+                headers: botHeaders(botToken),
+                body: JSON.stringify({
+                    content,
+                    // Only ping the approvals role (never @everyone / arbitrary users).
+                    allowed_mentions: roleId ? { roles: [roleId] } : { parse: [] },
+                }),
+            });
+            if (!msgRes.ok) {
+                throw new Error(`post message failed (${msgRes.status}): ${(await msgRes.text().catch(() => '')).slice(0, 200)}`);
+            }
+            const msg = (await msgRes.json()) as { id: string };
+
+            // Save the message id IMMEDIATELY (before seeding reactions) so a
+            // later reaction-seed failure can never orphan a live message.
+            await ctx.runMutation(internal.approvals.patchApproval, {
+                id,
+                discordChannelId: channelId,
+                discordMessageId: msg.id,
+            });
+
+            // Seed the two reaction options — best-effort; a failed seed must not
+            // error the row (team members can still add the reaction themselves).
+            for (const emoji of [APPROVE_EMOJI, DENY_EMOJI]) {
+                await fetch(
+                    `${DISCORD_API}/channels/${channelId}/messages/${msg.id}/reactions/${encodeURIComponent(emoji)}/@me`,
+                    { method: 'PUT', headers: { Authorization: `Bot ${botToken}` } },
+                ).catch(() => {});
+            }
+            console.log('[APPROVALS] posted creator', args.creatorId, 'msg', msg.id);
+        } catch (err) {
+            console.error('[APPROVALS] post failed:', (err as Error).message);
+            await ctx.runMutation(internal.approvals.patchApproval, {
+                id,
+                status: 'error',
+                error: (err as Error).message,
+            });
+        }
+    },
+});
+
+// ── pollPending (cron) ──────────────────────────────────────────────
+
+/**
+ * Every couple of minutes (convex/crons.ts): (1) post any pending creator not yet
+ * posted, then (2) for each open post — close it if the creator was already
+ * resolved in the dashboard, expire it if it's too old, retire it if the message
+ * was deleted, else read ✅/❌ reactions and drive the approve/deny decision.
+ * No-op unless DISCORD_APPROVALS_ENABLED and the channel + bot token are set.
+ */
+export const pollPending = internalAction({
+    args: {},
+    handler: async (ctx) => {
+        if (!approvalsEnabled()) return;
+        const channelId = process.env.DISCORD_PENDING_APPROVALS_CHANNEL_ID;
+        const botToken = process.env.DISCORD_BOT_TOKEN;
+        if (!channelId || !botToken) return;
+
+        // 1) Reconcile — post pending creators not yet posted. Isolated so a scan
+        // failure can't break the reaction-polling half below.
+        try {
+            const pending = await ctx.runQuery(internal.approvals.listPendingCreators, {});
+            for (const c of pending) {
+                await ctx.runAction(internal.approvals.createAndPost, { creatorId: c._id });
+            }
+        } catch (err) {
+            console.error('[APPROVALS] reconcile failed:', (err as Error).message);
+        }
+
+        // 2) Poll reactions on open posts and act.
+        const open = await ctx.runQuery(internal.approvals.listOpen, {});
+        for (const req of open) {
+            try {
+                // A claimed row whose message never posted (crash window) — retire it.
+                if (!req.discordMessageId || !req.discordChannelId) {
+                    if (Date.now() - req.createdAt > STALE_NO_MESSAGE_MS) {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'error', error: 'post never completed' });
+                    }
+                    continue;
+                }
+                const chan = req.discordChannelId;
+                const msg = req.discordMessageId;
+
+                // Resolved in the admin dashboard (not via reaction) → close the row.
+                // Also retire if the creator was deleted after posting (a reaction
+                // must not certify a soft-deleted creator).
+                const creator = await ctx.runQuery(internal.creators.getByIdInternal, { id: req.creatorId });
+                if (!creator || creator.isDeleted) {
+                    await ctx.runMutation(internal.approvals.patchApproval, {
+                        id: req._id,
+                        status: 'error',
+                        error: creator ? 'creator deleted' : 'creator not found',
+                    });
+                    continue;
+                }
+                if (creator.certifiedAt) {
+                    await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'approved', resolvedAt: Date.now() });
+                    await editMessage(chan, msg, `✅ **Approved** — ${displayName(creator)} is now certified. (via dashboard)`, botToken);
+                    continue;
+                }
+                if (creator.rejectedAt) {
+                    await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'denied', resolvedAt: Date.now() });
+                    await editMessage(chan, msg, `❌ **Denied** — ${displayName(creator)}'s application was rejected. (via dashboard)`, botToken);
+                    continue;
+                }
+
+                // Backstop: stop polling posts nobody resolved (creator stays
+                // pending in the dashboard — this only retires the Discord post).
+                if (Date.now() - req.createdAt > MAX_AGE_MS) {
+                    await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'expired' });
+                    await editMessage(chan, msg, `⌛ This request expired — please resolve ${displayName(creator)} in the admin dashboard.`, botToken);
+                    continue;
+                }
+
+                // Read reactions.
+                const [aRes, dRes] = await Promise.all([
+                    getReactors(chan, msg, APPROVE_EMOJI, botToken),
+                    getReactors(chan, msg, DENY_EMOJI, botToken),
+                ]);
+                if (aRes.gone || dRes.gone) {
+                    // Message deleted / access lost — retire so we stop polling it.
+                    await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'error', error: 'message removed' });
+                    continue;
+                }
+                const approvers = await authorizedReactorIds(aRes.users, botToken);
+                const deniers = await authorizedReactorIds(dRes.users, botToken);
+
+                // Contested — don't guess; leave it for a human in the dashboard.
+                if (approvers.length && deniers.length) {
+                    await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'conflict', lastPolledAt: Date.now() });
+                    await editMessage(chan, msg, `⚠️ **Conflicting reactions** — please resolve this one in the admin dashboard.`, botToken);
+                    continue;
+                }
+
+                if (approvers.length) {
+                    const who = approvers[0];
+                    const r = await ctx.runMutation(internal.creators.approveCreatorInternal, { id: req.creatorId, approvedBy: who });
+                    if (r.outcome === 'approved' || r.outcome === 'already_approved') {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'approved', resolvedBy: who, resolvedAt: Date.now() });
+                        await editMessage(chan, msg, `✅ **Approved** — ${r.name} is now certified. (by <@${who}>)`, botToken);
+                    } else if (r.outcome === 'already_rejected') {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'denied', resolvedBy: who, resolvedAt: Date.now() });
+                        await editMessage(chan, msg, `❌ ${r.name} was already denied in the dashboard.`, botToken);
+                    } else {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'error', error: 'creator not found' });
+                    }
+                    continue;
+                }
+
+                if (deniers.length) {
+                    const who = deniers[0];
+                    const r = await ctx.runMutation(internal.creators.rejectCreatorInternal, { id: req.creatorId, rejectedBy: `discord:${who}` });
+                    if (r.outcome === 'rejected' || r.outcome === 'already_rejected') {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'denied', resolvedBy: who, resolvedAt: Date.now() });
+                        await editMessage(chan, msg, `❌ **Denied** — ${r.name}'s application was rejected. (by <@${who}>)`, botToken);
+                    } else if (r.outcome === 'already_approved') {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'approved', resolvedBy: who, resolvedAt: Date.now() });
+                        await editMessage(chan, msg, `✅ ${r.name} was already approved in the dashboard.`, botToken);
+                    } else {
+                        await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, status: 'error', error: 'creator not found' });
+                    }
+                    continue;
+                }
+
+                // No authorized reaction yet — just record that we looked.
+                await ctx.runMutation(internal.approvals.patchApproval, { id: req._id, lastPolledAt: Date.now() });
+            } catch (err) {
+                console.error('[APPROVALS] poll failed for', req._id, (err as Error).message);
+            }
+        }
+    },
+});

--- a/convex/creators.ts
+++ b/convex/creators.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { query, mutation, internalQuery } from './_generated/server';
+import { query, mutation, internalQuery, internalMutation } from './_generated/server';
 import { internal } from './_generated/api';
 
 // ==================== QUERIES ====================
@@ -551,6 +551,77 @@ export const rejectCreator = mutation({
                 : "Your application wasn't approved this time. You can retake the quiz or contact support.",
             data: { rejectedByAdmin: true },
         });
+    },
+});
+
+/**
+ * Internal approve — same effect as approveCreator (certifiedAt + "You're
+ * approved!" notification) but WITHOUT the Clerk admin gate, for trusted server
+ * callers (the Discord #pending-approvals reaction poller, convex/approvals.ts).
+ * A Discord bot has no Clerk session, so the public approveCreator is unreachable;
+ * trust here comes from the bot-token-gated cron. Idempotent and respects the
+ * certifiedAt/rejectedAt mutex. Returns the outcome + display name so the caller
+ * can report the result back in Discord.
+ */
+export const approveCreatorInternal = internalMutation({
+    args: { id: v.id('creators'), approvedBy: v.optional(v.string()) },
+    handler: async (
+        ctx,
+        args,
+    ): Promise<{ outcome: 'approved' | 'already_approved' | 'already_rejected' | 'not_found'; name: string }> => {
+        const creator = await ctx.db.get(args.id);
+        if (!creator) return { outcome: 'not_found', name: '' };
+        const name = [creator.firstName, creator.lastName].filter(Boolean).join(' ') || creator.email || 'creator';
+        if (creator.certifiedAt) return { outcome: 'already_approved', name };
+        if (creator.rejectedAt) return { outcome: 'already_rejected', name };
+
+        await ctx.db.patch(args.id, { certifiedAt: Date.now(), lastActiveAt: Date.now() });
+        await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+            creatorId: args.id,
+            type: 'certification' as const,
+            title: "You're approved!",
+            body: 'Welcome aboard. You can now submit businesses and earn from your interviews.',
+            data: { approvedByAdmin: true, approvedVia: 'discord', approvedBy: args.approvedBy },
+        });
+        return { outcome: 'approved', name };
+    },
+});
+
+/**
+ * Internal reject — same effect as rejectCreator (rejectedAt + optional reason +
+ * "Verification update" notification) but WITHOUT the Clerk admin gate, for the
+ * Discord reaction poller. Idempotent; refuses if already certified (mutex).
+ */
+export const rejectCreatorInternal = internalMutation({
+    args: { id: v.id('creators'), reason: v.optional(v.string()), rejectedBy: v.optional(v.string()) },
+    handler: async (
+        ctx,
+        args,
+    ): Promise<{ outcome: 'rejected' | 'already_rejected' | 'already_approved' | 'not_found'; name: string }> => {
+        const creator = await ctx.db.get(args.id);
+        if (!creator) return { outcome: 'not_found', name: '' };
+        const name = [creator.firstName, creator.lastName].filter(Boolean).join(' ') || creator.email || 'creator';
+        if (creator.rejectedAt) return { outcome: 'already_rejected', name };
+        if (creator.certifiedAt) return { outcome: 'already_approved', name };
+
+        const trimmed = args.reason?.trim();
+        await ctx.db.patch(args.id, {
+            rejectedAt: Date.now(),
+            rejectionReason: trimmed && trimmed.length > 0 ? trimmed.slice(0, 500) : undefined,
+            rejectedBy: args.rejectedBy,
+            lastActiveAt: Date.now(),
+        });
+        await ctx.scheduler.runAfter(0, internal.notifications.createAndSend, {
+            creatorId: args.id,
+            type: 'certification' as const,
+            title: 'Verification update',
+            body:
+                trimmed && trimmed.length > 0
+                    ? `Your application wasn't approved this time. Reason: ${trimmed}`
+                    : "Your application wasn't approved this time. You can retake the quiz or contact support.",
+            data: { rejectedByAdmin: true, rejectedVia: 'discord' },
+        });
+        return { outcome: 'rejected', name };
     },
 });
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -53,4 +53,14 @@ crons.interval(
     {},
 );
 
+// Every 2 minutes: post new creators awaiting approval to Discord's
+// #pending-approvals channel and read ✅/❌ reactions to certify/reject them.
+// No-op unless DISCORD_APPROVALS_ENABLED (and the channel + bot token are set).
+crons.interval(
+    'poll-pending-approvals',
+    { minutes: 2 },
+    internal.approvals.pollPending,
+    {},
+);
+
 export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1072,4 +1072,36 @@ export default defineSchema({
         .index('by_thread', ['discordThreadId'])
         .index('by_normalized', ['normalizedQuestion', 'status'])
         .index('by_createdAt', ['createdAt']),
+
+    // New creator sign-ups awaiting admin approval, mirrored into Discord's
+    // #pending-approvals channel where a ✅/❌ reaction certifies or rejects them.
+    // One row per posted creator; the poll cron (convex/crons.ts → approvals.pollPending)
+    // reads reactions and drives creators.approveCreatorInternal / rejectCreatorInternal.
+    approvalRequests: defineTable({
+        creatorId: v.id('creators'),
+        // The creator's quizPassedAt at post time — the "pending episode" key.
+        // Dedup is per-episode: a retired (expired/error/denied) row blocks
+        // re-posting the SAME episode, but a re-certification gives the creator a
+        // fresh quizPassedAt (no matching row) so it posts again.
+        quizPassedAt: v.number(),
+        status: v.union(
+            v.literal('pending'), // posted to Discord, awaiting a reaction
+            v.literal('approved'), // ✅ → creator certified
+            v.literal('denied'), // ❌ → creator rejected
+            v.literal('conflict'), // both ✅ and ❌ present — needs a human
+            v.literal('expired'), // no decision within the window — stop polling
+            v.literal('error'),
+        ),
+        discordChannelId: v.optional(v.string()),
+        discordMessageId: v.optional(v.string()),
+        resolvedBy: v.optional(v.string()), // Discord user id who reacted decisively
+        resolvedAt: v.optional(v.number()),
+        error: v.optional(v.string()),
+        lastPolledAt: v.optional(v.number()),
+        createdAt: v.number(),
+        updatedAt: v.number(),
+    })
+        .index('by_creator', ['creatorId'])
+        .index('by_status', ['status'])
+        .index('by_message', ['discordMessageId']),
 });


### PR DESCRIPTION
## What
Field agents currently can only be approved from the admin dashboard. This adds a Discord approval loop (mirroring the Knowledge-Hub escalation loop): when a creator passes onboarding and is **awaiting approval**, the bot posts them to a **#pending-approvals** channel with ✅ and ❌ reactions. A team member's ✅ **certifies** the creator, ❌ **rejects** them — the exact same effect as the dashboard Approve/Reject buttons.

Tendso is serverless with no Discord gateway, so reactions are **polled via the bot-token REST API** by a cron (no dependency on the dormant interactions webhook).

## Flow
```
creator passes quiz (awaiting approval)
   → cron posts them to #pending-approvals with ✅ / ❌
   → team member reacts
        ✅ → creators.approveCreatorInternal → certifiedAt + "You're approved!" notification
        ❌ → creators.rejectCreatorInternal → rejectedAt + "Verification update" notification
   → bot edits the message to show the outcome
```

## Changes
- **`convex/schema.ts`** — `approvalRequests` table. Per-episode dedup via `quizPassedAt` (a re-certification gets a fresh key → re-posts; a retired post does not).
- **`convex/creators.ts`** — `approveCreatorInternal` / `rejectCreatorInternal`: bot-callable (no Clerk gate, since a bot has no Clerk session), replicating the public mutations' exact side effects and the `certifiedAt`/`rejectedAt` mutex.
- **`convex/approvals.ts`** — `createAndPost` (atomic claim → post → seed reactions) and `pollPending` (reconcile un-posted pendings, read reactions, drive the decision; handle expiry, deleted messages, and dashboard resolution).
- **`convex/crons.ts`** — `poll-pending-approvals` every 2 min (no-op unless enabled).

## Security
Reacting approves/denies a real creator, so:
1. **#pending-approvals must be restricted** to trusted team members via Discord channel permissions.
2. **Optional role gate** — if `DISCORD_APPROVALS_ROLE_ID` **and** `DISCORD_GUILD_ID` are both set, only reactors holding that role are honored; otherwise every non-bot reactor counts. Ties (both ✅ and ❌) are left for manual dashboard resolution.

## Config (no-op until enabled)
```
DISCORD_PENDING_APPROVALS_CHANNEL_ID   the new channel
DISCORD_APPROVALS_ENABLED=1            feature flag (default off)
DISCORD_APPROVALS_ROLE_ID              optional — pings + gates approvers
DISCORD_GUILD_ID                       optional — enables the role gate
```
Reuses the existing `DISCORD_BOT_TOKEN`. The bot needs post/react (and, for the gate, read-members) access in that channel.

## Verification
Two adversarial review rounds. Confirmed: the bot's own seeded ✅/❌ are correctly ignored (`!u.bot`), so no auto-resolve. First round found + fixed an orphaned-message bug and a missing role gate; second round found + fixed a re-post loop (dedup now keys on `quizPassedAt`), a soft-deleted-creator guard, and a silent-stall warning. `tsc --noEmit` clean.

## Known, accepted limitations
- `listPendingCreators` full-scans creators every 2 min (fine at current scale; same as the escalation loop).
- A `conflict`/`expired` message's text isn't refreshed if the creator is later resolved in the dashboard (the creator resolves correctly; only the old message text is stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)