### PR TITLE
Put the answer's article slug on the question-answered notification

### DIFF
--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -231,7 +231,11 @@ export const claimForProcessing = internalMutation({
 
 /** Notify the original asker (a signed-in field agent) that their question was answered. */
 export const notifyAsker = internalMutation({
-    args: { askerUserId: v.string(), question: v.string(), answer: v.string() },
+    // articleSlug lets the mobile app deep-link the notification straight to the
+    // KB article the answer was captured as (handleNotificationPress routes on
+    // data.articleSlug). Optional so older callers / a missing article degrade
+    // to a non-linking notification rather than failing.
+    args: { askerUserId: v.string(), question: v.string(), answer: v.string(), articleSlug: v.optional(v.string()) },
     handler: async (ctx, args): Promise<boolean> => {
         const creator = await ctx.db
             .query('creators')
@@ -243,7 +247,7 @@ export const notifyAsker = internalMutation({
             type: 'system',
             title: 'Your question was answered',
             body: `${args.question}\n\n${args.answer.slice(0, 300)}`,
-            data: { kbEscalation: true },
+            data: { kbEscalation: true, articleSlug: args.articleSlug },
         });
         return true;
     },
@@ -360,6 +364,9 @@ export const pollPending = internalAction({
                         askerUserId: esc.askerUserId,
                         question: esc.question,
                         answer,
+                        // Same slug already resolved above for the Discord link —
+                        // lets the mobile notification open the captured article.
+                        articleSlug: savedArticle?.slug,
                     });
                 }
 


### PR DESCRIPTION
Backend half of "tapping an answered-question notification opens the KB answer."

## Why

When the escalation loop answers a creator's question, `notifyAsker` sends a notification with `data: { kbEscalation: true }` — **no identifier for the answer**. So the mobile app has nothing to route to, and the tap is a silent no-op.

## What

`pollPending` already resolves the captured article's slug for the Discord thread link (`savedArticle.slug`). This threads that same slug through `notifyAsker` onto the notification as **`data.articleSlug`**, so the mobile app can deep-link the tap to the KB article.

- `notifyAsker` gains an optional `articleSlug` arg → placed in `data`.
- `pollPending` passes `articleSlug: savedArticle?.slug` (already in scope).
- **No schema change** — `notifications.data` is `v.any()`, `type` stays `'system'`.
- Optional throughout, so a missing article just yields a non-linking notification (today's behaviour).

## Pairs with mobile
Mobile PR adds the `data.articleSlug` branch to `handleNotificationPress`. It no-ops until this deploys, so order is free — but the feature only works once **both** ship.

## To ship
```
npx convex deploy   # to production
```

## Verify after deploy
Ask a question that escalates → answer it → the asker's "Your question was answered" notification, tapped in the mobile app, opens the captured KB article.
