### PR TITLE
fix(templates): stop v03 image frames collapsing to the base plate floor

### DIFF
--- a/astro-site-template/src/components/autoshop/PageAF.astro
+++ b/astro-site-template/src/components/autoshop/PageAF.astro
@@ -147,7 +147,7 @@ const __fontHref = buildFontHref(__themePairing);
 
     /* Art-directed "plate" — brushed-steel gradient that stays as the designed
        fallback background of every data-image-field photo slot. */
-    html[data-page="AF"] .plate {
+    html[data-page="AF"] :where(.plate) {
       position: relative; overflow: hidden;
       background:
         linear-gradient(135deg, rgba(21,24,27,.85), rgba(42,47,52,.6)),

--- a/astro-site-template/src/components/education/PageAJ.astro
+++ b/astro-site-template/src/components/education/PageAJ.astro
@@ -135,7 +135,7 @@ const __fontHref = buildFontHref(__themePairing);
 
     /* Art-directed "plate" — the ink-bordered gradient slot that stays as the
        designed fallback background of every data-image-field photo slot. */
-    html[data-page="AJ"] .plate {
+    html[data-page="AJ"] :where(.plate) {
       position: relative; overflow: hidden; border: 2px solid var(--ink); border-radius: 8px;
       min-height: 230px; display: flex; align-items: flex-end; background:
         linear-gradient(150deg, rgba(32,48,77,.78), rgba(84,98,126,.45)),

--- a/astro-site-template/src/components/fitness/PageAI.astro
+++ b/astro-site-template/src/components/fitness/PageAI.astro
@@ -128,7 +128,7 @@ const __fontHref = buildFontHref(__themePairing);
 
     /* Wheat-paste halftone plate — the art-directed gradient that stays as the
        designed fallback of every data-image-field photo slot. */
-    html[data-page="AI"] .halftone {
+    html[data-page="AI"] :where(.halftone) {
       position: relative; overflow: hidden; border: 3px solid var(--ink);
       min-height: 240px; display: flex; align-items: flex-end;
       background:

--- a/astro-site-template/src/components/foodcraft/PageAL.astro
+++ b/astro-site-template/src/components/foodcraft/PageAL.astro
@@ -126,7 +126,7 @@ const __fontHref = buildFontHref(__themePairing);
     /* Arched window frame — the art-directed photo slot. Keeps its terracotta
        gradient as the designed fallback; a photo layers over it via
        data-image-field .photo. */
-    html[data-page="AL"] .arch {
+    html[data-page="AL"] :where(.arch) {
       position: relative; overflow: hidden;
       border-radius: 200px 200px 12px 12px; border: 2px solid var(--cocoa);
       min-height: 260px; display: flex; align-items: flex-end;

--- a/astro-site-template/src/components/medical/PageAH.astro
+++ b/astro-site-template/src/components/medical/PageAH.astro
@@ -120,7 +120,7 @@ const __fontHref = buildFontHref(__themePairing);
 
     /* Art-directed "plate" — the seafoam gradient that stays as the designed
        fallback background of every data-image-field photo slot. */
-    html[data-page="AH"] .plate {
+    html[data-page="AH"] :where(.plate) {
       position: relative; overflow: hidden;
       background: linear-gradient(155deg, #d8e7e0 10%, #9dc4b5 60%, #6fa693 100%);
       min-height: 240px; display: flex; align-items: flex-end;

--- a/astro-site-template/src/components/restaurant/PageAE.astro
+++ b/astro-site-template/src/components/restaurant/PageAE.astro
@@ -116,8 +116,12 @@ const __fontHref = buildFontHref(__themePairing);
     html[data-page="AE"] .btn.ghost:hover { border-color: var(--ember); color: var(--ember); }
 
     /* Art-directed "plate" — the gradient charcoal/ember texture that stays as
-       the designed fallback background of every data-image-field photo slot. */
-    html[data-page="AE"] .plate {
+       the designed fallback background of every data-image-field photo slot.
+       `:where(.plate)` keeps this scoped to the AE page but drops the class out of
+       the specificity sum, so per-section size modifiers (.about-plate / .gal-tile /
+       .loc-plate, Astro-scoped) win their designed min-height instead of being
+       pinned to this 220px floor. */
+    html[data-page="AE"] :where(.plate) {
       position: relative; overflow: hidden; background:
         linear-gradient(160deg, rgba(232,99,44,.55), rgba(25,20,18,.9) 70%),
         repeating-linear-gradient(45deg, #2b221d 0 6px, #241d19 6px 12px);

--- a/astro-site-template/src/components/retail/PageAG.astro
+++ b/astro-site-template/src/components/retail/PageAG.astro
@@ -130,7 +130,7 @@ const __fontHref = buildFontHref(__themePairing);
     /* Art-directed "plate" — the sepia newsprint-halftone photo slot; the
        red/ink gradient + dot texture stay as the designed fallback background
        of every data-image-field photo. */
-    html[data-page="AG"] .plate {
+    html[data-page="AG"] :where(.plate) {
       position: relative; overflow: hidden; border: 1px solid var(--ink);
       min-height: 230px; display: flex; align-items: flex-end; filter: sepia(.15);
       background:

--- a/astro-site-template/src/components/trades/PageAK.astro
+++ b/astro-site-template/src/components/trades/PageAK.astro
@@ -138,7 +138,7 @@ const __fontHref = buildFontHref(__themePairing);
 
     /* Art-directed cyanotype "plate" — the diagonal-hatch cyan texture that
        stays as the designed fallback background of every data-image-field slot. */
-    html[data-page="AK"] .plate {
+    html[data-page="AK"] :where(.plate) {
       position: relative; overflow: hidden; border: 2px solid var(--chalk);
       min-height: 230px; display: flex; align-items: flex-end;
       background:


### PR DESCRIPTION
## What
Fixes the image frames in all 8 v03 designs (merged in #270) collapsing to a short, wide band — photos rendered squished instead of at their designed heights.

## Why
Each design defines its photo-slot primitive in a `<style is:global>` block as `html[data-page="X"] .plate { min-height: … }` — specificity **(0,2,1)**. Each section (hero / about / gallery / location) rides that primitive and sets its *designed* height on a modifier class (`.about-plate`, `.gal-tile`, `.hero-plate`, `.loc-plate`, …) in its Astro-scoped `<style>`, which Astro emits as `.about-plate[data-astro-cid-…]` — specificity **(0,2,0)**. The base out-specified every modifier by one point, so all frames were pinned to the base ~220–260px floor.

## Fix
Wrap each base primitive's class in `:where()`:
```
html[data-page="X"] .plate { … }   →   html[data-page="X"] :where(.plate) { … }
```
This keeps the `html[data-page="X"]` page scope but drops the class from the specificity sum (→ **(0,1,1)**), so the section modifiers now win their designed heights.

- **8 files** — one `PageX` wrapper per design. Primitive: `.plate` (AE/AF/AG/AH/AJ/AK), `.halftone` (AI/fitness), `.arch` (AL/foodcraft).
- **No markup or content changes** — every `data-image-field` / `data-field` hook is untouched; all content stays editable in the admin editor.

## Verification
- Served CSS confirms all 8 base primitives dropped to (0,1,1) with section modifiers at (0,2,0) winning.
- 8-agent adversarial audit (one per design): every design `clean` — no remaining squashed frames, no regressions, CSS properties byte-identical apart from the selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
