### PR TITLE
Fix deleted-account re-signup (skips exam, no name)

### DIFF
--- a/convex/creators.ts
+++ b/convex/creators.ts
@@ -23,10 +23,17 @@ export const count = query({
 export const getByClerkId = query({
     args: { clerkId: v.string() },
     handler: async (ctx, args) => {
-        return await ctx.db
+        const creator = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
             .unique();
+        // Treat a soft-deleted account as non-existent, so re-signing-in creates a
+        // fresh profile instead of resurrecting the old row. Returning the deleted
+        // row let a re-signed-in user land on the old (still certifiedAt, often
+        // nameless for Apple) record — skipping onboarding/the exam. Mirrors the
+        // mobile codegen copy, which already does this.
+        if (creator?.isDeleted) return null;
+        return creator;
     },
 });
 
@@ -182,9 +189,14 @@ export const getAllWithStats = query({
 export const create = mutation({
     args: {
         clerkId: v.string(),
-        firstName: v.string(),
+        // Optional: Sign in with Apple withholds the name on repeat authorizations
+        // (and for "Hide My Email"), so the app must be able to create a nameless
+        // creator. Was v.string(), which silently rejected those creates on the
+        // mobile home-screen safety net (the call is swallowed in a try/catch).
+        // The schema already allows nameless (firstName/lastName are v.optional).
+        firstName: v.optional(v.string()),
         middleName: v.optional(v.string()),
-        lastName: v.string(),
+        lastName: v.optional(v.string()),
         email: v.optional(v.string()),
         phone: v.optional(v.string()),
         referralCode: v.string(),
@@ -198,8 +210,20 @@ export const create = mutation({
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
             .unique();
 
-        if (existing) {
+        // A LIVE account already exists — reuse it.
+        if (existing && !existing.isDeleted) {
             return existing._id;
+        }
+
+        // A soft-deleted account exists for this clerkId (same Clerk user signed in
+        // again). Free the clerkId so the fresh row below owns it; the old row is
+        // left for its 30-day retention. Without this, `return existing._id` above
+        // resurrected the deleted (certified, often nameless) row and dropped the
+        // user past onboarding. Mirrors the mobile codegen copy.
+        if (existing?.isDeleted) {
+            await ctx.db.patch(existing._id, {
+                clerkId: `deleted_${existing._id}_${Date.now()}`,
+            });
         }
 
         const creatorId = await ctx.db.insert('creators', {


### PR DESCRIPTION
Delete your account, sign in with Apple again → you landed on Home with no name and couldn't take the exam. Root cause: two deployed `creators.*` functions diverged from the (correct) mobile codegen mirror.

## The two bugs

**1. `getByClerkId` returned soft-deleted rows.** It used `.unique()` with no `isDeleted` filter, so a re-signed-in user got back their **old deleted row** — which still has `certifiedAt` (soft delete doesn't clear it) and, for Apple, **no name**. The app treated the deleted account as a live, already-certified, nameless user → skipped onboarding. → now returns `null` for a soft-deleted row.

**2. `create` required a name AND reused deleted rows.**
- `firstName`/`lastName` were `v.string()` (required). Apple withholds the name on repeat auth / Hide My Email, so the home-screen safety-net create was **silently rejected** (it's in a try/catch) — a fresh nameless account couldn't be created. → made them `v.optional` (the schema already allows nameless).
- `if (existing) return existing._id` reused **any** row incl. soft-deleted. → now reuses only a **live** row; a soft-deleted row has its `clerkId` freed so a **fresh, uncertified** row is inserted and the user goes through onboarding.

## Notes

- Same `isDeleted`-aware logic the **mobile mirror already had** — the deployed web copy just never got it (same drift class as `deleteAccount` / `isDeletedByEmail`).
- **No schema change** — `firstName`/`lastName` are already `v.optional` on the creators table.
- Robust regardless of whether the Clerk user was actually deleted: a recurring `clerkId` gets its deleted row renamed and a fresh one inserted.

## To ship
```
npx convex deploy   # to production
```

## Pairs with mobile
Build #7's complete-profile gate then collects the name on the fresh nameless account. Web deploy fixes "skips the exam"; build #7 fixes "no name".

## ⚠️ Also worth checking (separate)
Whether the Clerk user is actually being deleted by the in-app flow (`user.delete()`). If the same `clerkId` recurs after "deletion," the Clerk credentials survived — a Guideline 5.1.1(v) concern independent of this fix (this fix makes the re-signup UX correct either way).

## Verify after deploy
Delete a certified account → sign in with Apple again → should land in onboarding (the exam), as a fresh account — not on Home.
