### PR TITLE
fix(leads): tolerate the auth-loading window in mobile CRM queries

### DIFF
--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -308,7 +308,17 @@ export const listForMobileCRM = query({
         onlyMine: v.optional(v.boolean()),
     },
     handler: async (ctx, args) => {
-        const identity = await requireIdentity(ctx);
+        // Read query consumed by the mobile CRM feed: it fires on mount, which can
+        // beat Clerk's token reaching the Convex client. Degrade to an empty feed
+        // during that window instead of throwing "Not authenticated" — the
+        // creator-not-found branch below already returns this same empty shape.
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) {
+            return {
+                leads: [],
+                stats: { total: 0, new: 0, contacted: 0, qualified: 0, converted: 0, lost: 0, mine: 0 },
+            };
+        }
 
         const currentCreator = await ctx.db
             .query('creators')
@@ -476,7 +486,10 @@ export const listForMobileCRM = query({
 export const listForMap = query({
     args: {},
     handler: async (ctx) => {
-        await requireIdentity(ctx);
+        // Mobile CRM map view — same mount-race tolerance as listForMobileCRM:
+        // return no pins until auth propagates rather than throwing.
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) return [];
 
         const allLeads = await ctx.db.query('leads').order('desc').collect();
 
@@ -609,7 +622,10 @@ export const listForMap = query({
 export const getDetailForMobileCRM = query({
     args: { id: v.id('leads') },
     handler: async (ctx, args) => {
-        const identity = await requireIdentity(ctx);
+        // Mobile CRM detail — tolerate the auth-loading window (return null, same
+        // as the not-found branches below) instead of throwing.
+        const identity = await ctx.auth.getUserIdentity();
+        if (!identity) return null;
 
         const currentCreator = await ctx.db
             .query('creators')


### PR DESCRIPTION
## Bug

`leads:listForMobileCRM` throws on the mobile CRM screen:

```
Uncaught Error: Not authenticated
    at requireIdentity (../convex/leads.ts:252:11)
    at async handler (../convex/leads.ts:316:13)
```

## Cause

The mobile CRM screens' `useQuery` fires on mount, which can beat Clerk's token reaching the Convex client. During that window `ctx.auth.getUserIdentity()` returns `null`, so `requireIdentity` throws **"Not authenticated"** as an uncaught error — even though the user is signed in a moment later and the query would succeed on its next run. It's a transient mount race, not a real auth failure.

## Fix

The three **read** queries the mobile CRM screens consume already degrade gracefully when the *creator* isn't found — make them do the same when there's no *identity* yet, returning their existing empty shape instead of throwing:

| Query | no-identity return |
|---|---|
| `listForMobileCRM` | `{ leads: [], stats: {…0} }` (same shape as its creator-not-found branch) |
| `listForMap` | `[]` |
| `getDetailForMobileCRM` | `null` |

**Deliberately unchanged:** `requireIdentity` itself (still used by `requireAdminIdentity`) and every admin/mutation path — those *should* throw on no-auth.

## Verification

- `npx tsc --noEmit` clean across all Convex files (only unrelated stale `.next` route-type artifacts remain).
- Not reproduced live on device — the logic mirrors the already-present graceful branches, so low risk; a device check is the real confirmation.

## Notes

- **Backend change** → needs a manual `npx convex deploy` to reach prod (merging only ships the frontend).
- Trade-off: a *genuinely* unauthenticated caller now gets an empty feed instead of an error. So a permanently-empty CRM for a signed-in user would indicate a client-token problem, not this. The belt-and-suspenders complement is for the mobile app to `skip` the query until `isSignedIn` (separate mobile repo); this backend guard is the fix available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)