### PR TITLE
feat(landing): "Get the app" download section

### DIFF
--- a/app/admin/app-release/page.tsx
+++ b/app/admin/app-release/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useAction, useMutation, useQuery } from "convex/react"
 import { api } from "@/convex/_generated/api"
 import { useAdminAuth } from "@/hooks/useAdmin"
@@ -23,6 +23,30 @@ export default function AppReleasePage() {
     const apkFileName = useQuery(api.settings.get, { key: "apk_file_name" }) as string | null
     const apkUploadedAt = useQuery(api.settings.get, { key: "apk_uploaded_at" }) as string | null
     const apkR2Key = useQuery(api.settings.get, { key: "apk_r2_key" }) as string | null
+
+    // Store-link settings (shown as App Store / Google Play buttons in the
+    // landing page "Get the app" section).
+    const savedAppStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null
+    const savedPlayStoreUrl = useQuery(api.settings.get, { key: "play_store_url" }) as string | null
+    const [appStoreUrl, setAppStoreUrl] = useState("")
+    const [playStoreUrl, setPlayStoreUrl] = useState("")
+    const [savingLinks, setSavingLinks] = useState(false)
+    const [linksSaved, setLinksSaved] = useState(false)
+    useEffect(() => { if (savedAppStoreUrl != null) setAppStoreUrl(savedAppStoreUrl) }, [savedAppStoreUrl])
+    useEffect(() => { if (savedPlayStoreUrl != null) setPlayStoreUrl(savedPlayStoreUrl) }, [savedPlayStoreUrl])
+
+    const handleSaveLinks = async () => {
+        setSavingLinks(true)
+        try {
+            const adminId = creator?._id ? String(creator._id) : undefined
+            await setSetting({ key: "app_store_url", value: appStoreUrl.trim() || null, description: "App Store listing URL", adminId })
+            await setSetting({ key: "play_store_url", value: playStoreUrl.trim() || null, description: "Google Play listing URL", adminId })
+            setLinksSaved(true)
+            setTimeout(() => setLinksSaved(false), 2500)
+        } finally {
+            setSavingLinks(false)
+        }
+    }
 
     const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0]
@@ -272,6 +296,42 @@ export default function AppReleasePage() {
                             {success}
                         </div>
                     )}
+                </div>
+
+                {/* Store Links — App Store + Google Play buttons on the landing page */}
+                <div className="bg-white rounded-2xl border border-amber-500 shadow-sm p-6 mt-6">
+                    <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider mb-1">Store links</h2>
+                    <p className="text-xs text-gray-500 mb-4">
+                        Shown as App Store + Google Play buttons in the landing page &quot;Get the app&quot; section.
+                        Leave a field blank to hide that button (Android falls back to the uploaded APK).
+                    </p>
+                    <label className="block mb-3">
+                        <span className="text-xs font-medium text-gray-600">App Store URL (iOS)</span>
+                        <input
+                            type="url"
+                            value={appStoreUrl}
+                            onChange={(e) => setAppStoreUrl(e.target.value)}
+                            placeholder="https://apps.apple.com/app/..."
+                            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                        />
+                    </label>
+                    <label className="block mb-4">
+                        <span className="text-xs font-medium text-gray-600">Google Play URL (Android)</span>
+                        <input
+                            type="url"
+                            value={playStoreUrl}
+                            onChange={(e) => setPlayStoreUrl(e.target.value)}
+                            placeholder="https://play.google.com/store/apps/details?id=..."
+                            className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                        />
+                    </label>
+                    <button
+                        onClick={handleSaveLinks}
+                        disabled={savingLinks}
+                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-500 hover:bg-amber-600 rounded-lg transition-colors disabled:opacity-50"
+                    >
+                        {savingLinks ? "Saving..." : linksSaved ? "Saved" : "Save links"}
+                    </button>
                 </div>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import ManifestoSection from "@/components/landing/ManifestoSection";
 import BusinessPricingSection from "@/components/landing/BusinessPricingSection";
 import EarningsSection from "@/components/landing/EarningsSection";
 import DirectorySection from "@/components/landing/DirectorySection";
+import AppDownloadSection from "@/components/landing/AppDownloadSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaSection from "@/components/landing/CtaSection";
 
@@ -37,6 +38,9 @@ export default function Home() {
             <main>
                 {/* Hero with counters + two doors */}
                 <HeroSection />
+
+                {/* Get the app — placed high as a priority to drive downloads */}
+                <AppDownloadSection />
 
                 {/* Live map (Convex listPublished → falls back to 4 known sites) */}
                 <ShowcaseSection

--- a/components/landing/AppDownloadSection.tsx
+++ b/components/landing/AppDownloadSection.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+/**
+ * AppDownloadSection — priority "Get the app" band (placed right after the
+ * hero to drive downloads).
+ *
+ * - Google Play links to the Tendso Android listing; an admin can override the
+ *   URL at /admin/app-release (setting `play_store_url`).
+ * - App Store shows "Coming soon" until an iOS build ships (set `app_store_url`
+ *   at /admin/app-release to turn it into a live download).
+ */
+
+const DEFAULT_PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.negosyodigital.app";
+
+function AppleGlyph() {
+    return (
+        <svg viewBox="0 0 384 512" width="24" height="24" fill="currentColor" aria-hidden="true">
+            <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z" />
+        </svg>
+    );
+}
+
+function PlayGlyph() {
+    return (
+        <svg viewBox="0 0 512 512" width="22" height="22" aria-hidden="true">
+            <path fill="#00d4ff" d="M48 59.49v393a4.33 4.33 0 0 0 7.37 3.07L260 256 55.37 56.42A4.33 4.33 0 0 0 48 59.49z" />
+            <path fill="#00f076" d="M345.8 174L89.62 32.61l-.09-.05c-4.66-2.55-9.25 3.71-5.42 7.42L281.4 231.85z" />
+            <path fill="#f43249" d="M84.11 471.94c-3.83 3.71.76 10 5.42 7.42l.09-.05L345.8 338l-64.4-57.9z" />
+            <path fill="#ffbd00" d="M449.66 231l-53.86-29.72-69.9 65.19 69.9 65.19L449.66 296c19.19-10.61 19.19-54.4 0-65z" />
+        </svg>
+    );
+}
+
+const btnBase: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 12,
+    minWidth: 220,
+    padding: "14px 26px",
+    borderRadius: 14,
+    textDecoration: "none",
+    transition: "transform .15s ease",
+};
+
+function StoreButton({ href, glyph, small, large }: { href: string; glyph: React.ReactNode; small: string; large: string }) {
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            style={{ ...btnBase, background: "var(--neo-paper)", color: "var(--neo-ink)", border: "1px solid var(--neo-paper)" }}
+        >
+            <span style={{ display: "inline-flex", flex: "0 0 auto" }}>{glyph}</span>
+            <span style={{ display: "flex", flexDirection: "column", textAlign: "left", lineHeight: 1.1 }}>
+                <span style={{ fontSize: 10.5, letterSpacing: ".05em", textTransform: "uppercase", opacity: 0.7 }}>{small}</span>
+                <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-.01em" }}>{large}</span>
+            </span>
+        </a>
+    );
+}
+
+/** Outlined, non-interactive badge for a store that isn't live yet. */
+function ComingSoonButton({ glyph, label }: { glyph: React.ReactNode; label: string }) {
+    return (
+        <span
+            aria-disabled="true"
+            title={`${label} — coming soon`}
+            style={{
+                ...btnBase,
+                background: "transparent",
+                color: "var(--neo-paper)",
+                border: "1px solid color-mix(in srgb, var(--neo-paper) 32%, transparent)",
+                opacity: 0.75,
+                cursor: "default",
+            }}
+        >
+            <span style={{ display: "inline-flex", flex: "0 0 auto" }}>{glyph}</span>
+            <span style={{ display: "flex", flexDirection: "column", textAlign: "left", lineHeight: 1.1 }}>
+                <span style={{ fontSize: 10.5, letterSpacing: ".05em", textTransform: "uppercase", opacity: 0.7 }}>Coming soon</span>
+                <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-.01em" }}>{label}</span>
+            </span>
+        </span>
+    );
+}
+
+export default function AppDownloadSection() {
+    const appStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null | undefined;
+    const playStoreUrl = useQuery(api.settings.get, { key: "play_store_url" }) as string | null | undefined;
+
+    const playHref = (playStoreUrl && playStoreUrl.trim()) || DEFAULT_PLAY_STORE_URL;
+    const appLive = !!(appStoreUrl && appStoreUrl.trim());
+
+    return (
+        <section style={{ position: "relative", background: "var(--neo-ink)", color: "var(--neo-paper)", padding: "clamp(96px, 12vw, 150px) 0", overflow: "hidden" }}>
+            {/* Accent glow behind the headline. */}
+            <div
+                aria-hidden="true"
+                style={{
+                    position: "absolute",
+                    top: "-25%",
+                    left: "50%",
+                    width: "min(1000px, 120%)",
+                    height: 620,
+                    transform: "translateX(-50%)",
+                    background: "radial-gradient(closest-side, color-mix(in srgb, var(--neo-creator) 20%, transparent), transparent)",
+                    pointerEvents: "none",
+                }}
+            />
+            <div className="container-wide" style={{ position: "relative", textAlign: "center" }}>
+                <div className="eyebrow" style={{ marginBottom: 22, color: "var(--neo-creator)" }}>Get the app</div>
+                <h2 className="display" style={{ fontSize: "clamp(52px, 8.5vw, 132px)", color: "var(--neo-paper)", lineHeight: 0.95 }}>
+                    Take Tendso
+                    <br />
+                    <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>with you.</em>
+                </h2>
+                <p className="lede" style={{ maxWidth: "48ch", margin: "28px auto 0", fontSize: 19, color: "oklch(82% 0.01 85)" }}>
+                    Get the Tendso app on your phone — available now on Android, with iOS on the way.
+                </p>
+
+                {/* Store buttons */}
+                <div style={{ display: "flex", gap: 16, justifyContent: "center", flexWrap: "wrap", marginTop: 44 }}>
+                    {appLive ? (
+                        <StoreButton href={appStoreUrl as string} glyph={<AppleGlyph />} small="Download on the" large="App Store" />
+                    ) : (
+                        <ComingSoonButton glyph={<AppleGlyph />} label="App Store" />
+                    )}
+                    <StoreButton href={playHref} glyph={<PlayGlyph />} small="Get it on" large="Google Play" />
+                </div>
+
+                <div style={{ marginTop: 22, fontSize: 11.5, letterSpacing: ".08em", textTransform: "uppercase", color: "oklch(66% 0.01 85)" }}>
+                    Available now on Android · iOS coming soon
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/components/landing/AppDownloadSection.tsx
+++ b/components/landing/AppDownloadSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { QRCodeSVG } from "qrcode.react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 
@@ -128,6 +129,16 @@ export default function AppDownloadSection() {
                         <ComingSoonButton glyph={<AppleGlyph />} label="App Store" />
                     )}
                     <StoreButton href={playHref} glyph={<PlayGlyph />} small="Get it on" large="Google Play" />
+                </div>
+
+                {/* QR to the Android listing — desktop only (on mobile you just tap the button). */}
+                <div className="hidden sm:flex" style={{ flexDirection: "column", alignItems: "center", gap: 11, marginTop: 44 }}>
+                    <div style={{ background: "#fff", padding: 12, borderRadius: 16, lineHeight: 0, boxShadow: "0 12px 36px -16px rgba(0,0,0,.55)" }}>
+                        <QRCodeSVG value={playHref} size={116} bgColor="#ffffff" fgColor="#111111" level="M" />
+                    </div>
+                    <span style={{ fontSize: 11.5, letterSpacing: ".08em", textTransform: "uppercase", color: "oklch(70% 0.01 85)" }}>
+                        Scan to install on Android
+                    </span>
                 </div>
 
                 <div style={{ marginTop: 22, fontSize: 11.5, letterSpacing: ".08em", textTransform: "uppercase", color: "oklch(66% 0.01 85)" }}>

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "convex/react";
-import { api } from "@/convex/_generated/api";
-import { Logo, ArrowUpRightIcon } from "./landingPrimitives";
+import { Logo } from "./landingPrimitives";
 import { useT, type Lang } from "./i18n";
 
 const selectStyle: React.CSSProperties = {
@@ -22,14 +20,6 @@ const selectStyle: React.CSSProperties = {
 
 export default function Navbar() {
     const { lang, setLang, t } = useT();
-    // Direct APK download URL (admin uploads via /admin/app-release).
-    // Falls back to /signup if no APK is currently uploaded. The URL points
-    // straight at the R2 public URL — R2 derives the download filename from
-    // the storage key (which the upload code pins to releases/tendso.apk),
-    // so no proxy route or Content-Disposition rewrite is needed.
-    const apkUrl = useQuery(api.settings.get, { key: "apk_download_url" }) as string | null | undefined;
-    const downloadHref = apkUrl ?? "/signup";
-    const isApk = !!apkUrl;
     return (
         <div className="topbar">
             <div
@@ -49,7 +39,8 @@ export default function Navbar() {
                     </div>
                 </div>
 
-                {/* Right cluster — language switch hides on phones, Get-the-app always visible */}
+                {/* Right cluster — language switch. (The "Get the app" button
+                    moved to the dedicated download section below the hero.) */}
                 <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
                     <select
                         value={lang}
@@ -61,19 +52,6 @@ export default function Navbar() {
                         <option value="en">EN</option>
                         <option value="tl">Tagalog</option>
                     </select>
-                    <a
-                        href={downloadHref}
-                        {...(isApk
-                            ? { download: "tendso.apk" }
-                            : {})}
-                        className="store-btn whitespace-nowrap"
-                        style={{ textDecoration: "none", padding: "10px 14px" }}
-                    >
-                        <span>{t("nav.getApp")}</span>
-                        <span style={{ opacity: 0.6 }}>
-                            <ArrowUpRightIcon />
-                        </span>
-                    </a>
                 </div>
             </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "nodemailer": "^7.0.12",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "19.2.3",
@@ -12911,6 +12912,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "nodemailer": "^7.0.12",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "19.2.3",


### PR DESCRIPTION
Adds a priority "Get the app" download band right below the hero to drive app installs.

## What's new
- **Google Play** button → the Tendso Android listing (`com.negosyodigital.app`); an admin can override the URL via the `play_store_url` setting.
- **App Store** button shows **"Coming soon"** until an iOS build ships — set `app_store_url` at `/admin/app-release` to make it a live download.
- **`/admin/app-release`** gains a "Store links" card (App Store URL + Google Play URL fields), following the existing APK-upload settings pattern.
- Removes the now-redundant "Get the app" button from the top navbar.

Dark, type-forward band matching the landing's neo aesthetic. Copy is availability-only (no feature claims).

## Verification
- Rebased onto latest `main`.
- `tsc --noEmit`: 0 source errors.
- Verified rendering on a local dev server (App Store "Coming soon", Google Play → the listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)