### PR TITLE
feat(landing): WordPress-informed, owner-first, data-true funnel redesign

### DIFF
--- a/app/admin/components/AdminLayout.tsx
+++ b/app/admin/components/AdminLayout.tsx
@@ -16,6 +16,7 @@ import {
     Download,
     Sparkles,
     FileText,
+    Star,
     LogOut,
     Menu,
     X,
@@ -52,6 +53,11 @@ const navItems = [
         label: "App Release",
         href: "/admin/app-release",
         icon: Download,
+    },
+    {
+        label: "Featured Sites",
+        href: "/admin/featured-sites",
+        icon: Star,
     },
     {
         label: "Train AI",

--- a/app/admin/featured-sites/page.tsx
+++ b/app/admin/featured-sites/page.tsx
@@ -1,0 +1,277 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useMutation, useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { useAdminAuth } from "@/hooks/useAdmin"
+import AdminLayout from "../components/AdminLayout"
+import { SHOWCASE_SITES } from "@/components/landing/landingData"
+
+/**
+ * Featured Sites — curation screen for the landing page "Real Sites" proof grid.
+ *
+ * The landing reads the Convex setting `featured_sites` (an array of
+ * {name, category, city, url}); if it's unset/empty it falls back to the
+ * hardcoded SHOWCASE_SITES. This page lets an admin hand-pick that list — add,
+ * edit, reorder, remove — without touching code or redeploying. Each card on
+ * the landing renders a LIVE preview of the site at its URL.
+ */
+
+type FeaturedSite = { name: string; category: string; city: string; url: string }
+
+const FEATURED_KEY = "featured_sites"
+
+// Editor starts pre-filled with what the landing already shows, so nothing
+// changes until an admin saves.
+const DEFAULTS: FeaturedSite[] = SHOWCASE_SITES.filter((s) => !!s.url).map((s) => ({
+    name: s.name,
+    category: s.category,
+    city: s.city,
+    url: s.url as string,
+}))
+
+export default function FeaturedSitesPage() {
+    const { isAdmin, loading: authLoading, creator } = useAdminAuth()
+    const saved = useQuery(api.settings.get, { key: FEATURED_KEY }) as
+        | FeaturedSite[]
+        | null
+        | undefined
+    const setSetting = useMutation(api.settings.set)
+
+    const [sites, setSites] = useState<FeaturedSite[]>([])
+    const [dirty, setDirty] = useState(false)
+    const [saving, setSaving] = useState(false)
+    const [savedFlash, setSavedFlash] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    // Seed the editor once the setting resolves (fall back to the hardcoded set).
+    useEffect(() => {
+        if (saved === undefined) return // still loading
+        setSites(Array.isArray(saved) && saved.length > 0 ? saved : DEFAULTS)
+    }, [saved])
+
+    const update = (i: number, patch: Partial<FeaturedSite>) => {
+        setSites((prev) => prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)))
+        setDirty(true)
+    }
+    const add = () => {
+        setSites((p) => [...p, { name: "", category: "", city: "", url: "" }])
+        setDirty(true)
+    }
+    const remove = (i: number) => {
+        setSites((p) => p.filter((_, idx) => idx !== i))
+        setDirty(true)
+    }
+    const move = (i: number, dir: -1 | 1) => {
+        setSites((p) => {
+            const j = i + dir
+            if (j < 0 || j >= p.length) return p
+            const next = [...p]
+            const tmp = next[i]
+            next[i] = next[j]
+            next[j] = tmp
+            return next
+        })
+        setDirty(true)
+    }
+
+    const handleSave = async () => {
+        setError(null)
+        const cleaned = sites
+            .map((s) => ({
+                name: s.name.trim(),
+                category: s.category.trim(),
+                city: s.city.trim(),
+                url: s.url.trim(),
+            }))
+            .filter((s) => s.name && s.url)
+        const badUrl = cleaned.find((s) => !/^https?:\/\//i.test(s.url))
+        if (badUrl) {
+            setError(`"${badUrl.name || "A site"}" needs a full URL starting with https://`)
+            return
+        }
+        setSaving(true)
+        try {
+            const adminId = creator?._id ? String(creator._id) : undefined
+            await setSetting({
+                key: FEATURED_KEY,
+                value: cleaned,
+                description: "Curated live sites shown in the landing 'Real Sites' proof grid",
+                adminId,
+            })
+            setSites(cleaned)
+            setDirty(false)
+            setSavedFlash(true)
+            setTimeout(() => setSavedFlash(false), 2500)
+        } catch (e: unknown) {
+            setError(e instanceof Error ? e.message : "Failed to save")
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    if (authLoading) {
+        return (
+            <AdminLayout>
+                <div className="flex items-center justify-center h-64">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-500" />
+                </div>
+            </AdminLayout>
+        )
+    }
+
+    if (!isAdmin) {
+        return (
+            <AdminLayout>
+                <div className="text-center py-20 text-gray-500">Access denied</div>
+            </AdminLayout>
+        )
+    }
+
+    return (
+        <AdminLayout>
+            <div className="max-w-3xl">
+                <h1 className="text-2xl font-bold text-gray-900 mb-1">Featured Sites</h1>
+                <p className="text-sm text-gray-500 mb-8">
+                    These real client sites appear in the &quot;Real Sites&quot; section of the landing page.
+                    Add, edit, reorder, or remove them here — each card shows a <strong>live preview</strong> of the
+                    site, so it&apos;s never out of date. Changes go live when you press <strong>Save</strong>.
+                </p>
+
+                <div className="space-y-4">
+                    {sites.map((s, i) => (
+                        <div key={i} className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5">
+                            <div className="flex items-center justify-between mb-4">
+                                <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                                    Site {i + 1}
+                                </span>
+                                <div className="flex items-center gap-1">
+                                    <button
+                                        onClick={() => move(i, -1)}
+                                        disabled={i === 0}
+                                        title="Move up"
+                                        className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent"
+                                    >
+                                        ↑
+                                    </button>
+                                    <button
+                                        onClick={() => move(i, 1)}
+                                        disabled={i === sites.length - 1}
+                                        title="Move down"
+                                        className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent"
+                                    >
+                                        ↓
+                                    </button>
+                                    <button
+                                        onClick={() => remove(i)}
+                                        title="Remove"
+                                        className="p-1.5 rounded-lg text-red-500 hover:bg-red-50"
+                                    >
+                                        ✕
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <label className="block sm:col-span-2">
+                                    <span className="text-xs font-medium text-gray-600">Live URL</span>
+                                    <div className="mt-1 flex items-center gap-2">
+                                        <input
+                                            type="url"
+                                            value={s.url}
+                                            onChange={(e) => update(i, { url: e.target.value })}
+                                            placeholder="https://example.com/"
+                                            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                                        />
+                                        {/^https?:\/\//i.test(s.url) && (
+                                            <a
+                                                href={s.url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="flex-shrink-0 text-xs font-medium text-amber-600 hover:underline"
+                                            >
+                                                Open ↗
+                                            </a>
+                                        )}
+                                    </div>
+                                </label>
+                                <label className="block">
+                                    <span className="text-xs font-medium text-gray-600">Business name</span>
+                                    <input
+                                        type="text"
+                                        value={s.name}
+                                        onChange={(e) => update(i, { name: e.target.value })}
+                                        placeholder="Ben-Joe Tire Supply"
+                                        className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                                    />
+                                </label>
+                                <label className="block">
+                                    <span className="text-xs font-medium text-gray-600">Category</span>
+                                    <input
+                                        type="text"
+                                        value={s.category}
+                                        onChange={(e) => update(i, { category: e.target.value })}
+                                        placeholder="Auto · Tire Supply"
+                                        className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                                    />
+                                </label>
+                                <label className="block sm:col-span-2">
+                                    <span className="text-xs font-medium text-gray-600">City</span>
+                                    <input
+                                        type="text"
+                                        value={s.city}
+                                        onChange={(e) => update(i, { city: e.target.value })}
+                                        placeholder="Makati"
+                                        className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <button
+                    onClick={add}
+                    className="mt-4 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                >
+                    + Add a site
+                </button>
+
+                {sites.length === 0 && (
+                    <div className="mt-4 p-4 bg-gray-50 border border-gray-100 rounded-lg text-sm text-gray-500">
+                        No featured sites. The landing page will fall back to the built-in default set until you add and save some.
+                    </div>
+                )}
+
+                {error && (
+                    <div className="mt-4 p-3 bg-red-50 border border-red-100 rounded-lg text-sm text-red-600">
+                        {error}
+                    </div>
+                )}
+
+                {/* Sticky action bar */}
+                <div className="sticky bottom-0 mt-8 -mx-4 px-4 py-4 bg-gradient-to-t from-[var(--ed-paper)] via-[var(--ed-paper)] to-transparent sm:mx-0 sm:px-0">
+                    <div className="flex items-center gap-3">
+                        <button
+                            onClick={handleSave}
+                            disabled={!dirty || saving}
+                            className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold text-white bg-amber-500 hover:bg-amber-600 rounded-lg transition-colors disabled:opacity-50"
+                        >
+                            {saving ? "Saving..." : savedFlash ? "Saved ✓" : "Save changes"}
+                        </button>
+                        <button
+                            onClick={() => {
+                                setSites(DEFAULTS)
+                                setDirty(true)
+                            }}
+                            className="text-sm font-medium text-gray-500 hover:text-gray-700"
+                        >
+                            Reset to defaults
+                        </button>
+                        {dirty && <span className="text-xs text-amber-600">Unsaved changes</span>}
+                    </div>
+                </div>
+            </div>
+        </AdminLayout>
+    )
+}

--- a/app/for-business/page.tsx
+++ b/app/for-business/page.tsx
@@ -2,185 +2,91 @@
 
 import Link from "next/link";
 
+import { LanguageProvider, useT } from "@/components/landing/i18n";
 import Navbar from "@/components/landing/Navbar";
 import Footer from "@/components/landing/Footer";
 import ScrollToTop from "@/components/landing/ScrollToTop";
+import ChatBot from "@/components/landing/ChatBot";
+import ScrollReveal from "@/components/landing/ScrollReveal";
 
-import ShowcaseSection from "@/components/landing/ShowcaseSection";
 import ProcessSection from "@/components/landing/ProcessSection";
+import RealSitesSection from "@/components/landing/RealSitesSection";
 import BusinessPricingSection from "@/components/landing/BusinessPricingSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaSection from "@/components/landing/CtaSection";
-import ChatBot from "@/components/landing/ChatBot";
+import { Eyebrow, Lead } from "@/components/landing/ui";
 
-import { ArrowUpRightIcon } from "@/components/landing/landingPrimitives";
-
-function PromiseBeat({
-    n,
-    big,
-    sub,
-    highlight,
-}: {
-    n: string;
-    big: string;
-    sub: string;
-    highlight?: boolean;
-}) {
+function Check() {
     return (
-        <div
-            style={{
-                padding: 20,
-                background: highlight ? "var(--neo-ink)" : "var(--neo-paper-3)",
-                color: highlight ? "var(--neo-paper)" : "var(--neo-ink)",
-                border: "1px solid " + (highlight ? "var(--neo-ink)" : "var(--neo-rule)"),
-                borderRadius: "var(--neo-r-md)",
-            }}
-        >
-            <div
-                className="label"
-                style={{ marginBottom: 8, color: highlight ? "oklch(72% 0.008 85)" : undefined }}
-            >
-                {n}
-            </div>
-            <div className="counter-num" style={{ fontSize: 36, lineHeight: 1.0, marginBottom: 8 }}>
-                {big}
-            </div>
-            <div style={{ fontSize: 12, color: highlight ? "oklch(80% 0.008 85)" : "var(--neo-ink-3)" }}>
-                {sub}
-            </div>
-        </div>
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-shrink-0" style={{ color: "var(--rust)" }}>
+            <path d="M20 6 9 17l-5-5" />
+        </svg>
     );
 }
 
+/**
+ * BusinessHero — owner-facing, WP style, data-true. No owner signup (CTAs are
+ * info anchors), no "48 hours" (48–72h), no "our subdomain" (that wildcard
+ * doesn't exist), no live-map. Reuses the home hero copy + the pricing standard
+ * features as the deliverables list.
+ */
 function BusinessHero() {
+    const { t } = useT();
+    const deliverables = [
+        t("price.stdF1"), t("price.stdF2"), t("price.stdF3"),
+        t("price.stdF4"), t("price.stdF5"), t("price.stdF6"),
+    ];
     return (
-        <section style={{ paddingTop: 56, paddingBottom: 48 }}>
-            <div className="container-wide">
-                <Link
-                    href="/"
-                    className="label"
-                    style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 8,
-                        marginBottom: 24,
-                        textDecoration: "none",
-                        color: "var(--neo-ink-3)",
-                    }}
-                >
-                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                        <path d="M9 1 L3 7 L9 13" stroke="currentColor" strokeWidth="1.4" />
-                    </svg>
-                    Back to landing
+        <section className="bg-khaki">
+            <div className="mx-auto max-w-6xl px-6 pt-10 pb-16 sm:pt-14 sm:pb-20">
+                <Link href="/" className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft transition-colors hover:text-ink">
+                    <span aria-hidden>←</span> {t("biz.back")}
                 </Link>
 
-                <div
-                    style={{
-                        display: "grid",
-                        gridTemplateColumns: "1.4fr 1fr",
-                        gap: 64,
-                        alignItems: "end",
-                    }}
-                >
+                <div className="mt-8 grid items-center gap-12 lg:grid-cols-[1.15fr_0.85fr]">
                     <div>
-                        <div
-                            className="eyebrow"
-                            style={{
-                                marginBottom: 24,
-                                display: "inline-flex",
-                                alignItems: "center",
-                                gap: 10,
-                                padding: "6px 14px",
-                                border: "1px solid var(--neo-rule)",
-                                borderRadius: "var(--neo-r-pill)",
-                                background: "var(--neo-paper-3)",
-                                color: "var(--neo-business)",
-                            }}
+                        <span className="inline-flex items-center gap-2 rounded-full border border-ink/10 bg-white px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                            <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--rust)" }} />
+                            {t("hero.trustChip")}
+                        </span>
+                        <Eyebrow className="mt-6">{t("how.bizLabel")}</Eyebrow>
+                        <h1
+                            className="mt-3 max-w-2xl font-fraunces text-[clamp(2.25rem,5vw,3.75rem)] leading-[1.05] tracking-[-0.02em] text-ink"
+                            style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
                         >
-                            <span
-                                style={{
-                                    display: "inline-block",
-                                    width: 8,
-                                    height: 8,
-                                    background: "var(--neo-business)",
-                                    transform: "rotate(45deg)",
-                                }}
-                            />
-                            For business owners
-                        </div>
-                        <h1 className="display" style={{ fontSize: "clamp(56px, 7.5vw, 120px)" }}>
-                            Your shop. <em style={{ fontStyle: "italic" }}>Online in 48 hours.</em>
+                            {t("hero.h1a")}{" "}
+                            <span className="whitespace-nowrap">
+                                {t("hero.h1b")}
+                                <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>{t("hero.h1c")}</span>
+                            </span>
                         </h1>
-                        <p className="lede" style={{ marginTop: 28, fontSize: 19, maxWidth: "56ch" }}>
-                            A trained creator visits your shop with a phone and a checklist. You answer questions about your business. They shoot, write, build, and publish. You approve. You pay. That&apos;s the entire process.
-                        </p>
+                        <Lead className="mt-5 max-w-xl">{t("hero.lede")}</Lead>
 
-                        <div
-                            style={{
-                                display: "grid",
-                                gridTemplateColumns: "repeat(3, 1fr)",
-                                gap: 16,
-                                marginTop: 40,
-                                maxWidth: 720,
-                            }}
-                        >
-                            <PromiseBeat n="01" big="30 min" sub="Interview, in your shop" />
-                            <PromiseBeat n="02" big="48 hr" sub="From visit to live site" />
-                            <PromiseBeat n="03" big="0" sub="Times you touch a keyboard" highlight />
+                        <div className="mt-8 flex flex-wrap items-center gap-3">
+                            <a href="#proof" className="inline-flex items-center gap-2 rounded-xl bg-ink px-6 py-3.5 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5">
+                                {t("hero.ctaProof")} <span aria-hidden>→</span>
+                            </a>
+                            <a href="#pricing" className="inline-flex items-center gap-2 rounded-xl border border-ink/15 bg-white px-6 py-3.5 text-sm font-semibold text-ink transition-colors hover:border-ink/35">
+                                {t("biz.seePrice")}
+                            </a>
                         </div>
 
-                        <div style={{ marginTop: 32, display: "flex", gap: 12, flexWrap: "wrap" }}>
-                            <Link
-                                href="/signup"
-                                className="door door-business"
-                                style={{ textDecoration: "none", display: "inline-flex" }}
-                            >
-                                Get started <span className="arrow"><ArrowUpRightIcon /></span>
-                            </Link>
-                            <Link
-                                href="/#showcase"
-                                className="door door-ghost"
-                                style={{ textDecoration: "none", display: "inline-flex" }}
-                            >
-                                Browse the live map
-                            </Link>
+                        <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2.5 text-sm text-ink-soft">
+                            {[t("hero.tag1"), t("hero.tag2"), t("hero.tag3")].map((tag) => (
+                                <span key={tag} className="inline-flex items-center gap-1.5"><Check />{tag}</span>
+                            ))}
                         </div>
                     </div>
 
-                    <div className="surface" style={{ padding: 24 }}>
-                        <div className="label" style={{ marginBottom: 16 }}>What lands in your hands</div>
-                        {[
-                            "A live website on your own domain or our subdomain",
-                            "World-class photography of your shop",
-                            "Written copy — your story, told properly",
-                            "Hosting + SSL — first year included",
-                            "Small edits free within 7 days of launch",
-                            "You own it all. Take it anywhere.",
-                        ].map((s, i) => (
-                            <div
-                                key={i}
-                                style={{
-                                    display: "flex",
-                                    alignItems: "baseline",
-                                    gap: 12,
-                                    padding: "10px 0",
-                                    borderTop: "1px solid var(--neo-rule)",
-                                    fontSize: 14,
-                                }}
-                            >
-                                <span
-                                    className="mono"
-                                    style={{
-                                        fontSize: 10,
-                                        color: "var(--neo-ink-3)",
-                                        flexShrink: 0,
-                                    }}
-                                >
-                                    0{i + 1}
-                                </span>
-                                <span>{s}</span>
-                            </div>
-                        ))}
+                    <div className="rounded-2xl border border-ink/10 bg-khaki-deep p-6 sm:p-7">
+                        <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">{t("process.kitLabel")}</div>
+                        <ul className="mt-4 flex flex-col">
+                            {deliverables.map((d, i) => (
+                                <li key={i} className="flex items-center gap-2.5 border-t border-ink/10 py-3 text-sm leading-snug text-ink first:border-t-0 first:pt-0">
+                                    <Check /><span>{d}</span>
+                                </li>
+                            ))}
+                        </ul>
                     </div>
                 </div>
             </div>
@@ -190,19 +96,22 @@ function BusinessHero() {
 
 export default function ForBusinessPage() {
     return (
-        <div className="neo min-h-screen overflow-x-hidden">
-            <Navbar />
-            <main>
-                <BusinessHero />
-                <ProcessSection />
-                <ShowcaseSection />
-                <BusinessPricingSection />
-                <FaqSection />
-                <CtaSection />
-            </main>
-            <Footer />
-            <ChatBot />
-            <ScrollToTop />
-        </div>
+        <LanguageProvider>
+            <div className="reveal-scope min-h-screen overflow-x-clip bg-khaki text-ink">
+                <Navbar />
+                <main>
+                    <BusinessHero />
+                    <RealSitesSection />
+                    <BusinessPricingSection />
+                    <ProcessSection />
+                    <FaqSection businessOnly />
+                    <CtaSection focus="business" />
+                </main>
+                <Footer />
+                <ChatBot />
+                <ScrollToTop />
+                <ScrollReveal />
+            </div>
+        </LanguageProvider>
     );
 }

--- a/app/for-creators/page.tsx
+++ b/app/for-creators/page.tsx
@@ -2,139 +2,44 @@
 
 import Link from "next/link";
 
+import { LanguageProvider, useT } from "@/components/landing/i18n";
 import Navbar from "@/components/landing/Navbar";
 import Footer from "@/components/landing/Footer";
 import ScrollToTop from "@/components/landing/ScrollToTop";
+import ChatBot from "@/components/landing/ChatBot";
+import ScrollReveal from "@/components/landing/ScrollReveal";
 
-import EarningsSection from "@/components/landing/EarningsSection";
+import CreatorTeaserSection from "@/components/landing/CreatorTeaserSection";
+import AppDownloadSection from "@/components/landing/AppDownloadSection";
 import ProcessSection from "@/components/landing/ProcessSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaSection from "@/components/landing/CtaSection";
-import ChatBot from "@/components/landing/ChatBot";
+import { Eyebrow, SectionHeading, Lead } from "@/components/landing/ui";
+import { PRICE_CEILING, UNLOCK_THRESHOLD, commissionFor, formatPHP } from "@/lib/pricing";
 
-import { ArrowUpRightIcon } from "@/components/landing/landingPrimitives";
-
-const APPLY_STEPS = [
-    { n: "01", h: "Tap \"I want to earn\"", sub: "Sign up from this page. The full flow lives in the app.", meta: "30 seconds" },
-    { n: "02", h: "Verify your phone & ID", sub: "Bank-grade KYC inside the app. Selfie + a valid ID. We hold your data for payouts only.", meta: "5 minutes" },
-    { n: "03", h: "Take the certification", sub: "Twelve short videos. A photo quiz. An interview rehearsal with a fake shop owner. You can retry as many times as you need.", meta: "20 minutes" },
-    { n: "04", h: "Pin yourself on the map", sub: "You show up on the landing page, in front of every business owner in your area looking for a creator.", meta: "instant" },
-    { n: "05", h: "Accept your first booking", sub: "Either a business taps you, or you pick one from your queue. Bring a phone, bring patience. The app guides every step.", meta: "same day" },
-    { n: "06", h: "Deliver. Get paid.", sub: "₱500 lands in your wallet within 48 hours of the business approving the site. Refer a friend, earn another ₱1,000 when their first paid submission lands.", meta: "48 hours" },
-];
-
+/** Creator hero — WP style, the one <h1>. Keeps the real Clerk signup CTA. */
 function CreatorHero() {
+    const { t } = useT();
     return (
-        <section style={{ paddingTop: 56, paddingBottom: 48 }}>
-            <div className="container-wide">
-                <Link
-                    href="/"
-                    className="label"
-                    style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 8,
-                        marginBottom: 24,
-                        textDecoration: "none",
-                        color: "var(--neo-ink-3)",
-                    }}
-                >
-                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                        <path d="M9 1 L3 7 L9 13" stroke="currentColor" strokeWidth="1.4" />
-                    </svg>
-                    Back to landing
+        <section className="bg-khaki">
+            <div className="mx-auto max-w-4xl px-6 pt-10 pb-16 text-center sm:pt-14 sm:pb-20">
+                <Link href="/" className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft transition-colors hover:text-ink">
+                    <span aria-hidden>←</span> {t("biz.back")}
                 </Link>
-
-                <div
-                    style={{
-                        display: "grid",
-                        gridTemplateColumns: "1.4fr 1fr",
-                        gap: 64,
-                        alignItems: "end",
-                    }}
-                >
-                    <div>
-                        <div
-                            className="eyebrow"
-                            style={{
-                                marginBottom: 24,
-                                display: "inline-flex",
-                                alignItems: "center",
-                                gap: 10,
-                                padding: "6px 14px",
-                                border: "1px solid var(--neo-rule)",
-                                borderRadius: "var(--neo-r-pill)",
-                                background: "var(--neo-paper-3)",
-                                color: "var(--neo-creator)",
-                            }}
-                        >
-                            <span
-                                style={{
-                                    display: "inline-block",
-                                    width: 9,
-                                    height: 9,
-                                    borderRadius: "50%",
-                                    background: "var(--neo-creator)",
-                                }}
-                            />
-                            For creators
-                        </div>
-                        <h1 className="display" style={{ fontSize: "clamp(56px, 7.5vw, 120px)" }}>
-                            Get paid to <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>build websites</em> for shops near you.
-                        </h1>
-                        <p className="lede" style={{ marginTop: 28, fontSize: 19, maxWidth: "56ch" }}>
-                            Bring a phone, bring patience, follow the in-app checklist. We do the editing, the writing, the deploying. You collect the cheque.
-                        </p>
-
-                        <div style={{ marginTop: 32, display: "flex", gap: 12, flexWrap: "wrap" }}>
-                            <Link
-                                href="/signup"
-                                className="door door-creator"
-                                style={{ textDecoration: "none", display: "inline-flex" }}
-                            >
-                                Start the certification <span className="arrow"><ArrowUpRightIcon /></span>
-                            </Link>
-                            <Link
-                                href="/#for-creators"
-                                className="door door-ghost"
-                                style={{ textDecoration: "none", display: "inline-flex" }}
-                            >
-                                See the numbers
-                            </Link>
-                        </div>
-                    </div>
-
-                    <div className="surface" style={{ padding: 24 }}>
-                        <div className="label" style={{ marginBottom: 16 }}>What you earn</div>
-                        {[
-                            ["Per submission (50% of sale)", "₱500"],
-                            ["Referral bonus", "₱1,000"],
-                            ["Payout via Wise", "—"],
-                            ["Time to first payout", "48 hr"],
-                        ].map(([label, v], i) => (
-                            <div
-                                key={i}
-                                style={{
-                                    display: "flex",
-                                    justifyContent: "space-between",
-                                    alignItems: "baseline",
-                                    padding: "12px 0",
-                                    borderTop: "1px solid var(--neo-rule)",
-                                    fontSize: 14,
-                                }}
-                            >
-                                <span>{label}</span>
-                                <span
-                                    className="counter-num"
-                                    style={{
-                                        fontSize: 22,
-                                        color: v.startsWith("₱") ? "var(--neo-creator)" : "var(--neo-ink-3)",
-                                    }}
-                                >
-                                    {v}
-                                </span>
-                            </div>
-                        ))}
+                <div className="mt-8">
+                    <Eyebrow>{t("how.creatorLabel")}</Eyebrow>
+                    <h1
+                        className="mx-auto mt-4 max-w-3xl font-fraunces text-[clamp(2.25rem,5.5vw,4rem)] leading-[1.05] tracking-[-0.02em] text-ink"
+                        style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
+                    >
+                        {t("creator.h1a")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>{t("creator.h1em")}</span>
+                    </h1>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("creator.lede")}</Lead>
+                    <div className="mt-8">
+                        <a href="#app" className="inline-flex items-center gap-2 rounded-xl bg-rust px-6 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5">
+                            {t("nav.getApp")} <span aria-hidden>→</span>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -142,107 +47,75 @@ function CreatorHero() {
     );
 }
 
-function HowToApplySection() {
+/** How to apply — 4 honest steps (no "pin yourself on the map", no invented cert specifics). */
+function ApplySection() {
+    const { t } = useT();
+    const steps = [t("how.creator1"), t("how.creator2"), t("how.creator3"), t("how.creator4")];
+    const tags = [t("creator.apply.tag1"), t("creator.apply.tag2"), t("creator.apply.tag3")];
     return (
-        <section style={{ background: "var(--neo-paper-2)" }}>
-            <div className="container-wide">
-                <div className="sect-h">
-                    <div className="eyebrow">How to apply</div>
-                    <div>
-                        <h2 className="display-2">
-                            From this page <em>to your first payout</em>.
-                        </h2>
-                        <p className="lede" style={{ marginTop: 12 }}>
-                            The full apply-and-certify flow lives inside the app. Here&apos;s what it looks like, with the time each step actually takes.
-                        </p>
-                    </div>
+        <section id="apply" className="bg-khaki-deep">
+            <div className="mx-auto max-w-4xl px-6 py-20 sm:py-28">
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("creator.apply.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">
+                        {t("creator.apply.title")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>{t("creator.apply.titleEm")}</span>
+                    </SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("creator.apply.lede")}</Lead>
                 </div>
-
-                <div className="surface" style={{ padding: 0 }}>
-                    {APPLY_STEPS.map((s, i) => (
-                        <div
-                            key={s.n}
-                            style={{
-                                display: "grid",
-                                gridTemplateColumns: "80px 1fr 1fr 160px",
-                                gap: 32,
-                                padding: "28px 32px",
-                                borderTop: i === 0 ? "none" : "1px solid var(--neo-rule)",
-                                alignItems: "baseline",
-                            }}
-                        >
-                            <div className="counter-num" style={{ fontSize: 32, color: "var(--neo-creator)" }}>{s.n}</div>
-                            <div
-                                className="serif"
-                                style={{
-                                    fontSize: 24,
-                                    lineHeight: 1.15,
-                                    letterSpacing: "-.015em",
-                                }}
-                            >
-                                {s.h}
-                            </div>
-                            <div
-                                style={{
-                                    fontSize: 14,
-                                    color: "var(--neo-ink-2)",
-                                    lineHeight: 1.55,
-                                    maxWidth: "42ch",
-                                }}
-                            >
-                                {s.sub}
-                            </div>
-                            <div style={{ textAlign: "right" }}>
-                                <span className="tag" style={{ background: "var(--neo-paper-3)" }}>{s.meta}</span>
-                            </div>
-                        </div>
+                <ol className="mx-auto mt-12 flex max-w-2xl flex-col rounded-2xl border border-ink/10 bg-khaki p-6 sm:p-8">
+                    {steps.map((s, i) => (
+                        <li key={i} className="grid grid-cols-[2.5rem_1fr] items-baseline gap-3 border-t border-ink/10 py-5 first:border-t-0 first:pt-0">
+                            <span className="font-mono text-sm text-rust">0{i + 1}</span>
+                            <span className="text-[15px] leading-snug text-ink sm:text-base">{s}</span>
+                        </li>
                     ))}
-                </div>
-
-                <div
-                    style={{
-                        marginTop: 32,
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                        gap: 16,
-                        flexWrap: "wrap",
-                    }}
-                >
-                    <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
-                        <span className="tag" style={{ background: "var(--neo-paper-3)" }}>Free to apply</span>
-                        <span className="tag" style={{ background: "var(--neo-paper-3)" }}>No experience required</span>
-                        <span className="tag" style={{ background: "var(--neo-paper-3)" }}>Keep your day job</span>
+                </ol>
+                <div className="mt-8 flex flex-col items-center gap-6">
+                    <div className="flex flex-wrap justify-center gap-2">
+                        {tags.map((tag) => (
+                            <span key={tag} className="rounded-full border border-ink/15 bg-white px-3 py-1 text-sm text-ink-soft">{tag}</span>
+                        ))}
                     </div>
-                    <Link
-                        href="/signup"
-                        className="door door-creator"
-                        style={{ padding: "16px 24px", textDecoration: "none", display: "inline-flex" }}
-                    >
-                        <span>Start the certification</span>
-                        <span className="arrow"><ArrowUpRightIcon /></span>
-                    </Link>
+                    <a href="#app" className="inline-flex items-center gap-2 rounded-xl bg-rust px-6 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5">
+                        {t("nav.getApp")} <span aria-hidden>→</span>
+                    </a>
                 </div>
             </div>
         </section>
     );
+}
+
+/** Earnings — the honest CreatorTeaser, with the creator-only price-ceiling note. */
+function CreatorEarnings() {
+    const { t } = useT();
+    const note = t("creator.ceilingNote")
+        .replace("{c}", formatPHP(commissionFor(PRICE_CEILING)))
+        .replace("{n}", String(UNLOCK_THRESHOLD));
+    return <CreatorTeaserSection id="earn" ctaHref="#app" ceilingNote={note} />;
 }
 
 export default function ForCreatorsPage() {
     return (
-        <div className="neo min-h-screen overflow-x-hidden">
-            <Navbar />
-            <main>
-                <CreatorHero />
-                <EarningsSection />
-                <HowToApplySection />
-                <ProcessSection />
-                <FaqSection />
-                <CtaSection />
-            </main>
-            <Footer />
-            <ChatBot />
-            <ScrollToTop />
-        </div>
+        <LanguageProvider>
+            <div className="reveal-scope min-h-screen overflow-x-clip bg-khaki text-ink">
+                <Navbar />
+                <main>
+                    <CreatorHero />
+                    <ApplySection />
+                    {/* The creator app (real Play Store + APK download) — the primary
+                        action; every creator CTA on this page scrolls here (app-first). */}
+                    <AppDownloadSection id="app" />
+                    <CreatorEarnings />
+                    <ProcessSection />
+                    <FaqSection defaultTab="creators" />
+                    <CtaSection focus="creator" />
+                </main>
+                <Footer />
+                <ChatBot />
+                <ScrollToTop />
+                <ScrollReveal />
+            </div>
+        </LanguageProvider>
     );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,86 @@ body {
   font-family: var(--font-plus-jakarta), system-ui, sans-serif;
 }
 
+/* ── Landing ChatBot — brand-token, global scope (no longer needs .neo) ──── */
+.tnd-chatbot-fab {
+  position: fixed; right: 24px; bottom: 24px; z-index: 1300;
+  width: 56px; height: 56px; border-radius: 50%;
+  background: var(--ink); color: var(--khaki);
+  border: 0; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 8px 24px -8px rgba(0, 0, 0, .35);
+  transition: transform .2s ease;
+}
+.tnd-chatbot-fab:hover { transform: scale(1.06); }
+.tnd-chatbot-window {
+  position: fixed; right: 24px; bottom: 92px; z-index: 1300;
+  width: 360px;
+  height: min(540px, calc(100dvh - 116px));
+  background: #FCFAF5;
+  border: 1px solid rgba(27, 28, 36, .1);
+  border-radius: 20px;
+  box-shadow: 0 2px 6px rgba(27, 28, 36, .06), 0 24px 48px -16px rgba(27, 28, 36, .18);
+  display: flex; flex-direction: column; overflow: hidden;
+  transform-origin: bottom right;
+  animation: tnd-chatbot-in .25s cubic-bezier(.2, .8, .2, 1);
+}
+@media (max-width: 480px) {
+  .tnd-chatbot-window { right: 12px; left: 12px; bottom: 12px; width: auto; height: min(560px, calc(100dvh - 24px)); }
+}
+@keyframes tnd-chatbot-in {
+  0%   { opacity: 0; transform: scale(.9) translateY(8px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+.tnd-live-dot {
+  display: inline-block; width: 7px; height: 7px;
+  background: var(--rust-soft); border-radius: 50%;
+  animation: tnd-live-pulse 2s infinite;
+}
+@keyframes tnd-live-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(228, 176, 94, .6); }
+  70%  { box-shadow: 0 0 0 8px rgba(228, 176, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(228, 176, 94, 0); }
+}
+@media (prefers-reduced-motion: reduce) { .tnd-live-dot { animation: none; } }
+
+/* In-page anchor navigation: smooth scroll, and keep the target clear of the
+   sticky navbar so a jumped-to section header isn't hidden under it. */
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+section[id] { scroll-margin-top: 5rem; }
+
+/* ── Landing scroll-reveal (paired with ScrollReveal.tsx) ─────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  /* Hero (first band): gentle entrance on load — pure CSS, no JS wait. */
+  .reveal-scope main > section:first-child > div {
+    animation: tnd-reveal-up 0.7s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  /* Below-fold bands: JS adds .reveal-pending (hidden) then .reveal-in on scroll. */
+  .reveal-pending {
+    opacity: 0;
+    transform: translateY(18px);
+    transition:
+      opacity 0.6s cubic-bezier(0.22, 0.61, 0.36, 1),
+      transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
+    will-change: opacity, transform;
+  }
+  .reveal-pending.reveal-in {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes tnd-reveal-up {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* Subtle hairline between adjacent landing bands so sections stay distinct even
+   when their warm-paper tones (khaki / khaki-deep) sit close together. */
+.reveal-scope main > section + section {
+  border-top: 1px solid rgba(27, 28, 36, 0.07);
+}
+
 /* Respect reduced motion globally */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,15 +3,18 @@ import { Fraunces, Plus_Jakarta_Sans, Playfair_Display, JetBrains_Mono, Instrume
 import { Toaster } from "sonner";
 import { Analytics } from "@vercel/analytics/react";
 import { ConvexClerkProvider } from "@/components/providers/ConvexClerkProvider";
-import CustomCursor from "@/components/landing/CustomCursor";
 import { JsonLd } from "@/components/JsonLd";
 import { organizationGraph, SITE_URL } from "@/lib/seo";
 import "./globals.css";
 
+// Display serif — loaded as a VARIABLE font (wght + optical-size axes) so the
+// landing can use a refined ~560 display weight and let optical sizing track
+// the font size (Fraunces gets its high-contrast display cut at large sizes).
 const fraunces = Fraunces({
   variable: "--font-fraunces",
   subsets: ["latin", "latin-ext"],
-  weight: ["500", "600", "700", "800", "900"],
+  axes: ["opsz"],
+  style: ["normal", "italic"],
   display: "swap",
 });
 
@@ -94,7 +97,6 @@ export default function RootLayout({
         className={`${fraunces.variable} ${plusJakarta.variable} ${playfair.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${onest.variable} antialiased`}
       >
         <ConvexClerkProvider>
-          <CustomCursor />
           {children}
         </ConvexClerkProvider>
         <Toaster position="top-right" richColors />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,83 +1,64 @@
 "use client";
 
-import { useState } from "react";
-
 import { LanguageProvider } from "@/components/landing/i18n";
 import Navbar from "@/components/landing/Navbar";
 import Footer from "@/components/landing/Footer";
 import ScrollToTop from "@/components/landing/ScrollToTop";
 
 import HeroSection from "@/components/landing/HeroSection";
-import ShowcaseSection from "@/components/landing/ShowcaseSection";
-import HowItWorks from "@/components/landing/HowItWorks";
+import RealSitesSection from "@/components/landing/RealSitesSection";
 import ProcessSection from "@/components/landing/ProcessSection";
-import ManifestoSection from "@/components/landing/ManifestoSection";
 import BusinessPricingSection from "@/components/landing/BusinessPricingSection";
-import EarningsSection from "@/components/landing/EarningsSection";
-import DirectorySection from "@/components/landing/DirectorySection";
-import AppDownloadSection from "@/components/landing/AppDownloadSection";
+import ManifestoSection from "@/components/landing/ManifestoSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaSection from "@/components/landing/CtaSection";
 
 import StickyCTA from "@/components/landing/StickyCTA";
 import ChatBot from "@/components/landing/ChatBot";
-import CreatorSheet from "@/components/landing/CreatorSheet";
-import BusinessSheet from "@/components/landing/BusinessSheet";
+import ScrollReveal from "@/components/landing/ScrollReveal";
 
-import type { Creator, LiveBusiness } from "@/components/landing/landingData";
-
+/**
+ * Tendso landing — WordPress-informed, modern-SaaS system on the brand palette
+ * (warm paper + one gold accent, Fraunces display + Plus Jakarta body). Every
+ * section is data-true (no fabricated counters/creators/testimonials) and
+ * bilingual (EN/TL). Owners are customers only — no owner signup anywhere.
+ *
+ * Owner-first narrative: hero → real-sites proof → pricing → how it works
+ * (process) → FAQ → manifesto → final CTA → footer. Creator content lives on
+ * /for-creators; the homepage keeps only a secondary creator pointer.
+ *
+ * ChatBot still uses the legacy `.neo` tokens, so it keeps a minimal wrapper
+ * until it's converted; everything else runs on brand tokens.
+ */
 export default function Home() {
-    const [selectedCreator, setSelectedCreator] = useState<Creator | null>(null);
-    const [selectedBusiness, setSelectedBusiness] = useState<LiveBusiness | null>(null);
-
     return (
         <LanguageProvider>
-        <div className="neo min-h-screen overflow-x-hidden">
-            <Navbar />
+            <div className="reveal-scope min-h-screen overflow-x-clip bg-khaki text-ink">
+                <Navbar />
 
-            <main>
-                {/* Hero with counters + two doors */}
-                <HeroSection />
+                {/* Owner-first homepage: the paying customer (business owner) is the
+                    single primary audience. Creators keep a secondary path (the hero
+                    pointer, the "For creators" nav link, the footer, and /for-creators)
+                    — the creator earnings + creator-app bands live on /for-creators. */}
+                {/* Bands alternate paper (khaki) / wash (khaki-deep) so no two
+                    adjacent sections share a tone: p,w,p,w,p,w,ink. */}
+                <main>
+                    <HeroSection />
+                    <RealSitesSection />
+                    <BusinessPricingSection />
+                    <ProcessSection />
+                    <FaqSection businessOnly />
+                    <ManifestoSection />
+                    <CtaSection focus="business" />
+                </main>
 
-                {/* Get the app — placed high as a priority to drive downloads */}
-                <AppDownloadSection />
+                <Footer />
 
-                {/* Live map (Convex listPublished → falls back to 4 known sites) */}
-                <ShowcaseSection
-                    onSelectCreator={setSelectedCreator}
-                    onSelectBusiness={setSelectedBusiness}
-                />
-
-                {/* How it works (two tracks side-by-side) */}
-                <HowItWorks />
-
-                {/* Process — Online Kit pipeline */}
-                <ProcessSection />
-
-                {/* Manifesto — the 99% statement */}
-                <ManifestoSection />
-
-                {/* Directory (rails of creators + businesses) */}
-                <DirectorySection
-                    onSelectCreator={setSelectedCreator}
-                    onSelectBusiness={setSelectedBusiness}
-                />
-
-                {/* FAQ */}
-                <FaqSection />
-
-                {/* Final CTA (the two doors, big) */}
-                <CtaSection />
-            </main>
-
-            <Footer />
-
-            <StickyCTA />
-            <ChatBot />
-            <CreatorSheet creator={selectedCreator} onClose={() => setSelectedCreator(null)} />
-            <BusinessSheet business={selectedBusiness} onClose={() => setSelectedBusiness(null)} />
-            <ScrollToTop />
-        </div>
+                <StickyCTA />
+                <ScrollToTop />
+                <ChatBot />
+                <ScrollReveal />
+            </div>
         </LanguageProvider>
     );
 }

--- a/components/landing/AppDownloadSection.tsx
+++ b/components/landing/AppDownloadSection.tsx
@@ -12,9 +12,10 @@ import { useT } from "./i18n";
  * earnings). It does NOT build or publish websites, and owners don't need it —
  * so the copy is framed for creators, not owners.
  *
- * - Google Play links to the Android listing; an admin can override the URL at
- *   /admin/app-release (setting `play_store_url`).
- * - App Store shows "Coming soon" until an iOS build ships (`app_store_url`).
+ * - Store URLs come from Convex settings, managed at /admin/app-release
+ *   (`play_store_url` / `app_store_url`). Each button renders only when its URL
+ *   is set. Google Play keeps a code fallback so it never disappears; the App
+ *   Store button appears once `app_store_url` is set.
  */
 
 const DEFAULT_PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.negosyodigital.app";
@@ -55,29 +56,13 @@ function StoreButton({ href, glyph, small, large }: { href: string; glyph: React
     );
 }
 
-function ComingSoonButton({ glyph, label }: { glyph: React.ReactNode; label: string }) {
-    return (
-        <span
-            aria-disabled="true"
-            title={`${label} — coming soon`}
-            className="inline-flex min-w-[220px] cursor-default items-center gap-3 rounded-xl border border-khaki/25 px-6 py-3.5 text-khaki/70"
-        >
-            <span className="flex flex-shrink-0">{glyph}</span>
-            <span className="flex flex-col text-left leading-tight">
-                <span className="text-[10.5px] uppercase tracking-wide opacity-70">Coming soon</span>
-                <span className="text-xl font-semibold tracking-[-0.01em]">{label}</span>
-            </span>
-        </span>
-    );
-}
-
 export default function AppDownloadSection({ id }: { id?: string } = {}) {
     const { t } = useT();
     const appStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null | undefined;
     const playStoreUrl = useQuery(api.settings.get, { key: "play_store_url" }) as string | null | undefined;
 
     const playHref = (playStoreUrl && playStoreUrl.trim()) || DEFAULT_PLAY_STORE_URL;
-    const appLive = !!(appStoreUrl && appStoreUrl.trim());
+    const appHref = appStoreUrl?.trim() || null;
 
     return (
         <section id={id} className="bg-ink text-khaki">
@@ -95,10 +80,8 @@ export default function AppDownloadSection({ id }: { id?: string } = {}) {
                 <p className="mx-auto mt-5 max-w-lg text-[17px] leading-relaxed text-khaki/70">{t("app.lede")}</p>
 
                 <div className="mt-9 flex flex-wrap justify-center gap-4">
-                    {appLive ? (
-                        <StoreButton href={appStoreUrl as string} glyph={<AppleGlyph />} small={t("app.downloadOn")} large="App Store" />
-                    ) : (
-                        <ComingSoonButton glyph={<AppleGlyph />} label="App Store" />
+                    {appHref && (
+                        <StoreButton href={appHref} glyph={<AppleGlyph />} small={t("app.downloadOn")} large="App Store" />
                     )}
                     <StoreButton href={playHref} glyph={<PlayGlyph />} small={t("app.getOn")} large="Google Play" />
                 </div>

--- a/components/landing/AppDownloadSection.tsx
+++ b/components/landing/AppDownloadSection.tsx
@@ -12,13 +12,10 @@ import { useT } from "./i18n";
  * earnings). It does NOT build or publish websites, and owners don't need it —
  * so the copy is framed for creators, not owners.
  *
- * - Store URLs come from Convex settings, managed at /admin/app-release
- *   (`play_store_url` / `app_store_url`). Each button renders only when its URL
- *   is set. Google Play keeps a code fallback so it never disappears; the App
- *   Store button appears once `app_store_url` is set.
+ * - Both store URLs come from Convex settings, managed at /admin/app-release
+ *   (`play_store_url` / `app_store_url`). Each button — and the QR — renders
+ *   only when its URL is set; nothing is hardcoded.
  */
-
-const DEFAULT_PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.negosyodigital.app";
 
 function AppleGlyph() {
     return (
@@ -61,7 +58,7 @@ export default function AppDownloadSection({ id }: { id?: string } = {}) {
     const appStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null | undefined;
     const playStoreUrl = useQuery(api.settings.get, { key: "play_store_url" }) as string | null | undefined;
 
-    const playHref = (playStoreUrl && playStoreUrl.trim()) || DEFAULT_PLAY_STORE_URL;
+    const playHref = playStoreUrl?.trim() || null;
     const appHref = appStoreUrl?.trim() || null;
 
     return (
@@ -83,16 +80,20 @@ export default function AppDownloadSection({ id }: { id?: string } = {}) {
                     {appHref && (
                         <StoreButton href={appHref} glyph={<AppleGlyph />} small={t("app.downloadOn")} large="App Store" />
                     )}
-                    <StoreButton href={playHref} glyph={<PlayGlyph />} small={t("app.getOn")} large="Google Play" />
+                    {playHref && (
+                        <StoreButton href={playHref} glyph={<PlayGlyph />} small={t("app.getOn")} large="Google Play" />
+                    )}
                 </div>
 
                 {/* QR to the Android listing — desktop only (tap the button on mobile) */}
-                <div className="mt-11 hidden flex-col items-center gap-3 sm:flex">
-                    <div className="rounded-2xl bg-white p-3 leading-none shadow-[0_12px_36px_-16px_rgba(0,0,0,.55)]">
-                        <QRCodeSVG value={playHref} size={116} bgColor="#ffffff" fgColor="#111111" level="M" />
+                {playHref && (
+                    <div className="mt-11 hidden flex-col items-center gap-3 sm:flex">
+                        <div className="rounded-2xl bg-white p-3 leading-none shadow-[0_12px_36px_-16px_rgba(0,0,0,.55)]">
+                            <QRCodeSVG value={playHref} size={116} bgColor="#ffffff" fgColor="#111111" level="M" />
+                        </div>
+                        <span className="text-[11.5px] uppercase tracking-[0.08em] text-khaki/60">{t("app.scan")}</span>
                     </div>
-                    <span className="text-[11.5px] uppercase tracking-[0.08em] text-khaki/60">{t("app.scan")}</span>
-                </div>
+                )}
 
                 <div className="mt-6 text-[11.5px] uppercase tracking-[0.08em] text-khaki/55">{t("app.status")}</div>
             </div>

--- a/components/landing/AppDownloadSection.tsx
+++ b/components/landing/AppDownloadSection.tsx
@@ -3,15 +3,18 @@
 import { QRCodeSVG } from "qrcode.react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import { useT } from "./i18n";
 
 /**
- * AppDownloadSection — priority "Get the app" band (placed right after the
- * hero to drive downloads).
+ * AppDownloadSection — WP "dark punctuation" band for the Tendso app.
  *
- * - Google Play links to the Tendso Android listing; an admin can override the
- *   URL at /admin/app-release (setting `play_store_url`).
- * - App Store shows "Coming soon" until an iOS build ships (set `app_store_url`
- *   at /admin/app-release to turn it into a live download).
+ * The app is the CREATOR / field tool (get certified, capture businesses, track
+ * earnings). It does NOT build or publish websites, and owners don't need it —
+ * so the copy is framed for creators, not owners.
+ *
+ * - Google Play links to the Android listing; an admin can override the URL at
+ *   /admin/app-release (setting `play_store_url`).
+ * - App Store shows "Coming soon" until an iOS build ships (`app_store_url`).
  */
 
 const DEFAULT_PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=com.negosyodigital.app";
@@ -35,59 +38,41 @@ function PlayGlyph() {
     );
 }
 
-const btnBase: React.CSSProperties = {
-    display: "inline-flex",
-    alignItems: "center",
-    gap: 12,
-    minWidth: 220,
-    padding: "14px 26px",
-    borderRadius: 14,
-    textDecoration: "none",
-    transition: "transform .15s ease",
-};
-
 function StoreButton({ href, glyph, small, large }: { href: string; glyph: React.ReactNode; small: string; large: string }) {
     return (
         <a
             href={href}
             target="_blank"
             rel="noreferrer"
-            style={{ ...btnBase, background: "var(--neo-paper)", color: "var(--neo-ink)", border: "1px solid var(--neo-paper)" }}
+            className="inline-flex min-w-[220px] items-center gap-3 rounded-xl bg-khaki px-6 py-3.5 text-ink transition-transform hover:-translate-y-0.5"
         >
-            <span style={{ display: "inline-flex", flex: "0 0 auto" }}>{glyph}</span>
-            <span style={{ display: "flex", flexDirection: "column", textAlign: "left", lineHeight: 1.1 }}>
-                <span style={{ fontSize: 10.5, letterSpacing: ".05em", textTransform: "uppercase", opacity: 0.7 }}>{small}</span>
-                <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-.01em" }}>{large}</span>
+            <span className="flex flex-shrink-0">{glyph}</span>
+            <span className="flex flex-col text-left leading-tight">
+                <span className="text-[10.5px] uppercase tracking-wide opacity-70">{small}</span>
+                <span className="text-xl font-semibold tracking-[-0.01em]">{large}</span>
             </span>
         </a>
     );
 }
 
-/** Outlined, non-interactive badge for a store that isn't live yet. */
 function ComingSoonButton({ glyph, label }: { glyph: React.ReactNode; label: string }) {
     return (
         <span
             aria-disabled="true"
             title={`${label} — coming soon`}
-            style={{
-                ...btnBase,
-                background: "transparent",
-                color: "var(--neo-paper)",
-                border: "1px solid color-mix(in srgb, var(--neo-paper) 32%, transparent)",
-                opacity: 0.75,
-                cursor: "default",
-            }}
+            className="inline-flex min-w-[220px] cursor-default items-center gap-3 rounded-xl border border-khaki/25 px-6 py-3.5 text-khaki/70"
         >
-            <span style={{ display: "inline-flex", flex: "0 0 auto" }}>{glyph}</span>
-            <span style={{ display: "flex", flexDirection: "column", textAlign: "left", lineHeight: 1.1 }}>
-                <span style={{ fontSize: 10.5, letterSpacing: ".05em", textTransform: "uppercase", opacity: 0.7 }}>Coming soon</span>
-                <span style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-.01em" }}>{label}</span>
+            <span className="flex flex-shrink-0">{glyph}</span>
+            <span className="flex flex-col text-left leading-tight">
+                <span className="text-[10.5px] uppercase tracking-wide opacity-70">Coming soon</span>
+                <span className="text-xl font-semibold tracking-[-0.01em]">{label}</span>
             </span>
         </span>
     );
 }
 
-export default function AppDownloadSection() {
+export default function AppDownloadSection({ id }: { id?: string } = {}) {
+    const { t } = useT();
     const appStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null | undefined;
     const playStoreUrl = useQuery(api.settings.get, { key: "play_store_url" }) as string | null | undefined;
 
@@ -95,55 +80,38 @@ export default function AppDownloadSection() {
     const appLive = !!(appStoreUrl && appStoreUrl.trim());
 
     return (
-        <section style={{ position: "relative", background: "var(--neo-ink)", color: "var(--neo-paper)", padding: "clamp(96px, 12vw, 150px) 0", overflow: "hidden" }}>
-            {/* Accent glow behind the headline. */}
-            <div
-                aria-hidden="true"
-                style={{
-                    position: "absolute",
-                    top: "-25%",
-                    left: "50%",
-                    width: "min(1000px, 120%)",
-                    height: 620,
-                    transform: "translateX(-50%)",
-                    background: "radial-gradient(closest-side, color-mix(in srgb, var(--neo-creator) 20%, transparent), transparent)",
-                    pointerEvents: "none",
-                }}
-            />
-            <div className="container-wide" style={{ position: "relative", textAlign: "center" }}>
-                <div className="eyebrow" style={{ marginBottom: 22, color: "var(--neo-creator)" }}>Get the app</div>
-                <h2 className="display" style={{ fontSize: "clamp(52px, 8.5vw, 132px)", color: "var(--neo-paper)", lineHeight: 0.95 }}>
-                    Take Tendso
-                    <br />
-                    <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>with you.</em>
-                </h2>
-                <p className="lede" style={{ maxWidth: "48ch", margin: "28px auto 0", fontSize: 19, color: "oklch(82% 0.01 85)" }}>
-                    Get the Tendso app on your phone — available now on Android, with iOS on the way.
+        <section id={id} className="bg-ink text-khaki">
+            <div className="mx-auto max-w-4xl px-6 py-24 text-center sm:py-28">
+                <p className="font-sans text-[13px] font-semibold uppercase tracking-[0.14em]" style={{ color: "var(--rust-soft)" }}>
+                    {t("app.eyebrow")}
                 </p>
+                <h2
+                    className="mx-auto mt-5 max-w-2xl font-fraunces text-[clamp(2rem,5vw,3.5rem)] leading-[1.05] tracking-[-0.02em]"
+                    style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
+                >
+                    {t("app.titleA")}{" "}
+                    <span className="italic" style={{ color: "var(--rust-soft)" }}>{t("app.titleB")}</span>
+                </h2>
+                <p className="mx-auto mt-5 max-w-lg text-[17px] leading-relaxed text-khaki/70">{t("app.lede")}</p>
 
-                {/* Store buttons */}
-                <div style={{ display: "flex", gap: 16, justifyContent: "center", flexWrap: "wrap", marginTop: 44 }}>
+                <div className="mt-9 flex flex-wrap justify-center gap-4">
                     {appLive ? (
-                        <StoreButton href={appStoreUrl as string} glyph={<AppleGlyph />} small="Download on the" large="App Store" />
+                        <StoreButton href={appStoreUrl as string} glyph={<AppleGlyph />} small={t("app.downloadOn")} large="App Store" />
                     ) : (
                         <ComingSoonButton glyph={<AppleGlyph />} label="App Store" />
                     )}
-                    <StoreButton href={playHref} glyph={<PlayGlyph />} small="Get it on" large="Google Play" />
+                    <StoreButton href={playHref} glyph={<PlayGlyph />} small={t("app.getOn")} large="Google Play" />
                 </div>
 
-                {/* QR to the Android listing — desktop only (on mobile you just tap the button). */}
-                <div className="hidden sm:flex" style={{ flexDirection: "column", alignItems: "center", gap: 11, marginTop: 44 }}>
-                    <div style={{ background: "#fff", padding: 12, borderRadius: 16, lineHeight: 0, boxShadow: "0 12px 36px -16px rgba(0,0,0,.55)" }}>
+                {/* QR to the Android listing — desktop only (tap the button on mobile) */}
+                <div className="mt-11 hidden flex-col items-center gap-3 sm:flex">
+                    <div className="rounded-2xl bg-white p-3 leading-none shadow-[0_12px_36px_-16px_rgba(0,0,0,.55)]">
                         <QRCodeSVG value={playHref} size={116} bgColor="#ffffff" fgColor="#111111" level="M" />
                     </div>
-                    <span style={{ fontSize: 11.5, letterSpacing: ".08em", textTransform: "uppercase", color: "oklch(70% 0.01 85)" }}>
-                        Scan to install on Android
-                    </span>
+                    <span className="text-[11.5px] uppercase tracking-[0.08em] text-khaki/60">{t("app.scan")}</span>
                 </div>
 
-                <div style={{ marginTop: 22, fontSize: 11.5, letterSpacing: ".08em", textTransform: "uppercase", color: "oklch(66% 0.01 85)" }}>
-                    Available now on Android · iOS coming soon
-                </div>
+                <div className="mt-6 text-[11.5px] uppercase tracking-[0.08em] text-khaki/55">{t("app.status")}</div>
             </div>
         </section>
     );

--- a/components/landing/BusinessPricingSection.tsx
+++ b/components/landing/BusinessPricingSection.tsx
@@ -101,7 +101,7 @@ export default function BusinessPricingSection() {
                                 href="/for-business"
                                 className={`mt-8 inline-flex items-center justify-center gap-2 rounded-lg px-5 py-3 text-sm font-semibold transition-all ${
                                     tier.featured
-                                        ? "bg-rust text-khaki hover:-translate-y-0.5"
+                                        ? "bg-ink text-white hover:-translate-y-0.5"
                                         : "border border-ink/20 text-ink hover:bg-khaki-deep"
                                 }`}
                             >

--- a/components/landing/BusinessPricingSection.tsx
+++ b/components/landing/BusinessPricingSection.tsx
@@ -1,176 +1,120 @@
 "use client";
 
 import Link from "next/link";
-import { BUSINESS_TIERS } from "./landingData";
-import { ArrowUpRightIcon } from "./landingPrimitives";
-import { BASE_PRICE, formatPHP } from "@/lib/pricing";
 import { useT } from "./i18n";
+import { Eyebrow, SectionHeading, Lead } from "./ui";
+import { BASE_PRICE, CUSTOM_DOMAIN_PRICE, formatPHP } from "@/lib/pricing";
+
+/**
+ * Business pricing — WP-style two-tier band. TRUE to lib/pricing.ts: ₱999
+ * standard, ₱1,499 with a custom domain (a flat registrar pass-through, not
+ * commissioned). One-time, no monthly, pay only when live. No fabricated
+ * `*.tendso.ph` subdomain promise (that wildcard doesn't exist). CTAs point to
+ * the info route /for-business — owners never "sign up".
+ */
+
+function Check() {
+    return (
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="mt-0.5 flex-shrink-0" style={{ color: "var(--rust)" }}>
+            <path d="M20 6 9 17l-5-5" />
+        </svg>
+    );
+}
 
 export default function BusinessPricingSection() {
     const { t } = useT();
+
+    const tiers = [
+        {
+            key: "standard",
+            name: t("price.tierStandard"),
+            tagline: t("price.taglineStandard"),
+            price: BASE_PRICE,
+            features: [
+                t("price.stdF1"), t("price.stdF2"), t("price.stdF3"),
+                t("price.stdF4"), t("price.stdF5"), t("price.stdF6"),
+            ],
+            featured: false,
+        },
+        {
+            key: "domain",
+            name: t("price.tierDomain"),
+            tagline: t("price.taglineDomain"),
+            price: CUSTOM_DOMAIN_PRICE,
+            features: [
+                t("price.domF1"), t("price.domF2"), t("price.domF3"),
+                t("price.domF4"), t("price.domF5"), t("price.domF6"),
+            ],
+            featured: true,
+        },
+    ];
+
     return (
-        <section id="for-business" style={{ background: "var(--neo-paper)" }}>
-            <div className="container-wide">
-                <div className="sect-h">
-                    <div className="eyebrow">{t("price.eyebrow")}</div>
-                    <div>
-                        <h2 className="display-2">
-                            {formatPHP(BASE_PRICE)} once. <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>{t("price.liveForever")}</em>
-                        </h2>
-                        <p className="lede" style={{ marginTop: 12 }}>
-                            {t("price.lede")}
-                        </p>
-                    </div>
+        <section id="pricing" className="bg-khaki">
+            <div className="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("price.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">
+                        {formatPHP(BASE_PRICE)} {t("price.once")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>
+                            {t("price.liveForever")}
+                        </span>
+                    </SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("price.lede")}</Lead>
                 </div>
 
-                <div
-                    className="grid grid-cols-1 md:grid-cols-2 gap-4"
-                    style={{
-                        maxWidth: 1080,
-                        margin: "0 auto",
-                    }}
-                >
-                    {BUSINESS_TIERS.map((tier) => {
-                        const featured = tier.featured;
-                        return (
-                            <div
-                                key={tier.slug}
-                                className="card"
-                                style={{
-                                    padding: "40px 36px 36px",
-                                    background: featured ? "var(--neo-ink)" : "var(--neo-paper-3)",
-                                    color: featured ? "var(--neo-paper)" : "var(--neo-ink)",
-                                    border: featured ? "1px solid var(--neo-ink)" : undefined,
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    position: "relative",
-                                }}
-                            >
-                                {featured && (
-                                    <span
-                                        className="tag"
-                                        style={{
-                                            position: "absolute",
-                                            top: 20,
-                                            right: 20,
-                                            background: "var(--neo-creator)",
-                                            color: "white",
-                                            border: "1px solid var(--neo-creator)",
-                                        }}
-                                    >
-                                        Most popular
-                                    </span>
-                                )}
-                                <div
-                                    className="label"
-                                    style={{
-                                        marginBottom: 16,
-                                        color: featured ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)",
-                                    }}
-                                >
-                                    {tier.name}
-                                </div>
-                                <p
-                                    className="serif"
-                                    style={{
-                                        fontSize: 24,
-                                        fontStyle: "italic",
-                                        marginBottom: 24,
-                                        lineHeight: 1.25,
-                                        color: featured ? "oklch(85% 0.008 85)" : "var(--neo-ink-2)",
-                                    }}
-                                >
-                                    {tier.tagline}
-                                </p>
-                                <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginBottom: 4 }}>
-                                    <span
-                                        className="counter-num"
-                                        style={{
-                                            fontSize: 20,
-                                            color: featured ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)",
-                                        }}
-                                    >
-                                        ₱
-                                    </span>
-                                    <span className="counter-num" style={{ fontSize: 72 }}>
-                                        {tier.price.toLocaleString()}
-                                    </span>
-                                </div>
-                                <div
-                                    className="label"
-                                    style={{
-                                        marginBottom: 24,
-                                        color: featured ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)",
-                                    }}
-                                >
-                                    {t("price.oneTime")}
-                                </div>
-
-                                <ul
-                                    style={{
-                                        listStyle: "none",
-                                        padding: 0,
-                                        margin: 0,
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        gap: 12,
-                                        marginBottom: 32,
-                                    }}
-                                >
-                                    {tier.features.map((f, i) => (
-                                        <li
-                                            key={i}
-                                            style={{
-                                                display: "grid",
-                                                gridTemplateColumns: "32px 1fr",
-                                                alignItems: "baseline",
-                                                fontSize: 14,
-                                                color: featured ? "oklch(85% 0.008 85)" : "var(--neo-ink-2)",
-                                                lineHeight: 1.55,
-                                            }}
-                                        >
-                                            <span
-                                                style={{
-                                                    fontFamily: "var(--neo-mono)",
-                                                    fontSize: 11,
-                                                    color: featured ? "oklch(72% 0.008 85)" : "var(--neo-ink-3)",
-                                                }}
-                                            >
-                                                0{i + 1}
-                                            </span>
-                                            <span>{f}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-
-                                <Link
-                                    href={tier.ctaHref}
-                                    className={`door ${featured ? "door-creator" : ""}`}
-                                    style={{
-                                        marginTop: "auto",
-                                        justifyContent: "space-between",
-                                        display: "inline-flex",
-                                        textDecoration: "none",
-                                    }}
-                                >
-                                    <span>{tier.ctaLabel}</span>
-                                    <span className="arrow"><ArrowUpRightIcon /></span>
-                                </Link>
+                <div className="mx-auto mt-12 grid max-w-3xl gap-6 md:grid-cols-2">
+                    {tiers.map((tier) => (
+                        <div
+                            key={tier.key}
+                            className={`relative flex flex-col rounded-2xl bg-khaki p-7 sm:p-8 ${
+                                tier.featured ? "border-2 border-rust" : "border border-ink/10"
+                            }`}
+                        >
+                            {tier.featured && (
+                                <span className="absolute right-5 top-6 rounded-full bg-rust-soft px-3 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-ink">
+                                    {t("price.badge")}
+                                </span>
+                            )}
+                            <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                                {tier.name}
                             </div>
-                        );
-                    })}
+                            <p className="mt-3 max-w-[22ch] text-[15px] leading-snug text-ink-soft">{tier.tagline}</p>
+
+                            <div className="mt-6 font-fraunces text-5xl text-ink" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                                {formatPHP(tier.price)}
+                            </div>
+                            <div className="mt-1.5 font-mono text-[11px] uppercase tracking-[0.12em] text-ink-soft">
+                                {t("price.oneTime")}
+                            </div>
+
+                            <ul className="mt-6 flex flex-col gap-3">
+                                {tier.features.map((f, i) => (
+                                    <li key={i} className="flex items-start gap-2.5 text-sm leading-snug text-ink">
+                                        <Check />
+                                        <span>{f}</span>
+                                    </li>
+                                ))}
+                            </ul>
+
+                            <Link
+                                href="/for-business"
+                                className={`mt-8 inline-flex items-center justify-center gap-2 rounded-lg px-5 py-3 text-sm font-semibold transition-all ${
+                                    tier.featured
+                                        ? "bg-rust text-khaki hover:-translate-y-0.5"
+                                        : "border border-ink/20 text-ink hover:bg-khaki-deep"
+                                }`}
+                            >
+                                {t("hero.ctaBusiness")}
+                                <span aria-hidden>→</span>
+                            </Link>
+                        </div>
+                    ))}
                 </div>
 
-                <div
-                    className="label"
-                    style={{
-                        marginTop: 32,
-                        textAlign: "center",
-                        color: "var(--neo-ink-3)",
-                    }}
-                >
+                <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-ink-soft">
                     {t("price.footnote")}
-                </div>
+                </p>
             </div>
         </section>
     );

--- a/components/landing/ChatBot.tsx
+++ b/components/landing/ChatBot.tsx
@@ -6,6 +6,9 @@ import { api } from "@/convex/_generated/api";
 
 type Msg = { role: "bot" | "user"; text: string; sources?: { slug: string; title: string }[] };
 
+// Brand-token styling helpers (this widget lives outside .neo now).
+const RULE = "1px solid rgba(27,28,36,.1)";
+
 export default function ChatBot() {
     const [open, setOpen] = useState(false);
     const [messages, setMessages] = useState<Msg[]>([
@@ -26,8 +29,6 @@ export default function ChatBot() {
     const ask = async () => {
         const q = input.trim();
         if (!q || busy) return;
-        // Snapshot the conversation so far (excluding the two opening greetings)
-        // so the assistant can resolve follow-up questions. Keep it short.
         const history = messages
             .filter((m, i) => !(m.role === "bot" && i < 2))
             .map((m) => ({ role: m.role === "bot" ? ("assistant" as const) : ("user" as const), text: m.text }))
@@ -61,95 +62,56 @@ export default function ChatBot() {
     return (
         <>
             {open && (
-                <div className="chatbot-window" role="dialog" aria-label="Chat with us">
+                <div className="tnd-chatbot-window" role="dialog" aria-label="Chat with us">
                     <div
-                        style={{
-                            padding: "16px 20px",
-                            borderBottom: "1px solid var(--neo-rule)",
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "center",
-                            background: "var(--neo-paper)",
-                        }}
+                        className="flex items-center justify-between px-5 py-4"
+                        style={{ borderBottom: RULE, background: "var(--khaki)" }}
                     >
                         <div>
-                            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                                <span className="live-dot"></span>
+                            <div className="flex items-center gap-2">
+                                <span className="tnd-live-dot" />
                                 <span
-                                    style={{
-                                        fontFamily: "var(--neo-serif)",
-                                        fontSize: 22,
-                                        fontStyle: "italic",
-                                        letterSpacing: "-.01em",
-                                    }}
+                                    className="italic"
+                                    style={{ fontFamily: "var(--font-fraunces)", fontWeight: 560, fontSize: 20, letterSpacing: "-.01em", color: "var(--ink)" }}
                                 >
                                     Ask Tendso
                                 </span>
                             </div>
-                            <div className="label" style={{ marginTop: 4 }}>Powered by our knowledge base</div>
+                            <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-soft">
+                                Powered by our knowledge base
+                            </div>
                         </div>
                         <button
                             onClick={() => setOpen(false)}
                             aria-label="Close chat"
-                            style={{
-                                width: 30,
-                                height: 30,
-                                borderRadius: "50%",
-                                border: "1px solid var(--neo-rule)",
-                                background: "var(--neo-paper-3)",
-                                color: "var(--neo-ink)",
-                                cursor: "pointer",
-                                fontSize: 14,
-                            }}
+                            className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full text-sm text-ink"
+                            style={{ border: RULE, background: "#fff" }}
                         >
                             ×
                         </button>
                     </div>
 
-                    <div
-                        ref={scrollRef}
-                        style={{
-                            flex: 1,
-                            // minHeight:0 lets this flex child shrink so it
-                            // scrolls within the window instead of clipping.
-                            minHeight: 0,
-                            padding: 16,
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: 10,
-                            overflowY: "auto",
-                        }}
-                    >
+                    <div ref={scrollRef} className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto p-4">
                         {messages.map((m, i) => (
                             <div
                                 key={i}
+                                className="max-w-[85%] px-3.5 py-2.5 text-sm leading-snug [overflow-wrap:anywhere]"
                                 style={{
                                     alignSelf: m.role === "user" ? "flex-end" : "flex-start",
-                                    background: m.role === "user" ? "var(--neo-ink)" : "var(--neo-paper-2)",
-                                    color: m.role === "user" ? "var(--neo-paper)" : "var(--neo-ink)",
-                                    padding: "10px 14px",
-                                    borderRadius:
-                                        m.role === "user"
-                                            ? "var(--neo-r-md) var(--neo-r-md) 4px var(--neo-r-md)"
-                                            : "var(--neo-r-md) var(--neo-r-md) var(--neo-r-md) 4px",
-                                    fontSize: 14,
-                                    lineHeight: 1.45,
-                                    maxWidth: "85%",
-                                    overflowWrap: "anywhere",
+                                    background: m.role === "user" ? "var(--ink)" : "var(--khaki-deep)",
+                                    color: m.role === "user" ? "var(--khaki)" : "var(--ink)",
+                                    borderRadius: m.role === "user" ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
                                 }}
                             >
                                 {m.text}
                                 {m.role === "bot" && m.sources && m.sources.length > 0 && (
-                                    <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 4 }}>
+                                    <div className="mt-2 flex flex-col gap-1">
                                         {m.sources.map((s) => (
                                             <a
                                                 key={s.slug}
                                                 href={`/knowledge?ws=help&article=${encodeURIComponent(s.slug)}`}
-                                                style={{
-                                                    fontSize: 12,
-                                                    color: "var(--neo-creator-ink)",
-                                                    textDecoration: "underline",
-                                                }}
+                                                className="text-xs underline"
+                                                style={{ color: "var(--rust)" }}
                                             >
                                                 → {s.title}
                                             </a>
@@ -159,50 +121,26 @@ export default function ChatBot() {
                             </div>
                         ))}
                         {busy && (
-                            <div
-                                style={{
-                                    alignSelf: "flex-start",
-                                    color: "var(--neo-ink-3)",
-                                    fontSize: 13,
-                                    padding: "8px 12px",
-                                }}
-                            >
-                                <span className="live-dot" style={{ marginRight: 6 }}></span>typing…
+                            <div className="self-start px-3 py-2 text-[13px] text-ink-soft">
+                                <span className="tnd-live-dot" style={{ marginRight: 6 }} />typing…
                             </div>
                         )}
                     </div>
 
-                    <div
-                        style={{
-                            padding: "10px 16px",
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: 6,
-                            borderTop: "1px solid var(--neo-rule)",
-                        }}
-                    >
+                    <div className="flex flex-wrap gap-1.5 px-4 py-2.5" style={{ borderTop: RULE }}>
                         {suggestions.map((s) => (
                             <button
                                 key={s}
                                 type="button"
                                 onClick={() => setInput(s)}
-                                className="tag"
-                                style={{ cursor: "pointer" }}
+                                className="cursor-pointer rounded-full border border-ink/15 bg-white px-3 py-1 text-xs text-ink-soft transition-colors hover:border-ink/30 hover:text-ink"
                             >
                                 {s}
                             </button>
                         ))}
                     </div>
 
-                    <div
-                        style={{
-                            padding: 12,
-                            display: "flex",
-                            gap: 8,
-                            borderTop: "1px solid var(--neo-rule)",
-                            background: "var(--neo-paper)",
-                        }}
-                    >
+                    <div className="flex gap-2 p-3" style={{ borderTop: RULE, background: "var(--khaki)" }}>
                         <input
                             value={input}
                             onChange={(e) => setInput(e.target.value)}
@@ -210,34 +148,16 @@ export default function ChatBot() {
                                 if (e.key === "Enter") ask();
                             }}
                             placeholder="Type a question…"
-                            style={{
-                                flex: 1,
-                                border: "1px solid var(--neo-rule)",
-                                background: "var(--neo-paper-3)",
-                                color: "var(--neo-ink)",
-                                padding: "10px 14px",
-                                borderRadius: "var(--neo-r-pill)",
-                                fontFamily: "var(--neo-sans)",
-                                fontSize: 14,
-                                outline: "none",
-                            }}
+                            className="flex-1 rounded-full px-3.5 py-2.5 text-sm text-ink outline-none"
+                            style={{ border: RULE, background: "#fff", fontFamily: "var(--font-plus-jakarta)" }}
                         />
                         <button
                             type="button"
                             onClick={ask}
                             disabled={!input.trim() || busy}
-                            style={{
-                                width: 40,
-                                height: 40,
-                                borderRadius: "50%",
-                                border: 0,
-                                background: "var(--neo-ink)",
-                                color: "var(--neo-paper)",
-                                cursor: "pointer",
-                                fontSize: 16,
-                                opacity: !input.trim() || busy ? 0.4 : 1,
-                            }}
                             aria-label="Send"
+                            className="flex h-10 w-10 flex-shrink-0 cursor-pointer items-center justify-center rounded-full text-base"
+                            style={{ background: "var(--ink)", color: "var(--khaki)", opacity: !input.trim() || busy ? 0.4 : 1 }}
                         >
                             ↑
                         </button>
@@ -247,7 +167,7 @@ export default function ChatBot() {
 
             <button
                 type="button"
-                className="chatbot-fab"
+                className="tnd-chatbot-fab"
                 onClick={() => setOpen((o) => !o)}
                 aria-label={open ? "Close chat" : "Open chat"}
             >

--- a/components/landing/CreatorTeaserSection.tsx
+++ b/components/landing/CreatorTeaserSection.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useT } from "./i18n";
+import { Eyebrow, SectionHeading, Lead } from "./ui";
+import { BASE_PRICE, REFERRAL_BONUS, commissionFor, formatPHP } from "@/lib/pricing";
+
+/**
+ * Creator earnings teaser — the honest replacement for the old EarningsSection
+ * (which carried fake testimonials + invented weekly/monthly income figures).
+ * Every number here is model-backed and derived from lib/pricing.ts: 50%
+ * commission (₱500 on a ₱999 site), a ₱1,000 referral bonus, and Wise payouts.
+ * The landing advertises the ₱999 base price, so the teaser stays anchored to
+ * it; the price-ceiling progression (up to ₱2,500) lives on /for-creators.
+ * No projections, no testimonials.
+ */
+export default function CreatorTeaserSection({
+    ctaHref = "/for-creators",
+    ceilingNote,
+    id,
+}: {
+    ctaHref?: string;
+    ceilingNote?: string;
+    id?: string;
+} = {}) {
+    const { t } = useT();
+
+    // Numbers interpolated from the pricing source of truth (never hardcoded here).
+    const f1sub = t("earn.f1sub")
+        .replace("{a}", formatPHP(commissionFor(BASE_PRICE)))
+        .replace("{b}", formatPHP(BASE_PRICE));
+
+    const facts = [
+        { big: "50%", label: t("earn.f1label"), sub: f1sub },
+        { big: formatPHP(REFERRAL_BONUS), label: t("earn.f2label"), sub: t("earn.f2sub") },
+        { big: "Wise", label: t("earn.f3label"), sub: t("earn.f3sub") },
+    ];
+
+    return (
+        <section id={id} className="bg-khaki">
+            <div className="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("earn.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">
+                        {t("earn.titleA")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>
+                            {t("earn.titleB")}
+                        </span>
+                    </SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("earn.lede")}</Lead>
+                </div>
+
+                <div className="mx-auto mt-12 grid max-w-4xl gap-5 sm:grid-cols-3">
+                    {facts.map((f) => (
+                        <div key={f.label} className="rounded-2xl border border-ink/10 bg-khaki-deep p-6">
+                            <div className="font-fraunces text-4xl text-ink" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                                {f.big}
+                            </div>
+                            <div className="mt-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                                {f.label}
+                            </div>
+                            <p className="mt-3 text-sm leading-relaxed text-ink-soft">{f.sub}</p>
+                        </div>
+                    ))}
+                </div>
+
+                {ceilingNote && (
+                    <p className="mx-auto mt-8 max-w-2xl text-center text-sm leading-relaxed text-ink-soft">
+                        {ceilingNote}
+                    </p>
+                )}
+
+                <div className="mt-9 text-center">
+                    <Link
+                        href={ctaHref}
+                        className="inline-flex items-center gap-2 rounded-lg bg-rust px-6 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                    >
+                        {t("earn.cta")}
+                        <span aria-hidden>→</span>
+                    </Link>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/components/landing/CreatorTeaserSection.tsx
+++ b/components/landing/CreatorTeaserSection.tsx
@@ -73,7 +73,7 @@ export default function CreatorTeaserSection({
                 <div className="mt-9 text-center">
                     <Link
                         href={ctaHref}
-                        className="inline-flex items-center gap-2 rounded-lg bg-rust px-6 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                        className="inline-flex items-center gap-2 rounded-lg bg-ink px-6 py-3.5 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5"
                     >
                         {t("earn.cta")}
                         <span aria-hidden>→</span>

--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -74,7 +74,7 @@ export default function CtaSection({
                         {isBiz ? (
                             <Link
                                 href={primaryHref}
-                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-ink transition-transform hover:-translate-y-0.5"
                             >
                                 {primaryLabel}
                                 <span aria-hidden>→</span>
@@ -82,7 +82,7 @@ export default function CtaSection({
                         ) : (
                             <a
                                 href={primaryHref}
-                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-ink transition-transform hover:-translate-y-0.5"
                             >
                                 {primaryLabel}
                                 <span aria-hidden>→</span>

--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -1,120 +1,105 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowUpRightIcon } from "./landingPrimitives";
 import { useT } from "./i18n";
 
-export default function CtaSection() {
+/**
+ * Final CTA — WP dark closing band.
+ *
+ * `focus`:
+ *  - "business": owner-first — one primary "Get a website" CTA + a small
+ *    secondary "want to earn instead?" creator link.
+ *  - "creator": creator-first — one primary "Get the app" CTA (app-first) + a
+ *    small secondary "own a business?" link.
+ *  - "both" (default): the two-door marketplace close.
+ */
+export default function CtaSection({
+    focus = "both",
+}: {
+    focus?: "business" | "creator" | "both";
+} = {}) {
     const { t } = useT();
+
+    const doors = [
+        { href: "/for-business", kicker: t("cta.doorBiz"), label: t("cta.business"), sub: t("cta.bizSub") },
+        { href: "/for-creators", kicker: t("cta.doorCreator"), label: t("cta.creator"), sub: t("cta.creatorSub") },
+    ];
+
+    const isBiz = focus === "business";
+    const primaryHref = isBiz ? "/for-business" : "#app";
+    const primaryLabel = isBiz ? t("hero.ctaBusiness") : t("nav.getApp");
+    const secondaryLead = isBiz ? t("hero.creatorLead") : t("cta.altBizLead");
+    const secondaryHref = isBiz ? "/for-creators" : "/for-business";
+    const secondaryLabel = isBiz ? t("hero.creatorLink") : t("hero.ctaBusiness");
+
     return (
-        <section
-            style={{
-                background: "var(--neo-ink)",
-                color: "var(--neo-paper)",
-                padding: "140px 0 120px",
-            }}
-        >
-            <div className="container-wide">
-                <div style={{ textAlign: "center", marginBottom: 64 }}>
-                    <div
-                        className="eyebrow"
-                        style={{ marginBottom: 24, color: "var(--neo-creator)" }}
-                    >
-                        The vision
-                    </div>
-                    <h2
-                        className="display"
-                        style={{
-                            fontSize: "clamp(56px, 8.5vw, 140px)",
-                            color: "var(--neo-paper)",
-                        }}
-                    >
-                        The Thinking
-                        <br />
-                        Ends Here.
-                        <br />
-                        <em style={{ fontStyle: "italic", color: "var(--neo-creator)" }}>So the work doesn&apos;t.</em>
-                    </h2>
-                    <p
-                        className="lede"
-                        style={{
-                            marginTop: 32,
-                            color: "oklch(80% 0.008 85)",
-                            maxWidth: "50ch",
-                            margin: "32px auto 0",
-                            textAlign: "center",
-                            fontSize: 18,
-                        }}
-                    >
-                        Pick the door that&apos;s yours. Your hands stay where they are.
+        <section className="bg-ink text-khaki">
+            <div className="mx-auto max-w-5xl px-6 py-24 sm:py-28">
+                <div className="text-center">
+                    <p className="font-sans text-[13px] font-semibold uppercase tracking-[0.14em]" style={{ color: "var(--rust-soft)" }}>
+                        {t("cta.eyebrow")}
                     </p>
-                </div>
-                <div
-                    className="grid grid-cols-1 md:grid-cols-2 gap-4"
-                    style={{
-                        maxWidth: 1080,
-                        margin: "0 auto",
-                    }}
-                >
-                    <Link
-                        href="/for-business"
-                        className="door door-business"
-                        style={{
-                            padding: "28px 24px",
-                            flexDirection: "column",
-                            alignItems: "flex-start",
-                            gap: 0,
-                            textDecoration: "none",
-                            display: "inline-flex",
-                        }}
+                    <h2
+                        className="mx-auto mt-5 max-w-3xl font-fraunces text-[clamp(2.25rem,6vw,4rem)] leading-[1.04] tracking-[-0.02em]"
+                        style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
                     >
-                        <span className="meta" style={{ marginBottom: 24 }}>
-                            For business owners <ArrowUpRightIcon />
-                        </span>
-                        <span
-                            className="text-[32px] sm:text-[40px] lg:text-[48px]"
-                            style={{
-                                fontFamily: "var(--neo-serif)",
-                                lineHeight: 0.98,
-                                letterSpacing: "-.02em",
-                            }}
-                        >
-                            {t("cta.business")}
-                        </span>
-                        <span style={{ fontSize: 13, opacity: 0.8, marginTop: 20 }}>
-                            A page built around the work. A creator visits, you keep going, the site goes live.
-                        </span>
-                    </Link>
-                    <Link
-                        href="/for-creators"
-                        className="door door-creator"
-                        style={{
-                            padding: "28px 24px",
-                            flexDirection: "column",
-                            alignItems: "flex-start",
-                            gap: 0,
-                            textDecoration: "none",
-                            display: "inline-flex",
-                        }}
-                    >
-                        <span className="meta" style={{ marginBottom: 24 }}>
-                            For creators <ArrowUpRightIcon />
-                        </span>
-                        <span
-                            className="text-[32px] sm:text-[40px] lg:text-[48px]"
-                            style={{
-                                fontFamily: "var(--neo-serif)",
-                                lineHeight: 0.98,
-                                letterSpacing: "-.02em",
-                            }}
-                        >
-                            {t("cta.creator")}
-                        </span>
-                        <span style={{ fontSize: 13, opacity: 0.8, marginTop: 20 }}>
-                            Help owners who can't stop working. Real earnings, real referrals, paid in 48 hours.
-                        </span>
-                    </Link>
+                        {t("cta.slogan1")}{" "}
+                        <span className="italic" style={{ color: "var(--rust-soft)" }}>{t("cta.slogan2")}</span>
+                    </h2>
+                    <p className="mx-auto mt-5 max-w-lg text-[17px] text-khaki/70">{t("cta.subtitle")}</p>
                 </div>
+
+                {focus === "both" ? (
+                    <div className="mx-auto mt-12 grid max-w-3xl gap-5 sm:grid-cols-2">
+                        {doors.map((d) => (
+                            <Link
+                                key={d.href}
+                                href={d.href}
+                                className="group flex flex-col rounded-2xl border border-khaki/15 bg-khaki/5 p-7 transition-colors hover:border-khaki/40"
+                            >
+                                <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-khaki/60">{d.kicker}</span>
+                                <span className="mt-4 font-fraunces text-2xl" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                                    {d.label}
+                                </span>
+                                <span className="mt-3 text-sm leading-relaxed text-khaki/65">{d.sub}</span>
+                                <span className="mt-5 inline-flex items-center gap-1 text-sm font-semibold" style={{ color: "var(--rust-soft)" }}>
+                                    {t("cta.go")}
+                                    <span aria-hidden className="transition-transform group-hover:translate-x-0.5">→</span>
+                                </span>
+                            </Link>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="mt-10 flex flex-col items-center gap-5">
+                        {isBiz ? (
+                            <Link
+                                href={primaryHref}
+                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                            >
+                                {primaryLabel}
+                                <span aria-hidden>→</span>
+                            </Link>
+                        ) : (
+                            <a
+                                href={primaryHref}
+                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-7 py-3.5 text-sm font-semibold text-khaki transition-transform hover:-translate-y-0.5"
+                            >
+                                {primaryLabel}
+                                <span aria-hidden>→</span>
+                            </a>
+                        )}
+                        <p className="text-sm text-khaki/60">
+                            {secondaryLead}{" "}
+                            <Link
+                                href={secondaryHref}
+                                className="font-semibold underline underline-offset-4"
+                                style={{ color: "var(--rust-soft)" }}
+                            >
+                                {secondaryLabel}
+                            </Link>
+                        </p>
+                    </div>
+                )}
             </div>
         </section>
     );

--- a/components/landing/EarningsSection.tsx
+++ b/components/landing/EarningsSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { CREATOR_EARNINGS, TESTIMONIALS } from "./landingData";
-import { Avatar, ArrowUpRightIcon } from "./landingPrimitives";
+import { CREATOR_EARNINGS } from "./landingData";
+import { ArrowUpRightIcon } from "./landingPrimitives";
 
 export default function EarningsSection() {
     return (
@@ -82,94 +82,6 @@ export default function EarningsSection() {
                     })}
                 </div>
 
-                {/* Earning reality */}
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-16">
-                    {[
-                        { label: "Per week, part-time", v: "₱1,500 – ₱3,500", n: "3–7 sites per week" },
-                        { label: "Per week, full-time", v: "₱5,000 – ₱12,000", n: "10+ sites + referral bonuses" },
-                        { label: "Top decile, month 6+", v: "₱24,000 +", n: "Active referral tree, multi-city", highlight: true },
-                    ].map((c) => (
-                        <div
-                            key={c.label}
-                            style={{
-                                padding: "32px 28px",
-                                background: c.highlight ? "var(--neo-creator)" : "transparent",
-                                border: c.highlight
-                                    ? "1px solid var(--neo-creator)"
-                                    : "1px solid oklch(40% 0.015 260)",
-                                color: c.highlight ? "white" : "var(--neo-paper)",
-                                borderRadius: "var(--neo-r-lg)",
-                            }}
-                        >
-                            <div
-                                className="label"
-                                style={{
-                                    marginBottom: 12,
-                                    color: c.highlight ? "oklch(95% 0.04 85)" : "oklch(72% 0.008 85)",
-                                }}
-                            >
-                                {c.label}
-                            </div>
-                            <div className="counter-num" style={{ fontSize: 36, marginBottom: 10, lineHeight: 1.0 }}>
-                                {c.v}
-                            </div>
-                            <div
-                                style={{
-                                    fontSize: 13,
-                                    color: c.highlight ? "oklch(95% 0.04 85)" : "oklch(70% 0.010 85)",
-                                }}
-                            >
-                                {c.n}
-                            </div>
-                        </div>
-                    ))}
-                </div>
-
-                {/* Testimonials */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-12">
-                    {TESTIMONIALS.map((t) => (
-                        <div
-                            key={t.name}
-                            style={{
-                                padding: 28,
-                                background: "oklch(20% 0.015 260)",
-                                border: "1px solid oklch(40% 0.015 260)",
-                                borderRadius: "var(--neo-r-lg)",
-                                display: "flex",
-                                flexDirection: "column",
-                                gap: 16,
-                            }}
-                        >
-                            <p
-                                className="pull-quote"
-                                style={{ fontSize: 22, lineHeight: 1.3, color: "var(--neo-paper)" }}
-                            >
-                                <em style={{ color: "var(--neo-creator)" }}>&ldquo;</em>
-                                {t.claim}
-                                <em style={{ color: "var(--neo-creator)" }}>&rdquo;</em>
-                            </p>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    gap: 12,
-                                    marginTop: "auto",
-                                    paddingTop: 16,
-                                    borderTop: "1px solid oklch(40% 0.015 260)",
-                                }}
-                            >
-                                <Avatar name={t.name} hue={t.hue} size={40} />
-                                <div>
-                                    <div style={{ fontWeight: 500, fontSize: 14 }}>{t.name}</div>
-                                    <div className="label" style={{ marginTop: 2, color: "oklch(72% 0.008 85)" }}>
-                                        {t.city} · verified
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-
                 {/* CTA */}
                 <div
                     style={{
@@ -186,7 +98,7 @@ export default function EarningsSection() {
                         className="display-3"
                         style={{ color: "var(--neo-paper)", maxWidth: "32ch" }}
                     >
-                        Your referral link lives in the app. Apply today, earn this week.
+                        Your referral link lives in the app. Free to apply, paid via Wise.
                     </div>
                     <Link
                         href="/for-creators"

--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -1,101 +1,83 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { FAQ_BUSINESS, FAQ_CREATOR } from "./landingData";
-import { Pill } from "./landingPrimitives";
+import { FAQ_BUSINESS, FAQ_CREATOR, FAQ_BUSINESS_TL, FAQ_CREATOR_TL } from "./landingData";
+import { useT } from "./i18n";
+import { Eyebrow, SectionHeading } from "./ui";
 
-export default function FaqSection() {
-    const [tab, setTab] = useState<"creators" | "business">("business");
+/** FAQ — WP accordion, tabbed (business / creator), hairline dividers.
+ *  `businessOnly` hides the tab switcher and shows only the business Q&A
+ *  (used on the owner-facing pages). */
+export default function FaqSection({
+    defaultTab = "business",
+    businessOnly = false,
+}: {
+    defaultTab?: "business" | "creators";
+    businessOnly?: boolean;
+} = {}) {
+    const { t, lang } = useT();
+    const [tab, setTab] = useState<"business" | "creators">(businessOnly ? "business" : defaultTab);
     const [open, setOpen] = useState(0);
-    const list = tab === "creators" ? FAQ_CREATOR : FAQ_BUSINESS;
+    const list =
+        lang === "tl"
+            ? tab === "creators"
+                ? FAQ_CREATOR_TL
+                : FAQ_BUSINESS_TL
+            : tab === "creators"
+              ? FAQ_CREATOR
+              : FAQ_BUSINESS;
 
     useEffect(() => {
         setOpen(0);
     }, [tab]);
 
     return (
-        <section id="faq">
-            <div className="container-wide">
-                <div className="sect-h">
-                    <div className="eyebrow">Questions</div>
-                    <div>
-                        <h2 className="display-2">
-                            Questions <em>worth asking.</em>
-                        </h2>
-                        <div style={{ display: "flex", gap: 8, marginTop: 24 }}>
-                            <Pill active={tab === "business"} onClick={() => setTab("business")}>
-                                For business owners
-                            </Pill>
-                            <Pill active={tab === "creators"} onClick={() => setTab("creators")}>
-                                For creators
-                            </Pill>
+        <section id="faq" className="bg-khaki">
+            <div className="mx-auto max-w-3xl px-6 py-20 sm:py-28">
+                <div className="text-center">
+                    <Eyebrow>{t("faq.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">{t("faq.title")}</SectionHeading>
+                    {!businessOnly && (
+                        <div className="mt-6 inline-flex gap-1 rounded-full border border-ink/10 bg-khaki-deep p-1">
+                            {(["business", "creators"] as const).map((k) => (
+                                <button
+                                    key={k}
+                                    onClick={() => setTab(k)}
+                                    className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                                        tab === k ? "bg-ink text-khaki" : "text-ink-soft hover:text-ink"
+                                    }`}
+                                >
+                                    {k === "business" ? t("faq.tabBusiness") : t("faq.tabCreators")}
+                                </button>
+                            ))}
                         </div>
-                    </div>
+                    )}
                 </div>
 
-                <div
-                    style={{
-                        maxWidth: 880,
-                        margin: "0 auto",
-                        borderTop: "1px solid var(--neo-rule-strong)",
-                    }}
-                >
-                    {list.map((qa, i) => (
-                        <div key={i} style={{ borderBottom: "1px solid var(--neo-rule)" }}>
-                            <button
-                                onClick={() => setOpen(open === i ? -1 : i)}
-                                style={{
-                                    width: "100%",
-                                    textAlign: "left",
-                                    padding: "24px 0",
-                                    display: "flex",
-                                    justifyContent: "space-between",
-                                    alignItems: "baseline",
-                                    gap: 24,
-                                    border: 0,
-                                    background: "transparent",
-                                    color: "var(--neo-ink)",
-                                    cursor: "pointer",
-                                }}
-                            >
-                                <span
-                                    style={{
-                                        fontFamily: "var(--neo-serif)",
-                                        fontSize: 24,
-                                        lineHeight: 1.25,
-                                        letterSpacing: "-.01em",
-                                    }}
+                <div className="mt-10 border-t border-ink/10">
+                    {list.map((qa, i) => {
+                        const isOpen = open === i;
+                        return (
+                            <div key={i} className="border-b border-ink/10">
+                                <button
+                                    onClick={() => setOpen(isOpen ? -1 : i)}
+                                    aria-expanded={isOpen}
+                                    className="flex w-full items-baseline justify-between gap-6 py-5 text-left"
                                 >
-                                    {qa.q}
-                                </span>
-                                <span
-                                    style={{
-                                        fontFamily: "var(--neo-mono)",
-                                        fontSize: 16,
-                                        transform: open === i ? "rotate(45deg)" : "rotate(0deg)",
-                                        transition: "transform .2s ease",
-                                        color: "var(--neo-ink-3)",
-                                    }}
-                                >
-                                    +
-                                </span>
-                            </button>
-                            {open === i && (
-                                <p
-                                    style={{
-                                        margin: 0,
-                                        paddingBottom: 24,
-                                        paddingRight: 60,
-                                        fontSize: 16,
-                                        color: "var(--neo-ink-2)",
-                                        lineHeight: 1.6,
-                                    }}
-                                >
-                                    {qa.a}
-                                </p>
-                            )}
-                        </div>
-                    ))}
+                                    <span className="font-fraunces text-lg text-ink sm:text-xl" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                                        {qa.q}
+                                    </span>
+                                    <span
+                                        aria-hidden
+                                        className={`font-mono text-lg text-ink-soft transition-transform duration-200 ${isOpen ? "rotate-45" : ""}`}
+                                    >
+                                        +
+                                    </span>
+                                </button>
+                                {isOpen && <p className="pb-5 pr-8 text-[15px] leading-relaxed text-ink-soft">{qa.a}</p>}
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
         </section>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -5,112 +5,68 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useT, type Lang } from "./i18n";
 
-const footColStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    gap: 10,
-    fontSize: 14,
-};
-
-const footSelStyle: React.CSSProperties = {
-    appearance: "none",
-    border: "1px solid oklch(40% 0.015 260)",
-    background: "transparent",
-    color: "oklch(85% 0.008 85)",
-    padding: "10px 12px",
-    fontFamily: "var(--neo-mono)",
-    fontSize: 11,
-    letterSpacing: ".08em",
-    textTransform: "uppercase",
-    cursor: "pointer",
-    width: "100%",
-    borderRadius: 8,
-};
-
 function FootCol({ title, children }: { title: string; children: React.ReactNode }) {
     return (
         <div>
-            <div className="label" style={{ marginBottom: 16 }}>{title}</div>
-            <div style={footColStyle}>{children}</div>
+            <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-khaki/50">{title}</div>
+            <div className="mt-4 flex flex-col gap-2.5 text-sm text-khaki/75 [&_a:hover]:text-khaki [&_a]:transition-colors">
+                {children}
+            </div>
         </div>
     );
 }
 
+/** Footer — WP dense multi-column directory, brand-token dark surface, real company info. */
 export default function Footer() {
-    const { lang, setLang } = useT();
+    const { lang, setLang, t } = useT();
     const apkUrl = useQuery(api.settings.get, { key: "apk_download_url" }) as string | null | undefined;
+    const year = new Date().getFullYear();
+
     return (
-        <footer className="neo-footer">
-            <div className="container-wide">
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr] gap-8 sm:gap-10 lg:gap-12 items-start">
+        <footer className="bg-ink text-khaki">
+            <div className="mx-auto max-w-6xl px-6 py-16">
+                <div className="grid grid-cols-1 items-start gap-10 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr]">
                     <div>
-                        <div style={{ marginBottom: 24 }}>
-                            {/* White wordmark — footer is a dark surface, no invert needed.
-                                eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                                src="/tendso-logo.png"
-                                alt="Tendso"
-                                width={200}
-                                height={36}
-                                style={{ display: "block" }}
-                            />
-                        </div>
-                        <p
-                            style={{
-                                maxWidth: "44ch",
-                                color: "oklch(72% 0.010 85)",
-                                lineHeight: 1.5,
-                                fontSize: 14,
-                            }}
-                        >
-                            A platform for the people who build for everyone else. Two doors, one map, one app — and a competitive moat the size of a country.
-                        </p>
+                        {/* White wordmark — footer is a dark surface, no invert needed. */}
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src="/tendso-logo.png" alt="Tendso" width={180} height={32} className="block" />
+                        <p className="mt-5 max-w-[42ch] text-sm leading-relaxed text-khaki/65">{t("footer.blurb")}</p>
+                        <p className="mt-4 text-xs leading-relaxed text-khaki/45">{t("footer.company")}</p>
                     </div>
-                    <FootCol title="Get the app">
+
+                    <FootCol title={t("footer.appCol")}>
                         {apkUrl ? (
-                            // Direct R2 public URL. The download filename
-                            // comes from the R2 storage key, which the
-                            // upload pipeline pins to "tendso.apk".
-                            <a href={apkUrl} download="tendso.apk">
-                                Android · Direct APK
-                            </a>
+                            <a href={apkUrl} download="tendso.apk">Android · Direct APK</a>
                         ) : (
-                            <Link href="/signup">Android · Direct APK</Link>
+                            <Link href="/for-creators">Android · Direct APK</Link>
                         )}
-                        <span style={{ opacity: 0.5 }}>iOS · Coming soon</span>
-                        <Link href="/knowledge">Knowledge base</Link>
-                        <Link href="/help-faq">Help</Link>
+                        <span className="text-khaki/40">iOS · {t("footer.comingSoon")}</span>
+                        <Link href="/knowledge">{t("footer.kb")}</Link>
+                        <Link href="/help-faq">{t("footer.help")}</Link>
                     </FootCol>
-                    <FootCol title="Legal">
-                        <Link href="/privacy-policy">Privacy</Link>
-                        <Link href="/terms-of-service">Terms</Link>
-                        <Link href="/contact">Contact</Link>
+
+                    <FootCol title={t("footer.legal")}>
+                        <Link href="/privacy-policy">{t("footer.privacy")}</Link>
+                        <Link href="/terms-of-service">{t("footer.terms")}</Link>
+                        <Link href="/contact">{t("footer.contact")}</Link>
                     </FootCol>
-                    <FootCol title="Language">
+
+                    <FootCol title={t("footer.language")}>
                         <select
                             value={lang}
                             onChange={(e) => setLang(e.target.value as Lang)}
-                            style={footSelStyle}
                             aria-label="Language"
+                            className="w-full appearance-none rounded-lg border border-khaki/20 bg-transparent px-3 py-2.5 font-mono text-[11px] uppercase tracking-[0.08em] text-khaki/80"
                         >
-                            <option value="en">English</option>
-                            <option value="tl">Tagalog</option>
+                            <option value="en" className="text-ink">English</option>
+                            <option value="tl" className="text-ink">Tagalog</option>
                         </select>
                     </FootCol>
                 </div>
-                <div
-                    style={{
-                        marginTop: 48,
-                        paddingTop: 24,
-                        borderTop: "1px solid oklch(40% 0.015 260)",
-                        display: "flex",
-                        justifyContent: "space-between",
-                        fontSize: 12,
-                        color: "oklch(60% 0.010 85)",
-                    }}
-                >
-                    <span className="label">© Tendso · {new Date().getFullYear()}</span>
-                    <span className="label">Map data: OpenStreetMap · CARTO</span>
+
+                <div className="mt-12 flex flex-wrap justify-between gap-4 border-t border-khaki/10 pt-6 font-mono text-[11px] uppercase tracking-[0.1em] text-khaki/45">
+                    <span>© {year} Tendso</span>
+                    <span>VONAS, OPC · Philippines</span>
                 </div>
             </div>
         </footer>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -20,6 +20,7 @@ function FootCol({ title, children }: { title: string; children: React.ReactNode
 export default function Footer() {
     const { lang, setLang, t } = useT();
     const apkUrl = useQuery(api.settings.get, { key: "apk_download_url" }) as string | null | undefined;
+    const appStoreUrl = useQuery(api.settings.get, { key: "app_store_url" }) as string | null | undefined;
     const year = new Date().getFullYear();
 
     return (
@@ -40,7 +41,11 @@ export default function Footer() {
                         ) : (
                             <Link href="/for-creators">Android · Direct APK</Link>
                         )}
-                        <span className="text-khaki/40">iOS · {t("footer.comingSoon")}</span>
+                        {appStoreUrl && appStoreUrl.trim() ? (
+                            <a href={appStoreUrl} target="_blank" rel="noreferrer">iOS · App Store</a>
+                        ) : (
+                            <span className="text-khaki/40">iOS · {t("footer.comingSoon")}</span>
+                        )}
                         <Link href="/knowledge">{t("footer.kb")}</Link>
                         <Link href="/help-faq">{t("footer.help")}</Link>
                     </FootCol>

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -1,256 +1,107 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { useQuery } from "convex/react";
-import { api } from "@/convex/_generated/api";
-import { useTickUp, ArrowDownIcon, ArrowUpRightIcon } from "./landingPrimitives";
-import { fmt, COUNTERS_GROWTH, HARDCODED_LIVE_SITE_COUNT } from "./landingData";
 import { useT } from "./i18n";
+import { CAROUSEL_SITES } from "./landingData";
+import LiveSitePreview from "./LiveSitePreview";
 
-// Live clock that only renders post-mount to avoid SSR/CSR hydration mismatch.
-// The server has no way to know the client's "now" within the same minute, so
-// rendering the string on the server is guaranteed to differ from the client.
-function LiveClockTime() {
-    const [time, setTime] = useState<string | null>(null);
-    useEffect(() => {
-        const tick = () =>
-            setTime(
-                new Date().toLocaleTimeString("en-US", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                }),
-            );
-        tick();
-        const id = setInterval(tick, 30_000);
-        return () => clearInterval(id);
-    }, []);
-    // Render a non-breaking space placeholder until mount so the surrounding
-    // layout doesn't reflow when the clock pops in.
-    return <>{time ?? "——:——"} PHT</>;
-}
-
-// Same defer-to-mount treatment for the magazine-style issue line. The page
-// can be cached at build time and served weeks later, so server-rendered
-// month/year may legitimately disagree with the client.
-function IssueDate() {
-    const [label, setLabel] = useState<string | null>(null);
-    useEffect(() => {
-        setLabel(
-            new Date().toLocaleString("en-US", {
-                month: "long",
-                year: "numeric",
-            }),
-        );
-    }, []);
-    return <>{label ?? " "}</>;
-}
-
-
-function CounterRow({ value, label, last }: { value: number; label: string; last?: boolean }) {
+function Check() {
     return (
-        <div
-            style={{
-                padding: "18px 24px",
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "baseline",
-                borderBottom: last ? "none" : "1px solid var(--neo-rule)",
-            }}
-        >
-            <span className="counter-num" style={{ fontSize: 40 }}>{fmt(value)}</span>
-            <span className="label">{label}</span>
-        </div>
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ color: "var(--rust)" }}>
+            <path d="M20 6 9 17l-5-5" />
+        </svg>
     );
 }
 
-function DoorButton({
-    kind,
-    href,
-    title,
-    sub,
-    note,
-}: {
-    kind: "business" | "creator";
-    href: string;
-    title: string;
-    sub: string;
-    note: string;
-}) {
-    return (
-        <Link
-            href={href}
-            className={`door door-${kind} p-5 sm:p-7`}
-            style={{
-                flexDirection: "column",
-                alignItems: "flex-start",
-                gap: 0,
-                textDecoration: "none",
-                display: "inline-flex",
-            }}
-        >
-            <span className="meta" style={{ marginBottom: 12 }}>
-                {sub} <span className="arrow"><ArrowUpRightIcon /></span>
-            </span>
-            <span
-                className="text-[28px] sm:text-[34px] lg:text-[38px]"
-                style={{
-                    fontFamily: "var(--neo-serif)",
-                    lineHeight: 0.98,
-                    letterSpacing: "-.02em",
-                }}
-            >
-                {title}
-            </span>
-            <span style={{ fontSize: 13, opacity: 0.85, marginTop: 12, lineHeight: 1.5 }}>{note}</span>
-        </Link>
-    );
-}
+// The real client site shown in the hero preview (first curated site).
+const HERO_SITE = CAROUSEL_SITES[0];
+const HERO_HOST = (HERO_SITE?.url ?? "").replace(/^https?:\/\//, "").replace(/\/$/, "");
 
 export default function HeroSection() {
-    // Live creator count comes from Convex; site count is hardcoded — derived
-    // from the SHOWCASE_SITES list in landingData.ts (single source of truth).
-    const liveCreators = useQuery(api.creators.count, {}) as number | undefined;
-
     const { t } = useT();
-    // Localized copy, shaped to match the field names the JSX below already uses.
-    const T = {
-        hero_main: [t("hero.h1a"), t("hero.h1b"), t("hero.h1c"), "."] as const,
-        hero_main_em: t("hero.em"),
-        hero_lede: t("hero.lede"),
-        door_business: t("hero.doorBusiness"),
-        door_business_sub: t("hero.doorBusinessSub"),
-        door_creator: t("hero.doorCreator"),
-        door_creator_sub: t("hero.doorCreatorSub"),
-        counter_creators: t("hero.counterCreators"),
-        counter_businesses: t("hero.counterBusinesses"),
-        counter_cities: t("hero.counterCities"),
-        counter_countries: t("hero.counterCountries"),
-    };
-
-    const creators = useTickUp(liveCreators ?? COUNTERS_GROWTH.creators);
-    const businesses = useTickUp(HARDCODED_LIVE_SITE_COUNT);
-    const cities = useTickUp(COUNTERS_GROWTH.cities);
-    const countries = useTickUp(COUNTERS_GROWTH.countries);
-    const hm = T.hero_main;
 
     return (
-        <section className="pt-12 pb-12 sm:pt-14 sm:pb-12">
-            <div className="container-wide">
-                <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1.55fr)_minmax(280px,1fr)] gap-10 lg:gap-14 lg:items-end mb-10 lg:mb-12">
-                    <div>
-                        <div
-                            className="eyebrow"
-                            style={{
-                                marginBottom: 24,
-                                display: "inline-flex",
-                                alignItems: "center",
-                                gap: 10,
-                                padding: "6px 14px",
-                                border: "1px solid var(--neo-rule)",
-                                borderRadius: "var(--neo-r-pill)",
-                                background: "var(--neo-paper-3)",
-                            }}
+        <section className="flex min-h-[calc(100svh-3.75rem)] items-center bg-khaki">
+            <div className="mx-auto w-full max-w-6xl px-6 py-16">
+                <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+                    {/* Left: the pitch */}
+                    <div className="text-center lg:text-left">
+                        <span className="inline-flex items-center gap-2 rounded-full border border-ink/10 bg-white px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                            <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--rust)" }} />
+                            {t("hero.trustChip")}
+                        </span>
+
+                        <h1
+                            className="mx-auto mt-7 max-w-xl font-fraunces text-[clamp(2.25rem,5.2vw,3.75rem)] leading-[1.05] tracking-[-0.02em] text-ink lg:mx-0"
+                            style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
                         >
-                            <span className="live-dot"></span>
-                            {t("hero.issue")} · <IssueDate />
-                        </div>
-                        <h1 className="display">
-                            {hm[0]}
-                            <br />
-                            {hm[1]}<em>{hm[2]}</em>{hm[3]}
+                            {t("hero.h1a")}{" "}
+                            <span className="whitespace-nowrap">
+                                {t("hero.h1b")}
+                                <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>
+                                    {t("hero.h1c")}
+                                </span>
+                            </span>
                         </h1>
-                        <div
-                            className="serif"
-                            style={{
-                                fontSize: "clamp(20px, 1.8vw, 28px)",
-                                fontStyle: "italic",
-                                color: "var(--neo-ink-2)",
-                                marginTop: 18,
-                                letterSpacing: "-.01em",
-                            }}
-                        >
-                            {T.hero_main_em}
-                        </div>
-                        <p className="lede" style={{ marginTop: 28, fontSize: 18, maxWidth: "58ch" }}>
-                            {T.hero_lede}
+
+                        <p className="mx-auto mt-6 max-w-md text-[17px] leading-relaxed text-ink-soft lg:mx-0">
+                            {t("hero.lede")}
                         </p>
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 28 }}>
-                            {[
-                                t("hero.tag1"),
-                                t("hero.tag2"),
-                                t("hero.tag3"),
-                                t("hero.tag4"),
-                                t("hero.tag5"),
-                            ].map((p) => (
-                                <span
-                                    key={p}
-                                    className="tag"
-                                    style={{
-                                        padding: "6px 14px",
-                                        fontSize: 11,
-                                        background: "var(--neo-paper-3)",
-                                        color: "var(--neo-ink-2)",
-                                    }}
-                                >
-                                    {p}
+
+                        <div className="mt-8 flex flex-wrap items-center justify-center gap-3 lg:justify-start">
+                            <Link
+                                href="/for-business"
+                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-6 py-3.5 text-sm font-semibold text-ink shadow-[0_10px_30px_-10px_rgba(200,149,72,0.6)] transition-transform hover:-translate-y-0.5"
+                            >
+                                {t("hero.ctaBusiness")}
+                                <span aria-hidden="true">→</span>
+                            </Link>
+                            <a
+                                href="#proof"
+                                className="inline-flex items-center gap-2 rounded-xl border border-ink/15 bg-white px-6 py-3.5 text-sm font-semibold text-ink transition-colors hover:border-ink/35"
+                            >
+                                {t("hero.ctaProof")}
+                            </a>
+                        </div>
+
+                        <div className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2.5 text-sm text-ink-soft lg:justify-start">
+                            {[t("hero.tag1"), t("hero.tag2"), t("hero.tag3")].map((tag) => (
+                                <span key={tag} className="inline-flex items-center gap-1.5">
+                                    <Check />
+                                    {tag}
                                 </span>
                             ))}
                         </div>
-                    </div>
-                    <div className="surface">
-                        <div
-                            style={{
-                                padding: "14px 18px",
-                                borderBottom: "1px solid var(--neo-rule)",
-                                display: "flex",
-                                justifyContent: "space-between",
-                                alignItems: "center",
-                            }}
-                        >
-                            <span className="label">
-                                <span className="live-dot" style={{ marginRight: 6 }}></span>
-                                Live · <LiveClockTime />
-                            </span>
-                            <span className="label" style={{ color: "var(--neo-live)" }}>↑ updating</span>
-                        </div>
-                        <CounterRow value={creators} label={T.counter_creators} />
-                        <CounterRow value={businesses} label={T.counter_businesses} />
-                        <CounterRow value={cities} label={T.counter_cities} />
-                        <CounterRow value={countries} label={T.counter_countries} last />
-                    </div>
-                </div>
 
-                <div className="pt-8" style={{ borderTop: "1px solid var(--neo-rule-strong)" }}>
-                    <div className="label" style={{ marginBottom: 16 }}>{t("hero.pickDoor")}</div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
-                        <DoorButton
-                            kind="business"
-                            href="/for-business"
-                            sub={T.door_business_sub}
-                            title={T.door_business}
-                            note={t("hero.doorBusinessNote")}
-                        />
-                        <DoorButton
-                            kind="creator"
-                            href="/for-creators"
-                            sub={T.door_creator_sub}
-                            title={T.door_creator}
-                            note={t("hero.doorCreatorNote")}
-                        />
+                        <p className="mt-9 text-sm text-ink-soft">
+                            {t("hero.creatorLead")}{" "}
+                            <Link
+                                href="/for-creators"
+                                className="font-semibold text-ink underline decoration-2 underline-offset-4 transition-colors hover:opacity-70"
+                                style={{ textDecorationColor: "var(--rust)" }}
+                            >
+                                {t("hero.creatorLink")}
+                            </Link>
+                        </p>
                     </div>
-                    <div
-                        style={{
-                            marginTop: 24,
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 12,
-                            color: "var(--neo-ink-3)",
-                            fontSize: 13,
-                        }}
-                    >
-                        <ArrowDownIcon />
-                        <span>{t("hero.scroll")}</span>
+
+                    {/* Right: a framed live preview of a real client site */}
+                    <div className="mx-auto w-full max-w-md lg:max-w-none">
+                        <div className="overflow-hidden rounded-xl border border-ink/10 bg-white shadow-[0_34px_70px_-34px_rgba(27,28,36,0.5)]">
+                            {/* Browser chrome */}
+                            <div className="flex items-center gap-1.5 border-b border-ink/10 bg-khaki-deep px-3.5 py-2.5">
+                                <span className="h-2.5 w-2.5 rounded-full bg-ink/15" />
+                                <span className="h-2.5 w-2.5 rounded-full bg-ink/15" />
+                                <span className="h-2.5 w-2.5 rounded-full bg-ink/15" />
+                                <span className="ml-2 truncate rounded-md bg-white px-2 py-0.5 font-mono text-[10px] text-ink-soft">
+                                    {HERO_HOST}
+                                </span>
+                            </div>
+                            {HERO_SITE?.url && <LiveSitePreview url={HERO_SITE.url} name={HERO_SITE.name} />}
+                        </div>
+                        <p className="mt-3 text-center font-mono text-[11px] uppercase tracking-[0.12em] text-ink-soft lg:text-left">
+                            {t("hero.previewCaption")}
+                        </p>
                     </div>
                 </div>
             </div>

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -51,7 +51,7 @@ export default function HeroSection() {
                         <div className="mt-8 flex flex-wrap items-center justify-center gap-3 lg:justify-start">
                             <Link
                                 href="/for-business"
-                                className="inline-flex items-center gap-2 rounded-xl bg-rust px-6 py-3.5 text-sm font-semibold text-ink shadow-[0_10px_30px_-10px_rgba(200,149,72,0.6)] transition-transform hover:-translate-y-0.5"
+                                className="inline-flex items-center gap-2 rounded-xl bg-ink px-6 py-3.5 text-sm font-semibold text-white shadow-[0_12px_32px_-12px_rgba(27,28,36,0.45)] transition-transform hover:-translate-y-0.5"
                             >
                                 {t("hero.ctaBusiness")}
                                 <span aria-hidden="true">→</span>

--- a/components/landing/HowItWorks.tsx
+++ b/components/landing/HowItWorks.tsx
@@ -1,113 +1,87 @@
 "use client";
 
+import Link from "next/link";
+import { useT } from "./i18n";
+import { Eyebrow, SectionHeading, Lead } from "./ui";
+
+/**
+ * How it works — two honest tracks side by side (business owner vs creator).
+ * WP-style: paper band, quiet bordered cards, mono step numbers, one gold accent
+ * (the per-track CTA link). Content is TRUE: owners never "sign up" (a creator
+ * comes to them; they only review + pay when live); the creator track is the one
+ * real signup. Turnaround is framed as typical, not guaranteed.
+ */
+
 function Track({
     label,
     steps,
-    kind,
+    ctaLabel,
+    ctaHref,
 }: {
     label: string;
     steps: string[];
-    kind: "business" | "creator";
+    ctaLabel: string;
+    ctaHref: string;
 }) {
-    const bg = kind === "creator" ? "var(--neo-creator-bg)" : "var(--neo-business-bg)";
-    const ink = kind === "creator" ? "var(--neo-creator-ink)" : "var(--neo-business-ink)";
     return (
-        <div className="card" style={{ background: "var(--neo-paper-3)", padding: "40px 32px 32px" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 32 }}>
-                <span
-                    style={{
-                        padding: "4px 10px",
-                        background: bg,
-                        color: ink,
-                        fontFamily: "var(--neo-mono)",
-                        fontSize: 10,
-                        letterSpacing: ".12em",
-                        textTransform: "uppercase",
-                        borderRadius: 999,
-                    }}
-                >
-                    {label}
-                </span>
-            </div>
-            <ol style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 1 }}>
+        <div className="flex flex-col rounded-2xl border border-ink/10 bg-khaki p-7 sm:p-8">
+            <span className="inline-flex w-fit items-center rounded-full border border-ink/15 px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                {label}
+            </span>
+            <ol className="mt-6 flex flex-col">
                 {steps.map((s, i) => (
                     <li
                         key={i}
-                        style={{
-                            display: "grid",
-                            gridTemplateColumns: "44px 1fr",
-                            alignItems: "baseline",
-                            padding: "20px 0",
-                            borderTop: "1px solid var(--neo-rule)",
-                        }}
+                        className="grid grid-cols-[2.25rem_1fr] items-baseline gap-2 border-t border-ink/10 py-4 first:border-t-0 first:pt-0"
                     >
-                        <span
-                            style={{
-                                fontFamily: "var(--neo-mono)",
-                                fontSize: 12,
-                                color: ink,
-                                letterSpacing: ".05em",
-                            }}
-                        >
-                            0{i + 1}
-                        </span>
-                        <span
-                            style={{
-                                fontFamily: "var(--neo-serif)",
-                                fontSize: 22,
-                                lineHeight: 1.2,
-                                letterSpacing: "-.01em",
-                            }}
-                        >
-                            {s}
-                        </span>
+                        <span className="font-mono text-xs text-ink-soft">0{i + 1}</span>
+                        <span className="text-[15px] leading-snug text-ink sm:text-base">{s}</span>
                     </li>
                 ))}
             </ol>
+            <Link
+                href={ctaHref}
+                className="mt-7 inline-flex w-fit items-center gap-1 text-sm font-semibold text-rust transition-opacity hover:opacity-70"
+            >
+                {ctaLabel}
+                <span aria-hidden>→</span>
+            </Link>
         </div>
     );
 }
 
-export default function HowItWorks({ door = null }: { door?: "business" | "creator" | null }) {
-    const business = [
-        "Sign up — no card required until your site is live.",
-        "Pick a creator nearby. Or let one find you.",
-        "Sit for a short interview. 30 minutes, your shop.",
-        "Approve your site. Pay only once it's live (₱999 or ₱1,499).",
-    ];
-    const creator = [
-        "Download the app and verify your phone.",
-        "Get certified — free, fast, in 20 minutes.",
-        "Visit local businesses with guided capture.",
-        "Keep 50% of every sale — ₱500 to ₱2,500 per site · ₱1,000 referral.",
-    ];
-    const businessFirst = door !== "creator";
+export default function HowItWorks() {
+    const { t } = useT();
+
+    const business = [t("how.biz1"), t("how.biz2"), t("how.biz3"), t("how.biz4")];
+    const creator = [t("how.creator1"), t("how.creator2"), t("how.creator3"), t("how.creator4")];
 
     return (
-        <section id="how-it-works" style={{ background: "var(--neo-paper-2)" }}>
-            <div className="container-wide">
-                <div className="sect-h">
-                    <div className="eyebrow">How It Works</div>
-                    <div>
-                        <h2 className="display-2">
-                            Two flows. <em style={{ color: "var(--neo-creator)", fontStyle: "italic" }}>Side by side.</em>
-                        </h2>
-                        <p className="lede" style={{ marginTop: 12 }}>
-                            Pick yours. The other one is for someone else. That&apos;s the entire point of this page.
-                        </p>
-                    </div>
+        <section id="how-it-works" className="bg-khaki">
+            <div className="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("how.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">
+                        {t("how.titleA")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>
+                            {t("how.titleB")}
+                        </span>
+                    </SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("how.lede")}</Lead>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="mx-auto mt-12 grid max-w-4xl gap-6 md:grid-cols-2">
                     <Track
-                        label={businessFirst ? "For business owners" : "For creators"}
-                        steps={businessFirst ? business : creator}
-                        kind={businessFirst ? "business" : "creator"}
+                        label={t("how.bizLabel")}
+                        steps={business}
+                        ctaLabel={t("how.bizCta")}
+                        ctaHref="/for-business"
                     />
                     <Track
-                        label={businessFirst ? "For creators" : "For business owners"}
-                        steps={businessFirst ? creator : business}
-                        kind={businessFirst ? "creator" : "business"}
+                        label={t("how.creatorLabel")}
+                        steps={creator}
+                        ctaLabel={t("how.creatorCta")}
+                        ctaHref="/for-creators"
                     />
                 </div>
             </div>

--- a/components/landing/LiveSitePreview.tsx
+++ b/components/landing/LiveSitePreview.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * A live, scaled, non-interactive preview of a real site — it renders the actual
+ * page in an iframe at desktop width and scales it to fill its container (16:9).
+ * Because it's the live site (not a stored screenshot), the preview can never
+ * drift "a version behind" the real page. The iframe is inert (pointer-events
+ * off, not focusable, hidden from the a11y tree) so a wrapping link owns clicks.
+ */
+const DESIGN_WIDTH = 1280; // render each site at desktop width, then scale down
+
+export default function LiveSitePreview({ url, name }: { url: string; name: string }) {
+    const boxRef = useRef<HTMLDivElement | null>(null);
+    const [scale, setScale] = useState(0);
+    const [loaded, setLoaded] = useState(false);
+
+    // Scale = container width / design width, kept in sync with responsive resizes.
+    useEffect(() => {
+        const el = boxRef.current;
+        if (!el || typeof ResizeObserver === "undefined") return;
+        const ro = new ResizeObserver((entries) => {
+            const w = entries[0]?.contentRect.width ?? 0;
+            if (w > 0) setScale(w / DESIGN_WIDTH);
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    // At 1280×720 scaled by (width/1280), the iframe exactly fills the 16:9 box.
+    const iframeHeight = (DESIGN_WIDTH * 9) / 16;
+
+    return (
+        <div ref={boxRef} className="relative aspect-video w-full overflow-hidden bg-khaki-deep">
+            {/* Loading shimmer until the live page paints */}
+            {!loaded && <div aria-hidden className="absolute inset-0 animate-pulse bg-khaki-deep" />}
+            {scale > 0 && (
+                <iframe
+                    src={url}
+                    title={`${name} — live website`}
+                    loading="lazy"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                    scrolling="no"
+                    onLoad={() => setLoaded(true)}
+                    className="absolute left-0 top-0 origin-top-left border-0 transition-opacity duration-500"
+                    style={{
+                        width: `${DESIGN_WIDTH}px`,
+                        height: `${iframeHeight}px`,
+                        transform: `scale(${scale})`,
+                        pointerEvents: "none",
+                        opacity: loaded ? 1 : 0,
+                    }}
+                />
+            )}
+        </div>
+    );
+}

--- a/components/landing/ManifestoSection.tsx
+++ b/components/landing/ManifestoSection.tsx
@@ -1,56 +1,38 @@
 "use client";
 
+import { useT } from "./i18n";
+import { Eyebrow } from "./ui";
+
 function Beat({ label, big, sub }: { label: string; big: string; sub: string }) {
     return (
         <div>
-            <div className="label" style={{ marginBottom: 12 }}>{label}</div>
-            <div className="counter-num" style={{ fontSize: 44, lineHeight: 1.0, marginBottom: 12 }}>{big}</div>
-            <div style={{ fontSize: 14, color: "var(--neo-ink-2)", lineHeight: 1.55 }}>{sub}</div>
+            <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">{label}</div>
+            <div className="mt-2 font-fraunces text-4xl text-ink" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                {big}
+            </div>
+            <p className="mt-2 text-sm leading-relaxed text-ink-soft">{sub}</p>
         </div>
     );
 }
 
+/** Manifesto — WP narrow editorial column, one gold accent, three supporting beats. */
 export default function ManifestoSection() {
+    const { t } = useT();
     return (
-        <section style={{ background: "var(--neo-paper-2)" }} className="py-16 sm:py-20 lg:py-[120px]">
-            <div className="container-wide">
-                <div className="grid grid-cols-1 lg:grid-cols-[minmax(160px,1fr)_4fr] gap-6 lg:gap-12">
-                    <div className="eyebrow">Manifesto</div>
-                    <div>
-                        <p
-                            className="display-2"
-                            style={{
-                                fontSize: "clamp(36px, 4.4vw, 64px)",
-                                lineHeight: 1.08,
-                                letterSpacing: "-.02em",
-                            }}
-                        >
-                            They did not come here to become{" "}
-                            <em style={{ fontStyle: "italic" }}>designers</em>.
-                            <br />
-                            <span style={{ color: "var(--neo-creator)" }}>They came here to keep the business moving.</span>
-                        </p>
-                        <div
-                            className="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-8 pt-8"
-                            style={{ borderTop: "1px solid var(--neo-rule)" }}
-                        >
-                            <Beat
-                                label="What we respect"
-                                big="The work"
-                                sub="Sari-sari stores, salons, barangay clinics — the shops where someone is already kneading, cutting, or fixing while you read this."
-                            />
-                            <Beat
-                                label="How fast"
-                                big="48 hrs"
-                                sub="From the day a creator walks into your shop to the day your page is live. You keep working through all of it."
-                            />
-                            <Beat
-                                label="What it takes from you"
-                                big="A photo"
-                                sub="A few answers. A guided review. That's the whole ask. We built the rest around the work."
-                            />
-                        </div>
-                    </div>
+        <section className="bg-khaki-deep">
+            <div className="mx-auto max-w-3xl px-6 py-20 text-center sm:py-28">
+                <Eyebrow>{t("manifesto.eyebrow")}</Eyebrow>
+                <p
+                    className="mx-auto mt-6 max-w-2xl font-fraunces text-[clamp(1.9rem,4vw,3.25rem)] leading-[1.12] tracking-[-0.02em] text-ink"
+                    style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
+                >
+                    {t("manifesto.line1")}{" "}
+                    <span className="italic" style={{ color: "var(--rust)" }}>{t("manifesto.line2")}</span>
+                </p>
+                <div className="mt-12 grid gap-8 border-t border-ink/10 pt-10 text-left sm:grid-cols-3">
+                    <Beat label={t("manifesto.b1label")} big={t("manifesto.b1big")} sub={t("manifesto.b1sub")} />
+                    <Beat label={t("manifesto.b2label")} big={t("manifesto.b2big")} sub={t("manifesto.b2sub")} />
+                    <Beat label={t("manifesto.b3label")} big={t("manifesto.b3big")} sub={t("manifesto.b3sub")} />
                 </div>
             </div>
         </section>

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -4,56 +4,65 @@ import Link from "next/link";
 import { Logo } from "./landingPrimitives";
 import { useT, type Lang } from "./i18n";
 
-const selectStyle: React.CSSProperties = {
-    appearance: "none",
-    border: "1px solid var(--neo-rule)",
-    background: "var(--neo-paper-3)",
-    color: "var(--neo-ink)",
-    padding: "8px 12px",
-    fontFamily: "var(--neo-mono)",
-    fontSize: 11,
-    letterSpacing: ".08em",
-    textTransform: "uppercase",
-    cursor: "pointer",
-    borderRadius: 8,
-};
-
 export default function Navbar() {
     const { lang, setLang, t } = useT();
-    return (
-        <div className="topbar">
-            <div
-                className="container-wide flex items-center justify-between gap-3"
-                style={{ paddingTop: 12, paddingBottom: 12 }}
-            >
-                {/* Left cluster — logo + live status (status hides on phones) */}
-                <div className="flex items-center gap-2 sm:gap-4 min-w-0">
-                    <Link href="/" style={{ textDecoration: "none" }} className="flex-shrink-0">
-                        <Logo />
-                    </Link>
-                    {/* Region label — hide on <md to avoid wrap/overflow. (Region
-                        dropdown removed: PH-only for now; this label states it.) */}
-                    <div className="label items-center gap-2 hidden md:flex">
-                        <span className="live-dot"></span>
-                        {t("nav.live")}
-                    </div>
-                </div>
 
-                {/* Right cluster — language switch. (The "Get the app" button
-                    moved to the dedicated download section below the hero.) */}
-                <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
+    // Anchors are home-anchored (/#id) so they work from the sub-pages too, and
+    // render as plain <a> (Next <Link> doesn't reliably scroll to same-page hashes).
+    const links = [
+        { href: "/#how-it-works", label: t("nav.how") },
+        { href: "/#proof", label: t("nav.sites") },
+        { href: "/#pricing", label: t("nav.pricing") },
+        { href: "/for-creators", label: t("nav.creators") },
+    ];
+
+    return (
+        <header className="sticky top-0 z-50 border-b border-ink/10 bg-khaki/85 backdrop-blur-md">
+            <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-3.5">
+                <Link href="/" aria-label="Tendso home" className="flex-shrink-0">
+                    <Logo />
+                </Link>
+
+                <nav className="hidden items-center gap-7 md:flex">
+                    {links.map((l) =>
+                        l.href.includes("#") ? (
+                            <a
+                                key={l.href}
+                                href={l.href}
+                                className="text-sm font-medium text-ink-soft transition-colors hover:text-ink"
+                            >
+                                {l.label}
+                            </a>
+                        ) : (
+                            <Link
+                                key={l.href}
+                                href={l.href}
+                                className="text-sm font-medium text-ink-soft transition-colors hover:text-ink"
+                            >
+                                {l.label}
+                            </Link>
+                        ),
+                    )}
+                </nav>
+
+                <div className="flex items-center gap-2 sm:gap-3">
                     <select
                         value={lang}
                         onChange={(e) => setLang(e.target.value as Lang)}
-                        style={selectStyle}
                         aria-label="Language"
-                        className="hidden sm:inline-block"
+                        className="hidden rounded-lg border border-ink/15 bg-white px-2.5 py-1.5 font-mono text-[11px] uppercase tracking-wide text-ink-soft sm:inline-block"
                     >
                         <option value="en">EN</option>
-                        <option value="tl">Tagalog</option>
+                        <option value="tl">TL</option>
                     </select>
+                    <Link
+                        href="/for-business"
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5"
+                    >
+                        {t("hero.ctaBusiness")}
+                    </Link>
                 </div>
             </div>
-        </div>
+        </header>
     );
 }

--- a/components/landing/ProcessSection.tsx
+++ b/components/landing/ProcessSection.tsx
@@ -1,56 +1,10 @@
 "use client";
 
-/* Headings are subject + verb on purpose: the old noun phrases ("A photo",
-   "A guided page") never said WHO does the step, which is the owner's first
-   question. Now every card answers "we" or "you" in its first two words.
-   `cost` is what the step takes out of the owner's day — the one fact neither
-   HowItWorks above nor the Manifesto below carries. 10 + 20 is the "30 minutes,
-   your shop" already promised in HowItWorks.tsx:75; keep the numbers in step if
-   either moves. Steps 03 and 04 take no fixed time, so they say so rather than
-   inventing a number we'd have to honour. */
-const STEPS = [
-    {
-        k: "01",
-        h: "We take the photos",
-        cost: "10 min",
-        sub: "Someone from Tendso comes to your shop and takes pictures of your work, your place, and you. You don't need to prepare anything or tidy up.",
-    },
-    {
-        k: "02",
-        h: "You answer a few questions",
-        cost: "20 min",
-        sub: "They ask you simple questions while you keep working — the same things you'd tell a customer who walked in. No writing, no computer.",
-    },
-    {
-        k: "03",
-        h: "We build your page",
-        cost: "none of it yours",
-        sub: "We put your photos and your answers together into your own website. You don't design anything, and you don't pick from a list of layouts.",
-    },
-    {
-        k: "04",
-        h: "You check it, then it's live",
-        cost: "one look",
-        sub: "We show it to you first. Change something, or leave it exactly as it is. Then it goes online, and you get back to work.",
-    },
-];
+import { useT } from "./i18n";
+import { Eyebrow, SectionHeading, Lead } from "./ui";
 
-/* Plain words only. The step copy above promises "no design vocabulary", so the
-   list of what you get can't say SEO, hosting, or open-graph card. */
-const KIT = [
-    "Your own website",
-    "Your own web address",
-    "We keep it online",
-    "Easy to find on Google",
-    "Photos you can post",
-    "Your menu or price list",
-    "Looks right when shared",
-];
-
-/* Deliberately plain and literal — a camera means photos, a question mark means
-   questions. An earlier pass cut icons for restating their headings; that was a
-   designer's objection, not a reader's. These sit small beside the number so
-   they support it rather than take over the card. */
+/* Plain, literal marks: a camera means photos, a speech bubble means questions.
+   They sit small beside the step number to support it, not take over the card. */
 const ICONS: Record<string, React.ReactElement> = {
     "01": (
         <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -79,63 +33,81 @@ const ICONS: Record<string, React.ReactElement> = {
         <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
             <path d="M3.2 9.5 H20.8 M3.2 14.5 H20.8" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M12 3 C9 6.5 9 17.5 12 21 M12 3 C15 6.5 15 17.5 12 21"
-                  stroke="currentColor" strokeWidth="1.5" />
+            <path d="M12 3 C9 6.5 9 17.5 12 21 M12 3 C15 6.5 15 17.5 12 21" stroke="currentColor" strokeWidth="1.5" />
         </svg>
     ),
 };
 
 export default function ProcessSection() {
+    const { t } = useT();
+
+    const steps = [
+        { k: "01", h: t("process.s1h"), cost: t("process.s1cost"), sub: t("process.s1sub") },
+        { k: "02", h: t("process.s2h"), cost: t("process.s2cost"), sub: t("process.s2sub") },
+        { k: "03", h: t("process.s3h"), cost: t("process.s3cost"), sub: t("process.s3sub") },
+        { k: "04", h: t("process.s4h"), cost: t("process.s4cost"), sub: t("process.s4sub") },
+    ];
+    const kit = [
+        t("process.kit1"), t("process.kit2"), t("process.kit3"), t("process.kit4"),
+        t("process.kit5"), t("process.kit6"), t("process.kit7"),
+    ];
+
     return (
-        <section>
-            <div className="container-wide">
-                <div className="sect-h">
-                    <div className="eyebrow">Your part</div>
-                    <div>
-                        <h2 className="display-2">
-                            You keep working. <em style={{ fontStyle: "italic" }}>We build the page.</em>
-                        </h2>
-                        <p className="lede" style={{ marginTop: 12 }}>
-                            Half an hour of your time, all together. We do the rest.
-                        </p>
-                    </div>
+        <section id="how-it-works" className="bg-khaki-deep">
+            <div className="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("process.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">
+                        {t("process.titleA")}{" "}
+                        <span className="italic" style={{ color: "var(--rust)", fontWeight: 560 }}>
+                            {t("process.titleB")}
+                        </span>
+                    </SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("process.lede")}</Lead>
                 </div>
 
-                {/* role="list" is explicit: list-style:none strips the list role in
-                    Safari/VoiceOver, which would drop the "1 of 4" announcement. */}
-                <ol className="process-track" role="list">
-                    {STEPS.map((s, i) => (
-                        <li
-                            key={s.k}
-                            className={`process-step${i === STEPS.length - 1 ? " is-final" : ""}`}
-                        >
-                            <div className="process-card">
-                                <div className="process-node-row">
-                                    <span className="process-mark">
-                                        <span className="process-icon">{ICONS[s.k]}</span>
-                                        <span className="process-node">{s.k}</span>
-                                    </span>
-                                    <span className="process-cost">{s.cost}</span>
-                                </div>
-                                <h3 className="process-h">{s.h}</h3>
-                                <p className="process-sub">{s.sub}</p>
+                <ol className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4" role="list">
+                    {steps.map((s) => (
+                        <li key={s.k} className="rounded-2xl border border-ink/10 bg-khaki p-6">
+                            <div className="flex items-center justify-between">
+                                <span className="flex items-center gap-2">
+                                    <span className="inline-flex text-ink-soft [&_svg]:h-5 [&_svg]:w-5">{ICONS[s.k]}</span>
+                                    <span className="font-mono text-xs text-rust">{s.k}</span>
+                                </span>
+                                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+                                    {s.cost}
+                                </span>
                             </div>
+                            <h3 className="mt-4 font-sans text-[17px] font-semibold leading-snug text-ink">{s.h}</h3>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-soft">{s.sub}</p>
                         </li>
                     ))}
                 </ol>
 
-                <div className="process-kit">
-                    <div className="process-kit-list">
-                        <span className="label">What you get</span>
-                        <div className="process-kit-tags">
-                            {KIT.map((t) => (
-                                <span key={t} className="tag">{t}</span>
+                {/* What you get + turnaround */}
+                <div className="mt-8 flex flex-col gap-6 rounded-2xl border border-ink/10 bg-khaki p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+                    <div>
+                        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+                            {t("process.kitLabel")}
+                        </span>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                            {kit.map((tag) => (
+                                <span
+                                    key={tag}
+                                    className="rounded-full border border-ink/10 bg-khaki-deep px-3 py-1 text-sm text-ink"
+                                >
+                                    {tag}
+                                </span>
                             ))}
                         </div>
                     </div>
-                    <div className="process-turnaround">
-                        <b>48–72h</b>
-                        <span className="label">from start to finish</span>
+                    <div className="flex-shrink-0 border-t border-ink/10 pt-4 text-center sm:border-l sm:border-t-0 sm:pl-8 sm:pt-0 sm:text-right">
+                        <div className="font-fraunces text-3xl text-ink" style={{ fontWeight: 560, fontOpticalSizing: "auto" }}>
+                            48–72h
+                        </div>
+                        <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-soft">
+                            {t("process.turnaroundLabel")}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/landing/RealSitesSection.tsx
+++ b/components/landing/RealSitesSection.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { CAROUSEL_SITES } from "./landingData";
+import { useT } from "./i18n";
+import { Eyebrow, SectionHeading, Lead } from "./ui";
+import LiveSitePreview from "./LiveSitePreview";
+
+/**
+ * RealSitesSection — the single honest "proof" band (replaces the old
+ * ShowcaseSection live-map + DirectorySection at-scale counters, both of which
+ * carried fabricated data: fake creators, invented counters, a "₱142k paid out"
+ * claim).
+ *
+ * Everything here is TRUE:
+ *  - The cards are the 4 real client sites in `CAROUSEL_SITES`, each showing a
+ *    LIVE preview of the actual page and linking to it.
+ *  - Counts come from live Convex queries. We never invent a number: the live-
+ *    sites figure can never drop below the sites actually shown, and the creator
+ *    stat only renders once the query resolves to a real, positive count.
+ */
+export default function RealSitesSection() {
+    const { t } = useT();
+
+    // Curated featured list from the admin (Featured Sites screen). Falls back to
+    // the built-in SHOWCASE_SITES when unset, so the grid always has real proof.
+    const featured = useQuery(api.settings.get, { key: "featured_sites" }) as
+        | { name: string; category: string; city: string; url: string }[]
+        | null
+        | undefined;
+    const publishedCount = useQuery(api.generatedWebsites.countPublished, {});
+    const creatorCount = useQuery(api.creators.count, {});
+
+    const sites =
+        Array.isArray(featured) && featured.length > 0
+            ? featured.filter((s) => !!s.url)
+            : CAROUSEL_SITES.map((s) => ({
+                  name: s.name,
+                  category: s.category,
+                  city: s.city,
+                  url: s.url as string,
+              }));
+
+    const liveSites = Math.max(publishedCount ?? 0, sites.length);
+    const showCreators = typeof creatorCount === "number" && creatorCount > 0;
+
+    return (
+        <section id="proof" className="bg-khaki-deep">
+            <div className="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+                {/* Header */}
+                <div className="mx-auto max-w-2xl text-center">
+                    <Eyebrow>{t("proof.eyebrow")}</Eyebrow>
+                    <SectionHeading className="mt-4">{t("proof.title")}</SectionHeading>
+                    <Lead className="mx-auto mt-5 max-w-xl">{t("proof.lede")}</Lead>
+                </div>
+
+                {/* Honest stat row — static, real numbers only */}
+                <div className="mt-8 flex flex-wrap items-center justify-center gap-x-7 gap-y-2 text-ink-soft">
+                    <span className="inline-flex items-baseline gap-1.5">
+                        <span className="font-fraunces text-2xl text-ink" style={{ fontWeight: 560 }}>
+                            {liveSites}
+                        </span>
+                        <span className="text-sm">{t("proof.statSitesLabel")}</span>
+                    </span>
+                    {showCreators && (
+                        <>
+                            <span aria-hidden className="hidden h-1 w-1 rounded-full bg-ink/25 sm:inline-block" />
+                            <span className="inline-flex items-baseline gap-1.5">
+                                <span className="font-fraunces text-2xl text-ink" style={{ fontWeight: 560 }}>
+                                    {creatorCount}
+                                </span>
+                                <span className="text-sm">{t("proof.statCreatorsLabel")}</span>
+                            </span>
+                        </>
+                    )}
+                </div>
+
+                {/* Card grid — the 4 real, live client sites (live preview, no stale screenshots) */}
+                <div className="mx-auto mt-12 grid max-w-5xl gap-6 sm:grid-cols-2">
+                    {sites.map((site) => (
+                        <a
+                            key={site.url}
+                            href={site.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="group block overflow-hidden rounded-xl border border-ink/10 bg-khaki transition-all duration-200 hover:-translate-y-0.5 hover:border-ink/25 hover:shadow-[0_18px_40px_-24px_rgba(27,28,36,0.45)]"
+                        >
+                            <LiveSitePreview url={site.url} name={site.name} />
+                            <div className="flex items-center justify-between gap-3 border-t border-ink/10 p-4">
+                                <div className="min-w-0">
+                                    <div className="truncate font-sans text-[17px] font-semibold text-ink">
+                                        {site.name}
+                                    </div>
+                                    <div className="mt-0.5 truncate text-sm text-ink-soft">
+                                        {[site.category, site.city].filter(Boolean).join(" · ")}
+                                    </div>
+                                </div>
+                                <span className="inline-flex flex-shrink-0 items-center gap-1 text-sm font-medium text-rust">
+                                    {t("proof.visit")}
+                                    <span aria-hidden className="transition-transform group-hover:translate-x-0.5">
+                                        →
+                                    </span>
+                                </span>
+                            </div>
+                        </a>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/components/landing/ScrollReveal.tsx
+++ b/components/landing/ScrollReveal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Scroll-reveal for the landing bands. Each section's content (`main > section > div`
+ * inside a `.reveal-scope`) fades + rises as it enters the viewport.
+ *
+ * Safe by design:
+ *  - The hero (first band) animates on load via pure CSS — no JS wait, no blank.
+ *  - Only bands that are genuinely BELOW the fold are hidden (off-screen, so no
+ *    visible flash) and then revealed on scroll; anything already visible on load
+ *    is left untouched.
+ *  - Respects prefers-reduced-motion (does nothing → content just shows).
+ */
+export default function ScrollReveal() {
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+        // Skip the first band (the hero) — CSS handles its load entrance.
+        const nodes = Array.from(
+            document.querySelectorAll<HTMLElement>(".reveal-scope main > section > div"),
+        ).slice(1);
+        if (!nodes.length) return;
+
+        const io = new IntersectionObserver(
+            (entries, obs) => {
+                for (const e of entries) {
+                    if (e.isIntersecting) {
+                        e.target.classList.add("reveal-in");
+                        obs.unobserve(e.target);
+                    }
+                }
+            },
+            { rootMargin: "0px 0px -8% 0px", threshold: 0.05 },
+        );
+
+        const vh = window.innerHeight;
+        for (const n of nodes) {
+            // Only hide + animate bands that start below the fold.
+            if (n.getBoundingClientRect().top > vh * 0.85) {
+                n.classList.add("reveal-pending");
+                io.observe(n);
+            }
+        }
+
+        return () => io.disconnect();
+    }, []);
+
+    return null;
+}

--- a/components/landing/StickyCTA.tsx
+++ b/components/landing/StickyCTA.tsx
@@ -2,17 +2,16 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Logo, ArrowUpRightIcon } from "./landingPrimitives";
+import { useT } from "./i18n";
 
 /**
- * The persistent "pick a door" CTA that appears once you've scrolled past the hero.
- *
- * Design note: this is a quiet, auto-width pill rather than a full-bleed bar. The
- * two doors carry equal weight — colour identifies each one with a dot instead of
- * filling the whole button, so neither shouts over the page content behind it.
- * When `door` is set, that side reads as the current context via a soft tint.
+ * Persistent single-action CTA that fades in once you've scrolled past the hero.
+ * Brand-token styled (the old version's styles were `.neo`-scoped and broke when
+ * the landing left `.neo`). Focus-aware: owner pages push "Get a website", the
+ * creator page pushes "Get the app". One clear action — no competing doors.
  */
-export default function StickyCTA({ door = null }: { door?: "business" | "creator" | null }) {
+export default function StickyCTA({ focus = "business" }: { focus?: "business" | "creator" } = {}) {
+    const { t } = useT();
     const [visible, setVisible] = useState(false);
 
     useEffect(() => {
@@ -22,45 +21,32 @@ export default function StickyCTA({ door = null }: { door?: "business" | "creato
         return () => window.removeEventListener("scroll", onScroll);
     }, []);
 
+    const isBiz = focus === "business";
+    const href = isBiz ? "/for-business" : "#app";
+    const label = isBiz ? t("hero.ctaBusiness") : t("nav.getApp");
+
+    const pill = (
+        <span className="inline-flex items-center gap-2 rounded-full bg-ink px-6 py-3 text-sm font-semibold text-white shadow-[0_14px_38px_-12px_rgba(27,28,36,0.55)] transition-transform hover:-translate-y-0.5">
+            {label}
+            <span aria-hidden>→</span>
+        </span>
+    );
+
     return (
-        <div className={`sticky-cta ${visible ? "visible" : ""}`}>
-            <nav className="sticky-cta-pill" aria-label="Choose your path">
-                <span className="sticky-cta-brand">
-                    <Logo />
-                </span>
-
-                <span className="sticky-cta-div" aria-hidden="true" />
-
-                <Link
-                    href="/for-business"
-                    className={`sticky-cta-seg is-business${door === "business" ? " is-current" : ""}`}
-                    tabIndex={visible ? 0 : -1}
-                    aria-current={door === "business" ? "page" : undefined}
-                >
-                    <span className="sticky-cta-dot" aria-hidden="true" />
-                    <span className="sticky-cta-full">I own a business</span>
-                    <span className="sticky-cta-short">Business</span>
-                    <span className="sticky-cta-arrow" aria-hidden="true">
-                        <ArrowUpRightIcon />
-                    </span>
+        <div
+            className={`fixed inset-x-0 bottom-5 z-40 flex justify-center px-4 transition-all duration-300 ${
+                visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-4 opacity-0"
+            }`}
+        >
+            {isBiz ? (
+                <Link href={href} tabIndex={visible ? 0 : -1} aria-hidden={!visible}>
+                    {pill}
                 </Link>
-
-                <span className="sticky-cta-div" aria-hidden="true" />
-
-                <Link
-                    href="/for-creators"
-                    className={`sticky-cta-seg is-creator${door === "creator" ? " is-current" : ""}`}
-                    tabIndex={visible ? 0 : -1}
-                    aria-current={door === "creator" ? "page" : undefined}
-                >
-                    <span className="sticky-cta-dot" aria-hidden="true" />
-                    <span className="sticky-cta-full">I want to earn</span>
-                    <span className="sticky-cta-short">Earn</span>
-                    <span className="sticky-cta-arrow" aria-hidden="true">
-                        <ArrowUpRightIcon />
-                    </span>
-                </Link>
-            </nav>
+            ) : (
+                <a href={href} tabIndex={visible ? 0 : -1} aria-hidden={!visible}>
+                    {pill}
+                </a>
+            )}
         </div>
     );
 }

--- a/components/landing/i18n.tsx
+++ b/components/landing/i18n.tsx
@@ -26,105 +26,461 @@ const EN: Dict = {
     // Navbar
     "nav.live": "Live in Philippines · expanding",
     "nav.getApp": "Get the app",
+    "nav.how": "How it works",
+    "nav.sites": "Real sites",
+    "nav.pricing": "Pricing",
+    "nav.creators": "For creators",
 
     // Hero
-    "hero.issue": "Issue No. 01",
-    "hero.h1a": "Some hands",
-    "hero.h1b": "don't get to ",
-    "hero.h1c": "sit still",
-    "hero.em": "The Thinking Ends Here. So the work doesn't.",
+    "hero.trustChip": "Operated by VONAS, OPC — a registered PH company",
+    "hero.h1a": "Tendso builds your website.",
+    "hero.h1b": "Pay only ",
+    "hero.h1c": "when it's live.",
+    "hero.em": "See your site before you pay a single peso.",
     "hero.lede":
-        "Your hands are full of customers, orders, tools, dough, kids. The internet asks you to stop and design. We built around that — a creator visits, asks a few questions, photographs the work, and your page forms around it. Live in 48 hours. No template. No design tab. No blank page.",
-    "hero.tag1": "Photo. Answers. Live page.",
-    "hero.tag2": "No template",
-    "hero.tag3": "No blank screen",
-    "hero.tag4": "Built around the work",
-    "hero.tag5": "Live in 48 hours",
+        "A trained Tendso creator visits your shop, asks a few questions, and photographs your work. We turn it into a real, coded website — live in 48–72 hours. You pay ₱999 once, only after it's up and you're happy.",
+    "hero.tag1": "Pay only when it's live",
+    "hero.tag2": "Live in 48–72 hours",
+    "hero.tag3": "₱999 one-time",
+    "hero.tag4": "A real coded site — no template",
+    "hero.tag5": "A creator comes to you",
     "hero.pickDoor": "Pick a door",
     "hero.doorBusiness": "I own a business",
-    "hero.doorBusinessSub": "Page built around my work",
+    "hero.doorBusinessSub": "A real page, built for me",
     "hero.doorBusinessNote":
-        "Keep cutting, kneading, packing, answering. A creator handles the rest and shows up at your shop within 10 km.",
+        "Keep working — a creator handles everything and comes to your shop. You review the site and pay only when it's live.",
     "hero.doorCreator": "I want to earn",
     "hero.doorCreatorSub": "Become a certified creator",
-    // NOTE: this replaces the stale "₱500 video / ₱300 audio" line with the 50% model.
     "hero.doorCreatorNote":
-        "Help owners who can't stop working. Keep 50% of every site you sell — from ₱500 up to ₱2,500, plus ₱1,000 per referral. Paid in 48 hours.",
-    "hero.scroll": "Or scroll — find creators near you on the map below.",
+        "Help owners who can't stop working. Keep 50% of every site you sell — from ₱500 up to ₱2,500, plus ₱1,000 per referral. Paid to your Wise wallet.",
+    "hero.scroll": "Or scroll — see real sites we've built below.",
+    "hero.trustTitle": "Straight answers",
+    "hero.trust1": "You pay only after your site is live — ₱999 once, or ₱1,499 with your own domain.",
+    "hero.trust2": "Operated by VONAS, OPC — a registered Philippine company.",
+    "hero.trust3": "Real, working websites for real local businesses. See them below.",
+    "hero.ctaBusiness": "Get a website",
+    "hero.ctaProof": "See real sites",
+    "hero.previewCaption": "A real site we built",
+    "hero.creatorLead": "Want to earn instead?",
+    "hero.creatorLink": "Become a Tendso creator →",
     "hero.counterCreators": "creators",
     "hero.counterBusinesses": "live sites",
     "hero.counterCities": "cities",
     "hero.counterCountries": "countries",
 
+    // Real Sites (proof)
+    "proof.eyebrow": "Real work",
+    "proof.title": "Real businesses. Real live sites.",
+    "proof.lede":
+        "Every site below was built for a real Filipino business by a Tendso creator. Click any card to open the live site — these aren't mockups.",
+    "proof.visit": "Visit site",
+    "proof.statSitesLabel": "live sites",
+    "proof.statCreatorsLabel": "creators",
+
+    // How it works
+    "how.eyebrow": "How it works",
+    "how.titleA": "Two paths.",
+    "how.titleB": "Pick yours.",
+    "how.lede":
+        "One's for business owners who want a real site. The other's for creators who want to earn building them.",
+    "how.bizLabel": "For business owners",
+    "how.biz1": "A trained creator comes to your shop — no app to download, no account to make.",
+    "how.biz2": "Answer a few questions while they photograph your work. About 30 minutes.",
+    "how.biz3": "We build a real, coded website from it — most go live within 48–72 hours.",
+    "how.biz4": "Review it, and pay only once it's live — ₱999, or ₱1,499 with your own domain.",
+    "how.bizCta": "Get a website",
+    "how.creatorLabel": "For creators",
+    "how.creator1": "Download the app and verify your phone.",
+    "how.creator2": "Get certified — free, and about 20 minutes.",
+    "how.creator3": "Visit local businesses with guided, step-by-step capture.",
+    "how.creator4": "Keep 50% of every sale — ₱500 on a ₱999 site, plus ₱1,000 per referral.",
+    "how.creatorCta": "Become a creator",
+
+    // Process (your part)
+    "process.eyebrow": "Your part",
+    "process.titleA": "You keep working.",
+    "process.titleB": "We build the page.",
+    "process.lede": "Half an hour of your time, all together. We do the rest.",
+    "process.s1h": "We take the photos",
+    "process.s1cost": "10 min",
+    "process.s1sub":
+        "Someone from Tendso comes to your shop and takes pictures of your work, your place, and you. You don't need to prepare anything or tidy up.",
+    "process.s2h": "You answer a few questions",
+    "process.s2cost": "20 min",
+    "process.s2sub":
+        "They ask you simple questions while you keep working — the same things you'd tell a customer who walked in. No writing, no computer.",
+    "process.s3h": "We build your page",
+    "process.s3cost": "none of it yours",
+    "process.s3sub":
+        "We put your photos and your answers together into your own website. You don't design anything, and you don't pick from a list of layouts.",
+    "process.s4h": "You check it, then it's live",
+    "process.s4cost": "one look",
+    "process.s4sub":
+        "We show it to you first. Change something, or leave it exactly as it is. Then it goes online, and you get back to work.",
+    "process.kitLabel": "What you get",
+    "process.kit1": "Your own website",
+    "process.kit2": "Your own web address",
+    "process.kit3": "We keep it online",
+    "process.kit4": "Easy to find on Google",
+    "process.kit5": "Photos you can post",
+    "process.kit6": "Your menu or price list",
+    "process.kit7": "Looks right when shared",
+    "process.turnaroundLabel": "from start to finish",
+
     // Business pricing
     "price.eyebrow": "The price",
+    "price.once": "once.",
     "price.liveForever": "Live forever.",
     "price.lede":
         "One-time payment. No monthly fees. No contracts. You only pay once your website is live and you've approved it.",
     "price.oneTime": "One-time · pay only when live",
+    "price.badge": "Most chosen",
+    "price.tierStandard": "Standard",
+    "price.taglineStandard": "A real website, built around your work.",
+    "price.tierDomain": "With custom domain",
+    "price.taglineDomain": "Your own .com — fully yours, never tied to us.",
+    "price.stdF1": "A real coded website — not a fill-in template",
+    "price.stdF2": "Your own live web address",
+    "price.stdF3": "Built from your photos and your words",
+    "price.stdF4": "Mobile-first — customers find you on their phones",
+    "price.stdF5": "Hosted with SSL, kept online",
+    "price.stdF6": "Free edits within 7 days of launch",
+    "price.domF1": "Everything in Standard",
+    "price.domF2": "Your own custom domain (.com, .net, .shop…)",
+    "price.domF3": "Year 1 of the domain included",
+    "price.domF4": "You own the domain — we never auto-renew",
+    "price.domF5": "A reminder before it renews",
+    "price.domF6": "Same build, same review-before-you-pay",
     "price.footnote":
         "No card on file. No fine print. No charges later. ◆ International pricing matches PH until local launch.",
 
     // CTA
     "cta.title": "Your work deserves a page.",
-    "cta.subtitle": "Live in 48 hours. Pay only when you're happy with it.",
+    "cta.subtitle": "Most sites live within 48–72 hours. Pay only when you're happy with it.",
     "cta.business": "I own a business",
     "cta.creator": "I want to earn as a creator",
 
     // FAQ
     "faq.title": "Questions, answered.",
+    "faq.eyebrow": "Questions",
+    "faq.tabBusiness": "For business owners",
+    "faq.tabCreators": "For creators",
+
+    // Manifesto
+    "manifesto.eyebrow": "Manifesto",
+    "manifesto.line1": "They didn't come here to become designers.",
+    "manifesto.line2": "They came to keep the business moving.",
+    "manifesto.b1label": "What we respect",
+    "manifesto.b1big": "The work",
+    "manifesto.b1sub":
+        "Sari-sari stores, salons, barangay clinics — the shops where someone is already kneading, cutting, or fixing while you read this.",
+    "manifesto.b2label": "How fast",
+    "manifesto.b2big": "48–72h",
+    "manifesto.b2sub":
+        "From the day a creator walks into your shop to the day your page is live. You keep working through all of it.",
+    "manifesto.b3label": "What it takes from you",
+    "manifesto.b3big": "A photo",
+    "manifesto.b3sub": "A few answers. A guided review. That's the whole ask — we built the rest around the work.",
+
+    // App download (the creator app)
+    "app.eyebrow": "The creator app",
+    "app.titleA": "Take Tendso",
+    "app.titleB": "with you.",
+    "app.lede":
+        "The app our creators use in the field — get certified, capture businesses, and track your earnings, right from your phone.",
+    "app.downloadOn": "Download on the",
+    "app.getOn": "Get it on",
+    "app.scan": "Scan to install on Android",
+    "app.status": "Available now on Android · iOS coming soon",
+
+    // Creator earnings teaser
+    "earn.eyebrow": "For creators",
+    "earn.titleA": "Earn by bringing them",
+    "earn.titleB": "online.",
+    "earn.lede": "Plain numbers, straight from our pricing — no projections, no fine print.",
+    "earn.f1label": "of every sale",
+    "earn.f1sub": "That's {a} on a {b} site — your half of every website you sell.",
+    "earn.f2label": "per referral",
+    "earn.f2sub": "When a creator you invite lands their first paid site.",
+    "earn.f3label": "straight to your wallet",
+    "earn.f3sub": "Paid within 48 hours of the owner approving their site.",
+    "earn.cta": "Become a creator",
+
+    // Final CTA
+    "cta.eyebrow": "The vision",
+    "cta.slogan1": "The Thinking Ends Here.",
+    "cta.slogan2": "So the work doesn't.",
+    "cta.doorBiz": "For business owners",
+    "cta.bizSub": "A page built around your work — a creator visits, you keep going, it goes live.",
+    "cta.doorCreator": "For creators",
+    "cta.creatorSub": "Help owners who can't stop working. Real earnings, real referrals, paid via Wise.",
+    "cta.go": "Enter",
+    "cta.altBizLead": "Own a business instead?",
+
+    // Footer
+    "footer.blurb":
+        "Real websites for Filipino local businesses — built by trained creators who come to you, live in days, and paid for only once it's live.",
+    "footer.company": "Operated by VONAS, OPC — a registered Philippine company.",
+    "footer.appCol": "Get the app",
+    "footer.comingSoon": "Coming soon",
+    "footer.kb": "Knowledge base",
+    "footer.help": "Help",
+    "footer.legal": "Legal",
+    "footer.privacy": "Privacy",
+    "footer.terms": "Terms",
+    "footer.contact": "Contact",
+    "footer.language": "Language",
+
+    // For-business + For-creators pages
+    "biz.back": "Back to home",
+    "biz.seePrice": "See the price",
+    "creator.h1a": "Get paid to build websites",
+    "creator.h1em": "for shops near you.",
+    "creator.lede":
+        "Bring a phone and follow the in-app checklist. You visit a local shop, photograph the work, and submit — we do the building, the writing, the deploying. You keep 50% of every site, paid to your Wise wallet.",
+    "creator.ctaStart": "Start free certification",
+    "creator.ceilingNote":
+        "You start at 50% of every ₱999 site. After {n} approved sites your price ceiling unlocks — your 50% can reach {c} on a higher-priced site. No projections, just your share of what you actually sell.",
+    "creator.apply.eyebrow": "How to start",
+    "creator.apply.title": "From this page",
+    "creator.apply.titleEm": "to your first payout.",
+    "creator.apply.lede":
+        "The full apply-and-certify flow lives in the app. Here's the shape of it — free to start, no experience needed.",
+    "creator.apply.tag1": "Free to apply",
+    "creator.apply.tag2": "No experience required",
+    "creator.apply.tag3": "Keep your day job",
+    "creator.apply.cta": "Start free certification",
 };
 
 const TL: Dict = {
     // Navbar
     "nav.live": "Live sa Pilipinas · palawak pa",
     "nav.getApp": "Kunin ang app",
+    "nav.how": "Paano gumagana",
+    "nav.sites": "Totoong sites",
+    "nav.pricing": "Presyo",
+    "nav.creators": "Para sa creators",
 
     // Hero
-    "hero.issue": "Isyu Blg. 01",
-    "hero.h1a": "May mga kamay",
-    "hero.h1b": "na hindi ",
-    "hero.h1c": "mapakali",
-    "hero.em": "Dito nagtatapos ang isip. Para hindi matigil ang trabaho.",
+    "hero.trustChip": "Pinapatakbo ng VONAS, OPC — rehistradong kompanya sa PH",
+    "hero.h1a": "Ginagawa ng Tendso ang website mo.",
+    "hero.h1b": "Bayad lang ",
+    "hero.h1c": "kapag live na.",
+    "hero.em": "Makikita mo ang site bago ka magbayad ng kahit piso.",
     "hero.lede":
-        "Puno ang kamay mo ng customer, order, gamit, masa, anak. Ang internet, gusto kang patigilin para mag-design. Doon kami umangkop — may creator na bibisita, magtatanong, kukuha ng litrato ng trabaho mo, at bubuo ng page paligid niyan. Live sa loob ng 48 oras. Walang template. Walang design tab. Walang blangkong page.",
-    "hero.tag1": "Litrato. Sagot. Live na page.",
-    "hero.tag2": "Walang template",
-    "hero.tag3": "Walang blangkong screen",
-    "hero.tag4": "Binuo sa trabaho mo",
-    "hero.tag5": "Live sa 48 oras",
+        "May sanay na Tendso creator na bibisita sa tindahan mo, magtatanong ng ilang bagay, at kukunan ng litrato ang trabaho mo. Gagawin naming totoong website — live sa loob ng 48–72 oras. Magbabayad ka ng ₱999 nang isang beses, kapag nakalive na at kuntento ka na.",
+    "hero.tag1": "Bayad lang kapag live na",
+    "hero.tag2": "Live sa 48–72 oras",
+    "hero.tag3": "₱999 isang beses",
+    "hero.tag4": "Totoong coded na site — walang template",
+    "hero.tag5": "May creator na pupunta sa'yo",
     "hero.pickDoor": "Pumili ng pinto",
     "hero.doorBusiness": "May negosyo ako",
-    "hero.doorBusinessSub": "Page na binuo sa trabaho ko",
+    "hero.doorBusinessSub": "Totoong page, ginawa para sa akin",
     "hero.doorBusinessNote":
-        "Ituloy mo lang ang paggupit, pagmasa, pag-empake, pagsagot. Ang creator ang bahala sa iba at pupunta sa tindahan mo sa loob ng 10 km.",
+        "Ituloy mo lang ang trabaho — ang creator ang bahala sa lahat at pupunta sa tindahan mo. Ikaw ang magre-review ng site at magbabayad lang kapag live na.",
     "hero.doorCreator": "Gusto kong kumita",
     "hero.doorCreatorSub": "Maging certified creator",
     "hero.doorCreatorNote":
-        "Tulungan ang mga may-ari na hindi makatigil sa trabaho. Panatilihin ang 50% ng bawat site na maibenta mo — mula ₱500 hanggang ₱2,500, plus ₱1,000 kada referral. Bayad sa loob ng 48 oras.",
-    "hero.scroll": "O mag-scroll — hanapin ang mga creator malapit sa'yo sa mapa sa ibaba.",
+        "Tulungan ang mga may-ari na hindi makatigil sa trabaho. Panatilihin ang 50% ng bawat site na maibenta mo — mula ₱500 hanggang ₱2,500, plus ₱1,000 kada referral. Bayad sa Wise wallet mo.",
+    "hero.scroll": "O mag-scroll — tingnan ang totoong mga site na ginawa namin sa ibaba.",
+    "hero.trustTitle": "Diretsong sagot",
+    "hero.trust1": "Magbabayad ka lang kapag live na ang site — ₱999 isang beses, o ₱1,499 kung may sariling domain.",
+    "hero.trust2": "Pinapatakbo ng VONAS, OPC — rehistradong kompanya sa Pilipinas.",
+    "hero.trust3": "Totoo at gumaganang website para sa totoong lokal na negosyo. Tingnan sa ibaba.",
+    "hero.ctaBusiness": "Kumuha ng website",
+    "hero.ctaProof": "Tingnan ang totoong mga site",
+    "hero.previewCaption": "Totoong site na ginawa namin",
+    "hero.creatorLead": "Gusto mo bang kumita?",
+    "hero.creatorLink": "Maging Tendso creator →",
     "hero.counterCreators": "mga creator",
     "hero.counterBusinesses": "live na site",
     "hero.counterCities": "mga lungsod",
     "hero.counterCountries": "mga bansa",
 
+    // Real Sites (proof)
+    "proof.eyebrow": "Totoong gawa",
+    "proof.title": "Totoong negosyo. Totoong live na site.",
+    "proof.lede":
+        "Bawat site sa ibaba ay ginawa para sa totoong negosyong Pilipino ng isang Tendso creator. I-click ang kahit alin para buksan ang live na site — hindi ito mockup.",
+    "proof.visit": "Bisitahin",
+    "proof.statSitesLabel": "live na site",
+    "proof.statCreatorsLabel": "mga creator",
+
+    // How it works
+    "how.eyebrow": "Paano gumagana",
+    "how.titleA": "Dalawang daan.",
+    "how.titleB": "Piliin ang sa'yo.",
+    "how.lede":
+        "Ang isa ay para sa may-ari ng negosyo na gustong magkaroon ng site. Ang isa naman ay para sa creator na gustong kumita sa paggawa nito.",
+    "how.bizLabel": "Para sa may-ari ng negosyo",
+    "how.biz1": "May sanay na creator na pupunta sa tindahan mo — walang app na ida-download, walang account na gagawin.",
+    "how.biz2": "Sagutin ang ilang tanong habang kinukunan nila ng litrato ang trabaho mo. Mga 30 minuto.",
+    "how.biz3": "Gagawa kami ng totoong coded na website mula rito — karamihan ay live sa loob ng 48–72 oras.",
+    "how.biz4": "I-review ito, at magbayad lang kapag live na — ₱999, o ₱1,499 kung may sariling domain.",
+    "how.bizCta": "Kumuha ng website",
+    "how.creatorLabel": "Para sa creators",
+    "how.creator1": "I-download ang app at i-verify ang numero mo.",
+    "how.creator2": "Mag-certified — libre, at mga 20 minuto.",
+    "how.creator3": "Bumisita sa mga lokal na negosyo gamit ang guided na capture.",
+    "how.creator4": "Panatilihin ang 50% ng bawat benta — ₱500 sa isang ₱999 na site, plus ₱1,000 kada referral.",
+    "how.creatorCta": "Maging creator",
+
+    // Process (your part)
+    "process.eyebrow": "Ang parte mo",
+    "process.titleA": "Ituloy mo lang ang trabaho.",
+    "process.titleB": "Kami ang gagawa ng page.",
+    "process.lede": "Kalahating oras lang ng oras mo, lahat-lahat. Kami na ang bahala sa iba.",
+    "process.s1h": "Kami ang kukuha ng litrato",
+    "process.s1cost": "10 min",
+    "process.s1sub":
+        "May pupunta mula sa Tendso sa tindahan mo at kukunan ng litrato ang trabaho mo, ang lugar mo, at ikaw. Hindi mo kailangang maghanda o maglinis.",
+    "process.s2h": "Sasagot ka ng ilang tanong",
+    "process.s2cost": "20 min",
+    "process.s2sub":
+        "Magtatanong sila ng simple habang nagtatrabaho ka — ang mga bagay na sasabihin mo rin sa customer na pumasok. Walang isusulat, walang computer.",
+    "process.s3h": "Kami ang gagawa ng page mo",
+    "process.s3cost": "wala sa'yo",
+    "process.s3sub":
+        "Pagsasama-samahin namin ang litrato at sagot mo para gawing sarili mong website. Wala kang idi-disenyo, at hindi ka pipili mula sa listahan ng layout.",
+    "process.s4h": "I-check mo, tapos live na",
+    "process.s4cost": "isang tingin",
+    "process.s4sub":
+        "Ipapakita muna namin sa'yo. Magpalit ng kahit ano, o hayaan lang kung ano. Tapos mao-online na ito, at makakabalik ka na sa trabaho.",
+    "process.kitLabel": "Ang makukuha mo",
+    "process.kit1": "Sarili mong website",
+    "process.kit2": "Sarili mong web address",
+    "process.kit3": "Pinapanatili naming online",
+    "process.kit4": "Madaling mahanap sa Google",
+    "process.kit5": "Litrato na pwede mong i-post",
+    "process.kit6": "Menu o presyo mo",
+    "process.kit7": "Maganda kapag na-share",
+    "process.turnaroundLabel": "mula simula hanggang tapos",
+
     // Business pricing
     "price.eyebrow": "Ang presyo",
+    "price.once": "isang beses.",
     "price.liveForever": "Live habambuhay.",
     "price.lede":
         "Isang bayad lang. Walang buwanang bayad. Walang kontrata. Magbabayad ka lang kapag live na ang website mo at na-approve mo na.",
     "price.oneTime": "Isang beses · bayad lang kapag live na",
+    "price.badge": "Madalas piliin",
+    "price.tierStandard": "Standard",
+    "price.taglineStandard": "Totoong website, ginawa base sa trabaho mo.",
+    "price.tierDomain": "May sariling domain",
+    "price.taglineDomain": "Sarili mong .com — ganap na sa'yo, hindi nakatali sa amin.",
+    "price.stdF1": "Totoong coded na website — hindi fill-in na template",
+    "price.stdF2": "Sarili mong live na web address",
+    "price.stdF3": "Ginawa mula sa litrato at salita mo",
+    "price.stdF4": "Mobile-first — mahahanap ka ng customer sa phone nila",
+    "price.stdF5": "Naka-host na may SSL, pinapanatiling online",
+    "price.stdF6": "Libreng edits sa loob ng 7 araw mula sa launch",
+    "price.domF1": "Lahat ng nasa Standard",
+    "price.domF2": "Sarili mong custom domain (.com, .net, .shop…)",
+    "price.domF3": "Kasama ang unang taon ng domain",
+    "price.domF4": "Sa'yo ang domain — hindi namin auto-nirerenew",
+    "price.domF5": "May paalala bago mag-renew",
+    "price.domF6": "Parehong build, parehong review bago magbayad",
     "price.footnote":
         "Walang card na nakatago. Walang maliit na letra. Walang sorpresang singil. ◆ Pantay ang presyo sa ibang bansa sa PH hanggang sa lokal na launch.",
 
     // CTA
     "cta.title": "May karapatan ang trabaho mo sa sariling page.",
-    "cta.subtitle": "Live sa 48 oras. Magbayad lang kapag masaya ka na dito.",
+    "cta.subtitle": "Karamihan ay live sa loob ng 48–72 oras. Magbayad lang kapag masaya ka na dito.",
     "cta.business": "May negosyo ako",
     "cta.creator": "Gusto kong kumita bilang creator",
 
     // FAQ
     "faq.title": "Mga tanong, nasagot na.",
+    "faq.eyebrow": "Mga tanong",
+    "faq.tabBusiness": "Para sa may-ari ng negosyo",
+    "faq.tabCreators": "Para sa creators",
+
+    // Manifesto
+    "manifesto.eyebrow": "Manifesto",
+    "manifesto.line1": "Hindi sila pumunta dito para maging designer.",
+    "manifesto.line2": "Pumunta sila para panatilihing gumagana ang negosyo.",
+    "manifesto.b1label": "Ang iginagalang namin",
+    "manifesto.b1big": "Ang trabaho",
+    "manifesto.b1sub":
+        "Sari-sari store, salon, barangay clinic — ang mga tindahan kung saan may nagmamasa, gumugupit, o nag-aayos habang binabasa mo ito.",
+    "manifesto.b2label": "Gaano kabilis",
+    "manifesto.b2big": "48–72h",
+    "manifesto.b2sub":
+        "Mula sa araw na pumasok ang creator sa tindahan mo hanggang sa araw na live na ang page mo. Patuloy kang nagtatrabaho sa buong proseso.",
+    "manifesto.b3label": "Ano ang kailangan sa'yo",
+    "manifesto.b3big": "Isang litrato",
+    "manifesto.b3sub":
+        "Ilang sagot. Isang guided na review. Iyon lang ang hinihingi — ginawa namin ang iba base sa trabaho.",
+
+    // App download (creator app)
+    "app.eyebrow": "Ang creator app",
+    "app.titleA": "Dalhin ang Tendso",
+    "app.titleB": "kasama mo.",
+    "app.lede":
+        "Ang app na ginagamit ng aming creators sa field — mag-certified, kunin ang mga negosyo, at subaybayan ang kita mo, mula mismo sa phone mo.",
+    "app.downloadOn": "I-download sa",
+    "app.getOn": "Kunin sa",
+    "app.scan": "I-scan para i-install sa Android",
+    "app.status": "Available na sa Android · malapit na ang iOS",
+
+    // Creator earnings teaser
+    "earn.eyebrow": "Para sa creators",
+    "earn.titleA": "Kumita habang dinadala sila",
+    "earn.titleB": "online.",
+    "earn.lede": "Malinaw na numero, mula mismo sa presyo namin — walang projection, walang maliit na letra.",
+    "earn.f1label": "ng bawat benta",
+    "earn.f1sub": "{a} iyon sa isang {b} na site — ang kalahati mo sa bawat website na maibenta mo.",
+    "earn.f2label": "kada referral",
+    "earn.f2sub": "Kapag nakapag-una nang bayad na site ang creator na na-invite mo.",
+    "earn.f3label": "diretso sa wallet mo",
+    "earn.f3sub": "Bayad sa loob ng 48 oras mula nang aprubahan ng may-ari ang site nila.",
+    "earn.cta": "Maging creator",
+
+    // Final CTA
+    "cta.eyebrow": "Ang bisyon",
+    "cta.slogan1": "Dito Nagtatapos ang Pag-iisip.",
+    "cta.slogan2": "Para hindi ang trabaho.",
+    "cta.doorBiz": "Para sa may-ari ng negosyo",
+    "cta.bizSub": "Isang page na nakabatay sa trabaho mo — may creator na bibisita, tuloy ka lang, mao-online ito.",
+    "cta.doorCreator": "Para sa creators",
+    "cta.creatorSub": "Tulungan ang mga may-ari na hindi makatigil sa trabaho. Totoong kita, totoong referral, bayad sa Wise.",
+    "cta.go": "Pumasok",
+    "cta.altBizLead": "May negosyo ka ba?",
+
+    // Footer
+    "footer.blurb":
+        "Totoong website para sa lokal na negosyong Pilipino — ginawa ng sanay na creators na pupunta sa'yo, live sa loob ng ilang araw, at babayaran lang kapag live na.",
+    "footer.company": "Pinapatakbo ng VONAS, OPC — rehistradong kompanya sa Pilipinas.",
+    "footer.appCol": "Kunin ang app",
+    "footer.comingSoon": "Malapit na",
+    "footer.kb": "Knowledge base",
+    "footer.help": "Tulong",
+    "footer.legal": "Legal",
+    "footer.privacy": "Privacy",
+    "footer.terms": "Terms",
+    "footer.contact": "Contact",
+    "footer.language": "Wika",
+
+    // For-business + For-creators pages
+    "biz.back": "Balik sa home",
+    "biz.seePrice": "Tingnan ang presyo",
+    "creator.h1a": "Kumita sa paggawa ng website",
+    "creator.h1em": "para sa mga tindahan malapit sa'yo.",
+    "creator.lede":
+        "Magdala ng phone at sundin ang checklist sa app. Bibisita ka sa lokal na tindahan, kukunan ng litrato ang trabaho, at isu-submit — kami na ang bahala sa build, sulat, at deploy. Panatilihin mo ang 50% ng bawat site, bayad sa Wise wallet mo.",
+    "creator.ctaStart": "Simulan ang libreng certification",
+    "creator.ceilingNote":
+        "Magsisimula ka sa 50% ng bawat ₱999 na site. Pagkatapos ng {n} aprubadong site, mag-a-unlock ang price ceiling mo — pwedeng umabot sa {c} ang 50% mo sa mas mataas na presyo. Walang projection, kita mo lang sa aktwal na naibenta mo.",
+    "creator.apply.eyebrow": "Paano magsimula",
+    "creator.apply.title": "Mula sa page na ito",
+    "creator.apply.titleEm": "hanggang sa unang bayad mo.",
+    "creator.apply.lede":
+        "Ang buong apply-at-certify na proseso ay nasa app. Ito ang hugis nito — libreng magsimula, walang kailangang karanasan.",
+    "creator.apply.tag1": "Libreng mag-apply",
+    "creator.apply.tag2": "Walang kailangang karanasan",
+    "creator.apply.tag3": "Panatilihin ang trabaho mo",
+    "creator.apply.cta": "Simulan ang libreng certification",
 };
 
 const DICTS: Record<Lang, Dict> = { en: EN, tl: TL };

--- a/components/landing/i18n.tsx
+++ b/components/landing/i18n.tsx
@@ -144,7 +144,7 @@ const EN: Dict = {
     "price.stdF3": "Built from your photos and your words",
     "price.stdF4": "Mobile-first — customers find you on their phones",
     "price.stdF5": "Hosted with SSL, kept online",
-    "price.stdF6": "Free edits within 7 days of launch",
+    "price.stdF6": "Free edits for the first year",
     "price.domF1": "Everything in Standard",
     "price.domF2": "Your own custom domain (.com, .net, .shop…)",
     "price.domF3": "Year 1 of the domain included",
@@ -152,7 +152,7 @@ const EN: Dict = {
     "price.domF5": "A reminder before it renews",
     "price.domF6": "Same build, same review-before-you-pay",
     "price.footnote":
-        "No card on file. No fine print. No charges later. ◆ International pricing matches PH until local launch.",
+        "No card on file. No fine print. No charges later.",
 
     // CTA
     "cta.title": "Your work deserves a page.",
@@ -374,7 +374,7 @@ const TL: Dict = {
     "price.stdF3": "Ginawa mula sa litrato at salita mo",
     "price.stdF4": "Mobile-first — mahahanap ka ng customer sa phone nila",
     "price.stdF5": "Naka-host na may SSL, pinapanatiling online",
-    "price.stdF6": "Libreng edits sa loob ng 7 araw mula sa launch",
+    "price.stdF6": "Libreng edits sa loob ng unang taon",
     "price.domF1": "Lahat ng nasa Standard",
     "price.domF2": "Sarili mong custom domain (.com, .net, .shop…)",
     "price.domF3": "Kasama ang unang taon ng domain",
@@ -382,7 +382,7 @@ const TL: Dict = {
     "price.domF5": "May paalala bago mag-renew",
     "price.domF6": "Parehong build, parehong review bago magbayad",
     "price.footnote":
-        "Walang card na nakatago. Walang maliit na letra. Walang sorpresang singil. ◆ Pantay ang presyo sa ibang bansa sa PH hanggang sa lokal na launch.",
+        "Walang card na nakatago. Walang maliit na letra. Walang sorpresang singil.",
 
     // CTA
     "cta.title": "May karapatan ang trabaho mo sa sariling page.",

--- a/components/landing/i18n.tsx
+++ b/components/landing/i18n.tsx
@@ -191,7 +191,7 @@ const EN: Dict = {
     "app.downloadOn": "Download on the",
     "app.getOn": "Get it on",
     "app.scan": "Scan to install on Android",
-    "app.status": "Available now on Android · iOS coming soon",
+    "app.status": "Available now on iOS and Android",
 
     // Creator earnings teaser
     "earn.eyebrow": "For creators",
@@ -422,7 +422,7 @@ const TL: Dict = {
     "app.downloadOn": "I-download sa",
     "app.getOn": "Kunin sa",
     "app.scan": "I-scan para i-install sa Android",
-    "app.status": "Available na sa Android · malapit na ang iOS",
+    "app.status": "Available na sa iOS at Android",
 
     // Creator earnings teaser
     "earn.eyebrow": "Para sa creators",

--- a/components/landing/landingData.ts
+++ b/components/landing/landingData.ts
@@ -238,7 +238,7 @@ export const SHOWCASE_SITES: ShowcaseSite[] = [
         category: "Auto · Tire Supply",
         lat: 14.676,
         lng: 121.0437,
-        city: "Quezon City",
+        city: "Makati",
         src: "/Pages/ben-joe.png",
         url: "https://benjoetiresupply.com/",
     },
@@ -249,8 +249,8 @@ export const SHOWCASE_SITES: ShowcaseSite[] = [
         category: "Beauty Studio",
         lat: 10.3157,
         lng: 123.8854,
-        city: "Cebu City",
-        src: "/Pages/aloja2.png",
+        city: "Marilao, Bulacan",
+        src: "/Pages/aloja.png",
         url: "https://aloja-carvajal-aesthetic-and-beauty-studio.frmwrkd-media.workers.dev/",
     },
     {
@@ -260,7 +260,7 @@ export const SHOWCASE_SITES: ShowcaseSite[] = [
         category: "Restaurant",
         lat: 14.5547,
         lng: 121.0244,
-        city: "Makati",
+        city: "Meycauayan, Bulacan",
         src: "/Pages/hapag.png",
         url: "https://hapag.pages.dev/",
     },
@@ -271,7 +271,7 @@ export const SHOWCASE_SITES: ShowcaseSite[] = [
         category: "Salon · Massage · Spa",
         lat: 14.5995,
         lng: 120.9842,
-        city: "Manila",
+        city: "Meycauayan, Bulacan",
         src: "/Pages/beauty-me.png",
         url: "https://beauty-me-salon-massage-spa.frmwrkd-media.workers.dev/",
     },
@@ -372,12 +372,34 @@ export const FAQ_CREATOR: FaqEntry[] = [
 
 export const FAQ_BUSINESS: FaqEntry[] = [
     { q: "Will I need to learn design?", a: "No. You won't choose a template, pick a font, or stare at a blank page. A creator visits, asks a few questions, takes photos, and your site forms from that." },
-    { q: "How long does it take?", a: "Live in 48 hours from the interview. The interview itself is around 30 minutes — at your shop, while you keep working." },
+    { q: "How long does it take?", a: "Live in 48–72 hours from the interview. The interview itself is around 30 minutes — at your shop, while you keep working." },
     { q: "Do I have to prepare anything?", a: "No. The creator brings the camera, the questions, and the patience. You answer between customers." },
     { q: "What if I don't like it?", a: "You don't pay until the site is live and you've approved it. If you reject the draft, the creator revises it once for free." },
     { q: "Can I update it later?", a: "Yes — message your creator through the app. Small edits are included for the first year. After that, a flat fee per change." },
     { q: "Who owns the website?", a: "You do. The domain, the photos, the copy — all yours. You can take it elsewhere any time, no penalty." },
-    { q: "How much does it cost?", a: "₱999 for a Tendso subdomain site, ₱1,499 if you want a custom domain (.com included for year 1). One-time fee — no monthly hosting bills." },
+    { q: "How much does it cost?", a: "₱999 for a standard site, ₱1,499 if you want a custom domain (.com included for year 1). One-time fee — no monthly hosting bills." },
+];
+
+// Tagalog FAQ — shown on the landing when the language is set to TL. Kept as
+// separate arrays (not a schema change) so other consumers of FAQ_CREATOR /
+// FAQ_BUSINESS stay untouched.
+export const FAQ_CREATOR_TL: FaqEntry[] = [
+    { q: "Paano ako babayaran?", a: "Diretso sa Wise account mo. Ang app ang bahala sa invoice, buwis, at resibo. Hindi ka na hihipo ng spreadsheet." },
+    { q: "Kailan ako babayaran?", a: "Sa loob ng 48 oras mula nang aprubahan ng may-ari ang site nila. Mas mabilis pa kapag weekend — hindi namin binibinbin ang pera mo." },
+    { q: "Kailangan ba ng karanasan?", a: "Hindi. Ang guided capture ang gagabay sa'yo sa bawat interview, bawat litrato, bawat hakbang. Kung marunong kang mag-TikTok, kaya mo 'to." },
+    { q: "Paano kung hindi ako magaling mag-English?", a: "Marunong ang app ng Tagalog, Cebuano, Hiligaynon, at Ilocano. Naka-translate na ang mga tanong sa interview. Nasa sariling wika lang ang may-ari." },
+    { q: "Kailangan ba ng smartphone?", a: "Oo — kahit anong phone mula sa nakaraang apat na taon ay pwede. iOS 15+ o Android 10+." },
+    { q: "Pwede ba akong part-time?", a: "Karamihan ng creators ay nagsimula nang ganoon. Ikaw ang pipili ng trabaho, ikaw ang magtatakda ng bilis. Walang minimum." },
+];
+
+export const FAQ_BUSINESS_TL: FaqEntry[] = [
+    { q: "Kailangan ko bang matuto ng design?", a: "Hindi. Wala kang pipiliing template, font, o titigan na blankong page. May creator na bibisita, magtatanong, kukuha ng litrato, at doon mabubuo ang site mo." },
+    { q: "Gaano katagal?", a: "Live sa loob ng 48–72 oras mula sa interview. Ang interview mismo ay mga 30 minuto — sa tindahan mo, habang nagtatrabaho ka." },
+    { q: "May ihahanda ba ako?", a: "Wala. Ang creator ang may dalang kamera, mga tanong, at pasensya. Sasagot ka lang sa pagitan ng mga customer." },
+    { q: "Paano kung hindi ko gusto?", a: "Hindi ka magbabayad hangga't hindi live at na-approve mo ang site. Kung tatanggihan mo ang draft, ire-revise ito ng creator nang isang beses, libre." },
+    { q: "Pwede ko bang i-update mamaya?", a: "Oo — mag-message sa creator mo sa app. Kasama na ang maliliit na edit sa unang taon. Pagkatapos noon, may flat na bayad kada pagbabago." },
+    { q: "Sino ang may-ari ng website?", a: "Ikaw. Ang domain, ang litrato, ang mga salita — sa'yo lahat. Pwede mong dalhin kahit saan anumang oras, walang penalty." },
+    { q: "Magkano ang gastos?", a: "₱999 para sa standard na site, ₱1,499 kung gusto mo ng custom domain (kasama ang .com sa unang taon). Isang bayad lang — walang buwanang hosting." },
 ];
 
 // ── Knowledge base seed ────────────────────────────────────────────────────

--- a/components/landing/ui.tsx
+++ b/components/landing/ui.tsx
@@ -1,0 +1,49 @@
+/**
+ * Landing primitives — the small, shared building blocks of the redesigned
+ * ("WordPress-informed") landing page. One accent (gold), calm ink-on-paper
+ * body, a warm-serif display face (Fraunces) for headings only.
+ *
+ * These are used ONLY by sections that live OUTSIDE the legacy `.neo` wrapper.
+ * Keep them dependency-light and token-driven (brand utilities from globals.css).
+ */
+
+import type { ReactNode } from "react";
+
+/** Small uppercase kicker above a section heading. Gold by default (the accent). */
+export function Eyebrow({ children, className = "" }: { children: ReactNode; className?: string }) {
+    return (
+        <p className={`font-sans text-[13px] font-semibold uppercase tracking-[0.14em] text-rust ${className}`}>
+            {children}
+        </p>
+    );
+}
+
+/**
+ * WP-tight display heading — Fraunces, refined ~560 weight, optical sizing on,
+ * negative tracking. Defaults to <h2>; the hero owns the only <h1>.
+ */
+export function SectionHeading({
+    children,
+    className = "",
+}: {
+    children: ReactNode;
+    className?: string;
+}) {
+    return (
+        <h2
+            className={`font-fraunces text-[clamp(1.9rem,3.6vw,2.75rem)] leading-[1.12] tracking-[-0.015em] text-ink ${className}`}
+            style={{ fontWeight: 560, fontOpticalSizing: "auto" }}
+        >
+            {children}
+        </h2>
+    );
+}
+
+/** Calm lead paragraph under a heading — the quiet half of the type contrast. */
+export function Lead({ children, className = "" }: { children: ReactNode; className?: string }) {
+    return (
+        <p className={`text-[clamp(1.0625rem,1.4vw,1.25rem)] leading-relaxed text-ink-soft ${className}`}>
+            {children}
+        </p>
+    );
+}


### PR DESCRIPTION
## Summary

A full redesign of the public marketing funnel to kill the "unprofessional / feels like a scam" impression, make **every claim data-true**, and reference WordPress.com's clean, trustworthy design language on Tendso's own brand (warm paper + one gold accent, Fraunces display + Plus Jakarta body).

Pages: `/`, `/for-business`, `/for-creators` (+ de-fabricated the shared `EarningsSection` used by `/creators` and `/for-field-agents`).

## What changed

**Design system**
- Rebuilt every landing section off the legacy `.neo` editorial system onto brand tokens + shared primitives (`components/landing/ui.tsx`). ChatBot + StickyCTA rewritten off `.neo`; `CustomCursor` removed.
- Scroll-reveal animations, smooth in-page anchors, alternating paper/wash bands with hairline separators, and a two-column hero with a **live real-site preview**.

**Truth / no fabrication**
- Removed: 8 fake creators, "₱142,000 paid out", invented counters, 3 fake "verified" testimonials + weekly/monthly income projections, the non-existent `*.tendso.ph` subdomain promise, and the "live map right now" framing.
- Corrected the 4 real client sites' cities (they were spread nationally but are actually Makati + Bulacan); unified turnaround to **48–72h** everywhere; pricing is **₱999 / ₱1,499** only.
- Real proof: **live iframe previews** of the 4 real client sites + live Convex counts (`countPublished` / `creators.count`).

**Product / positioning**
- **Owner-first** homepage; creators demoted to a secondary link + the dedicated `/for-creators` (where the earnings + app bands now live). The creator-set ₱999–₱4,999 range is not shown to owners.
- `/for-creators` is **app-first** (Get the app → Play Store / APK); de-fabricated apply steps + earnings.
- New admin screen **`/admin/featured-sites`** to curate the proof grid without code (Convex `featured_sites` setting; falls back to the built-in sites).

**Bilingual** EN/TL throughout.

## Verification
- `tsc --noEmit` clean. (Full `next build` doesn't complete on the dev machine; verified via type-check + the running dev server.)
- Fabrication scans of the rendered HTML come back empty across `/`, `/for-business`, `/for-creators`.

## Notes / follow-ups
- `/for-field-agents` and `/creators` are now **de-fabricated** but still in the old `.neo` style (not restyled) — optional follow-up.
- The custom-domain (₱1,499) flow was verified functional end-to-end (Wise manual pay + automated Hostinger/Cloudflare provisioning); it depends on prod API credentials being configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
