### PR TITLE
feat(editor): unified v3 website editor (parity + click-to-edit, device toggle, undo/redo, draft recovery)

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -13,6 +13,7 @@ import VisualEditor from "@/components/editor/VisualEditor";
 import ContentEditor, { EditorCustomizations } from "@/components/ContentEditor";
 import SandboxEditor, { type SandboxEditorProps } from "@/components/editor/SandboxEditor";
 import SandboxEditorV2 from "@/components/editor/SandboxEditorV2";
+import SandboxEditorV3 from "@/components/editor/SandboxEditorV3";
 import TopActionBar from "./_components/TopActionBar";
 import DetailsSidebar from "./_components/DetailsSidebar";
 import DriveSection from "./_components/DriveSection";
@@ -202,16 +203,16 @@ export default function SubmissionDetailPage() {
     // Per-admin editor preference: "v1" = classic SandboxEditor, "v2" = the
     // redesigned SandboxEditorV2. It's an editing-surface choice (not submission
     // data), so it lives in localStorage only and defaults to v1.
-    const [editorVersion, setEditorVersion] = useState<"v1" | "v2">("v1");
+    const [editorVersion, setEditorVersion] = useState<"v1" | "v2" | "v3">("v1");
     useEffect(() => {
         try {
             const saved = window.localStorage.getItem("tendso.editorVersion");
-            if (saved === "v1" || saved === "v2") setEditorVersion(saved);
+            if (saved === "v1" || saved === "v2" || saved === "v3") setEditorVersion(saved);
         } catch {
             /* localStorage unavailable — keep the v1 default */
         }
     }, []);
-    const chooseEditorVersion = (v: "v1" | "v2") => {
+    const chooseEditorVersion = (v: "v1" | "v2" | "v3") => {
         setEditorVersion(v);
         try {
             window.localStorage.setItem("tendso.editorVersion", v);
@@ -834,7 +835,7 @@ export default function SubmissionDetailPage() {
                         role="group"
                         aria-label="Editor version"
                     >
-                        {(["v1", "v2"] as const).map((v) => (
+                        {(["v1", "v2", "v3"] as const).map((v) => (
                             <button
                                 key={v}
                                 type="button"
@@ -1127,7 +1128,9 @@ export default function SubmissionDetailPage() {
                                     },
                                     detailsOpen: sidebarOpen,
                                 };
-                                return editorVersion === "v2" ? (
+                                return editorVersion === "v3" ? (
+                                    <SandboxEditorV3 {...editorProps} />
+                                ) : editorVersion === "v2" ? (
                                     <SandboxEditorV2 {...editorProps} />
                                 ) : (
                                     <SandboxEditor {...editorProps} />

--- a/components/editor/SandboxEditorV3.tsx
+++ b/components/editor/SandboxEditorV3.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+/**
+ * SandboxEditorV3 — the unified editor.
+ *
+ * v2's design surface (live themeOverride recolour/refont, template design-preview
+ * swap, safe in-iframe contenteditable, batched save-once → single rebuild)
+ * + v1's structured power (schema sidebar form with add/remove/reorder lists,
+ * image picker, link popover) surfaced by ROUTING preview clicks to those tested
+ * sidebar editors — so everything v2 defers is recovered with zero new data-loss
+ * surface (arrays/links/images are still written whole by v1's logic).
+ *
+ * Same SandboxEditorProps + onSaveContent + astro build + ed:* bridge as v1/v2;
+ * a drop-in behind the editorVersion toggle. Draft model + undo/redo + local
+ * draft recovery live in useEditorDraft.
+ *
+ * NOT runtime-tested locally (Next build won't finish on the dev box) — verify on
+ * a throwaway submission per the PR's checklist.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { injectEditorBridge } from "./editorBridge";
+import type { SandboxEditorProps } from "./SandboxEditor";
+import { TEMPLATE_FAMILIES, templateByCode } from "./templateCatalog";
+import { COLOR_SCHEMES, FONT_PAIRINGS, ALL_BLOCKS, CURATED } from "./editorConstants";
+import { buildOverrideCss, buildFontHref, resolveAutoScheme } from "./themeOverride";
+import { useEditorDraft } from "./useEditorDraft";
+import { applyImageSlot, isImageField, uploadImage } from "./editorImageSlots";
+import ContentFieldsAuto from "./ContentFieldsAuto";
+import ImagePickerModal from "./ImagePickerModal";
+import LinkPopover, { type LinkPopoverData } from "./LinkPopover";
+
+const TB = "inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-neutral-600 transition-colors hover:border-neutral-300 disabled:opacity-40 disabled:cursor-not-allowed";
+
+const SCHEME_SWATCH: Record<string, string> = {
+    auto: "#94a3b8", blue: "#2563eb", green: "#16a34a", purple: "#7c3aed",
+    orange: "#ea580c", dark: "#1f2937", pink: "#db2777", brown: "#92400e",
+    red: "#dc2626", yellow: "#eab308", maroon: "#7f1d1d", black: "#111111",
+    gold: "#b8860b", whitegold: "#d4af37", professional: "#334155",
+};
+
+const VIEWPORTS: Record<string, number | null> = { desktop: null, tablet: 834, mobile: 390 };
+
+// Inject the picked Color Scheme / Font Pairing live into the same-origin preview
+// iframe — identical to v2's applyThemeToIframe (SandboxEditorV2.tsx:30-63).
+function applyThemeToIframe(iframe: HTMLIFrameElement | null, scheme: string, font: string, businessType: string) {
+    try {
+        const doc = iframe?.contentDocument;
+        if (!doc || !doc.body) return;
+        const resolvedScheme = !scheme || scheme === "auto" || scheme === "default" ? resolveAutoScheme(businessType) : scheme;
+        const pairing = !font || font === "auto" || font === "default" ? "" : font;
+        const fontHref = buildFontHref(pairing);
+        if (fontHref && doc.head) {
+            let linkEl = doc.getElementById("ed-live-font") as HTMLLinkElement | null;
+            if (!linkEl) {
+                linkEl = doc.createElement("link");
+                linkEl.id = "ed-live-font";
+                linkEl.rel = "stylesheet";
+                doc.head.appendChild(linkEl);
+            }
+            if (linkEl.href !== fontHref) linkEl.href = fontHref;
+        }
+        const css = buildOverrideCss(resolvedScheme, pairing);
+        let styleEl = doc.getElementById("ed-live-theme") as HTMLStyleElement | null;
+        if (!css) { if (styleEl) styleEl.textContent = ""; return; }
+        if (!styleEl) {
+            styleEl = doc.createElement("style");
+            styleEl.id = "ed-live-theme";
+            doc.body.appendChild(styleEl);
+        }
+        styleEl.textContent = css;
+    } catch { /* same-origin access can throw — Save still applies it for real */ }
+}
+
+type Panel = "design" | "content" | "media";
+
+export default function SandboxEditorV3(props: SandboxEditorProps) {
+    const {
+        businessName, htmlContent, submissionId, photos, enhancedImageUrls,
+        onSaveContent, websitePublishedUrl,
+        websiteGenerated, generatingWebsite, publishingWebsite, republishingWebsite,
+        unpublishingWebsite, enhancing, sendingEmail,
+        onSendToClient, onEnhanceImages, onRegenerate, onPublish, onRepublish,
+        onUnpublish, onDelete, onApprove, onReject, onToggleDetails,
+    } = props;
+
+    const m = useEditorDraft(props);
+
+    const [panel, setPanel] = useState<Panel>("design");
+    const panelRef = useRef<Panel>(panel);
+    panelRef.current = panel;
+    const [viewport, setViewport] = useState<keyof typeof VIEWPORTS>("desktop");
+    const [saving, setSaving] = useState(false);
+    const [imagePickerField, setImagePickerField] = useState<string | null>(null);
+    const [linkData, setLinkData] = useState<LinkPopoverData | null>(null);
+    const [pendingImageField, setPendingImageField] = useState<string | null>(null);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const [uploadingPhoto, setUploadingPhoto] = useState(false);
+
+    const iframeRef = useRef<HTMLIFrameElement | null>(null);
+    const railRef = useRef<HTMLDivElement | null>(null);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+    const busy = generatingWebsite || saving;
+    const previewHtml = useMemo(() => injectEditorBridge(htmlContent || ""), [htmlContent]);
+    const curatedSchemes = m.activeFamily ? CURATED[m.activeFamily] : COLOR_SCHEMES.map((c) => c.id).filter((id) => id !== "auto");
+
+    // ── Live theme apply ──────────────────────────────────────────────────
+    const applyTheme = useCallback(() => {
+        applyThemeToIframe(iframeRef.current, m.currentScheme, m.currentFont, m.btForTheme);
+    }, [m.currentScheme, m.currentFont, m.btForTheme]);
+
+    const setThemeField = (field: "colorScheme" | "fontPairing", value: string) => {
+        m.setThemeField(field, value);
+        const nextScheme = field === "colorScheme" ? value : m.currentScheme;
+        const nextFont = field === "fontPairing" ? value : m.currentFont;
+        applyThemeToIframe(iframeRef.current, nextScheme, nextFont, m.btForTheme);
+    };
+
+    // ── Live text push to the iframe (sidebar edit → preview) ─────────────
+    const pushLiveText = useCallback((path: string, value: any) => {
+        try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:update", field: path, value }, "*"); } catch { /* ignore */ }
+    }, []);
+
+    // ── Safe in-iframe contenteditable (v2:201-252, unchanged SKIP set) ───
+    const setupInlineEditing = useCallback(() => {
+        const doc = iframeRef.current?.contentDocument;
+        if (!doc) return;
+        const SKIP = (f: string) =>
+            f === "hero.headline" ||
+            /^(nav\.brand|nav\.status|nav\.links|navbar_links)(\.|$)/.test(f) ||
+            /\.(items|steps|paragraphs)\.\d+/.test(f);
+        const readVal = (node: Element) =>
+            ((node as HTMLElement).innerText ?? node.textContent ?? "")
+                .replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+        const wire = (target: HTMLElement, ownerField: string) => {
+            const orig = readVal(target);
+            target.setAttribute("contenteditable", "true");
+            target.setAttribute("spellcheck", "false");
+            target.addEventListener("keydown", (ev: any) => {
+                if (ev.key === "Enter" && !ev.shiftKey) { ev.preventDefault(); target.blur(); }
+            });
+            target.addEventListener("blur", () => {
+                const val = readVal(target);
+                if (val === orig) return;
+                m.setDeepDraft(ownerField, val);
+            });
+        };
+        doc.querySelectorAll<HTMLElement>("[data-field]").forEach((el) => {
+            const field = el.getAttribute("data-field") || "";
+            if (!field || (el as any).__v3wired) return;
+            if (el.hasAttribute("data-href-field") || el.hasAttribute("data-image-field")) return;
+            if (el.tagName.toLowerCase() === "a" && /^(tel:|mailto:)/i.test(el.getAttribute("href") || "")) return;
+            if (SKIP(field)) return;
+            const childEls = Array.from(el.children);
+            const looseText = Array.from(el.childNodes).filter((n) => n.nodeType === 3 && !!n.nodeValue && !!n.nodeValue.trim());
+            (el as any).__v3wired = true;
+            if (childEls.length === 0) {
+                wire(el, field);
+            } else if (looseText.length === 1 && childEls.every((c) => !(c.textContent || "").trim())) {
+                const s = doc.createElement("span");
+                el.replaceChild(s, looseText[0]);
+                s.appendChild(looseText[0]);
+                wire(s, field);
+            }
+        });
+    }, [m]);
+
+    // ── Focus a sidebar input by data-field path (v1:566-630) ─────────────
+    const focusSidebarField = useCallback((field: string, opts?: { pulse?: boolean }) => {
+        if (panelRef.current !== "content") setPanel("content");
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            const el = document.querySelector(`[data-field-input="${field}"]`) as HTMLElement | null;
+            if (!el) return;
+            el.scrollIntoView({ block: "center", behavior: "smooth" });
+            if (opts?.pulse) {
+                el.classList.add("ed-selection-pulse");
+                window.setTimeout(() => el.classList.remove("ed-selection-pulse"), 1400);
+            } else {
+                (el as any).focus?.();
+            }
+        }));
+    }, []);
+
+    // ── ed:* click routing (from v1, adapted to the 3-panel rail) ─────────
+    useEffect(() => {
+        function onMessage(e: MessageEvent) {
+            const data: any = e?.data;
+            if (!data || typeof data !== "object" || !data.type) return;
+            if (data.type === "ed:link-click") {
+                setLinkData({
+                    field: String(data.field || ""),
+                    hrefField: String(data.hrefField || ""),
+                    platformField: data.platformField ? String(data.platformField) : undefined,
+                    text: String(data.text || ""),
+                    href: String(data.href || ""),
+                    platform: data.platform ? String(data.platform) : undefined,
+                });
+                return;
+            }
+            if (data.type === "ed:image-click" && typeof data.field === "string") {
+                setImagePickerField(data.field);
+                return;
+            }
+            if (data.type === "ed:select" && typeof data.field === "string") {
+                focusSidebarField(data.field, { pulse: true });
+                return;
+            }
+            if (data.type === "ed:click" && typeof data.field === "string") {
+                // An image slot clicked as plain text → open the picker on it.
+                if (isImageField(data.field)) { setImagePickerField(data.field); return; }
+                focusSidebarField(data.field);
+            }
+        }
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
+    }, [focusSidebarField]);
+
+    // ── Image picker select (v1:661-670 parity: write the data-field path) ─
+    const handleImagePick = useCallback((field: string, src: string) => {
+        try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:image", field, src }, "*"); } catch { /* ignore */ }
+        m.setValue(field, src);
+        setImagePickerField(null);
+    }, [m]);
+
+    // ── Link popover save (v1:637-658) ────────────────────────────────────
+    const handleLinkSave = useCallback((next: LinkPopoverData) => {
+        try {
+            iframeRef.current?.contentWindow?.postMessage({
+                type: "ed:link-update", field: next.field, hrefField: next.hrefField,
+                text: next.text, href: next.href, platformField: next.platformField, platform: next.platform,
+            }, "*");
+        } catch { /* ignore */ }
+        if (next.field) m.setValue(next.field, next.text);
+        if (next.hrefField) m.setValue(next.hrefField, next.href);
+    }, [m]);
+
+    // ── Upload a photo into a slot (v1 assignImageToSlot path) ────────────
+    const handleUpload = useCallback(async (file: File, slot: string | null) => {
+        setUploadError(null);
+        setUploadingPhoto(true);
+        try {
+            const url = await uploadImage(file, submissionId);
+            m.replaceDraft(applyImageSlot(m.draftRef.current, slot, url));
+            if (slot) {
+                try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:image", field: slot, src: url }, "*"); } catch { /* ignore */ }
+            }
+            setPendingImageField(null);
+        } catch (err: any) {
+            setUploadError(err?.message ?? "Image upload failed");
+        } finally {
+            setUploadingPhoto(false);
+            if (fileInputRef.current) fileInputRef.current.value = "";
+        }
+    }, [m, submissionId]);
+
+    // ── Save (v2:301-331) — batched, single rebuild ───────────────────────
+    const handleSave = useCallback(async () => {
+        if (busy) return;
+        try { (iframeRef.current?.contentDocument?.activeElement as HTMLElement | null)?.blur?.(); } catch { /* ignore */ }
+        const currentDraft = m.draftRef.current;
+        if (m.contentDirty === false && m.customizationsDirty === false) return;
+        setSaving(true);
+        const toastId = toast.loading(m.customizationsDirty ? "Saving changes · regenerating site…" : "Saving content…", { duration: Infinity });
+        try {
+            await onSaveContent({ ...currentDraft, business_type: m.selectedBucket }, m.customizationsDirty ? m.pendingCustomizations : undefined);
+            m.setPreviewSrc(null);
+            m.clearCache();
+            toast.success("Changes saved", { id: toastId, description: m.customizationsDirty ? "Theme + content applied. Refreshing preview." : "Content updated." });
+        } catch (err: any) {
+            toast.error("Save failed", { id: toastId, description: err?.message ?? "Please try again." });
+        } finally {
+            setSaving(false);
+        }
+    }, [busy, m, onSaveContent]);
+
+    // ── Keyboard shortcuts: ⌘S save · ⌘Z undo · ⌘⇧Z redo ──────────────────
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            const mod = e.metaKey || e.ctrlKey;
+            if (!mod) return;
+            const k = e.key.toLowerCase();
+            if (k === "s") { e.preventDefault(); void handleSave(); }
+            else if (k === "z" && !e.shiftKey) { e.preventDefault(); m.undo(); }
+            else if ((k === "z" && e.shiftKey) || k === "y") { e.preventDefault(); m.redo(); }
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [handleSave, m]);
+
+    // ── Template thumbnail lazy-mount (v2:268-299) ────────────────────────
+    useEffect(() => {
+        const root = railRef.current;
+        if (!root) return;
+        const W = 1280;
+        const fill = (thumb: HTMLElement) => {
+            if (thumb.dataset.done) return;
+            const src = thumb.dataset.src;
+            if (!src) return;
+            thumb.dataset.done = "1";
+            const scale = (thumb.clientWidth || 150) / W;
+            const ifr = document.createElement("iframe");
+            ifr.setAttribute("scrolling", "no");
+            ifr.setAttribute("tabindex", "-1");
+            ifr.setAttribute("aria-hidden", "true");
+            ifr.style.transform = `scale(${scale.toFixed(4)})`;
+            ifr.addEventListener("load", () => { thumb.querySelector(".v3-ph")?.remove(); });
+            ifr.src = src;
+            thumb.appendChild(ifr);
+        };
+        const thumbs = Array.from(root.querySelectorAll<HTMLElement>(".v3-thumb"));
+        if (!("IntersectionObserver" in window)) { thumbs.forEach(fill); return; }
+        const io = new IntersectionObserver((entries) => {
+            entries.forEach((e) => { if (e.isIntersecting) { io.unobserve(e.target); fill(e.target as HTMLElement); } });
+        }, { root, rootMargin: "260px 0px" });
+        thumbs.forEach((t) => io.observe(t));
+        return () => io.disconnect();
+        // panel switches re-mount the grid; re-observe when Design opens
+    }, [panel]);
+
+    const vw = VIEWPORTS[viewport];
+
+    return (
+        <div className="flex h-[calc(100vh-8rem)] min-h-[560px] flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white">
+            {/* Draft-recovery banner */}
+            {m.hasCachedDraft && (
+                <div className="flex items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-[12px] text-amber-800">
+                    <span>You have unsaved edits from a previous session.</span>
+                    <span className="flex gap-2">
+                        <button type="button" onClick={m.restoreCachedDraft} className="rounded bg-amber-500 px-2.5 py-1 font-semibold text-white hover:bg-amber-600">Restore</button>
+                        <button type="button" onClick={m.dismissCachedDraft} className="rounded border border-amber-300 px-2.5 py-1 font-medium hover:bg-amber-100">Dismiss</button>
+                    </span>
+                </div>
+            )}
+
+            <div className="flex min-h-0 flex-1">
+                {/* ── Left rail ─────────────────────────────────────────── */}
+                <aside ref={railRef} className="flex w-[320px] flex-shrink-0 flex-col overflow-hidden border-r border-neutral-200 bg-neutral-50">
+                    <div className="border-b border-neutral-200 px-4 py-3">
+                        <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-amber-600">Editor v3</div>
+                        <h2 className="truncate text-sm font-bold text-neutral-900">{businessName}</h2>
+                    </div>
+                    {/* Panel switch */}
+                    <div className="flex gap-1 border-b border-neutral-200 p-2">
+                        {(["design", "content", "media"] as Panel[]).map((p) => (
+                            <button
+                                key={p}
+                                type="button"
+                                onClick={() => setPanel(p)}
+                                className={`flex-1 rounded-md px-2 py-1.5 text-[11px] font-semibold capitalize transition-colors ${panel === p ? "bg-neutral-900 text-white" : "text-neutral-500 hover:bg-neutral-100"}`}
+                            >{p}</button>
+                        ))}
+                    </div>
+
+                    <div className="min-h-0 flex-1 overflow-y-auto">
+                        {panel === "design" && (
+                            <>
+                                <section className="border-b border-neutral-200 p-4">
+                                    <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-neutral-400">Template</h3>
+                                    {TEMPLATE_FAMILIES.map((fam) => (
+                                        <div key={fam.family} className="mb-3 last:mb-0">
+                                            <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-neutral-400">{fam.label}</div>
+                                            <div className="grid grid-cols-2 gap-2">
+                                                {fam.templates.map((t) => {
+                                                    const active = t.code === m.currentHeroStyle;
+                                                    return (
+                                                        <button
+                                                            key={t.code}
+                                                            type="button"
+                                                            title={t.tagline}
+                                                            aria-pressed={active}
+                                                            onClick={() => m.onPickTemplate(t.code)}
+                                                            className={`flex flex-col gap-1.5 overflow-hidden rounded-lg border p-1.5 text-left transition-all ${active ? "border-amber-500 bg-amber-50 ring-1 ring-amber-500" : "border-neutral-200 bg-white hover:border-neutral-300 hover:-translate-y-px"}`}
+                                                        >
+                                                            <div className="v3-thumb relative aspect-[16/10] w-full overflow-hidden rounded-md border border-neutral-200 bg-white [&>iframe]:pointer-events-none [&>iframe]:absolute [&>iframe]:left-0 [&>iframe]:top-0 [&>iframe]:h-[800px] [&>iframe]:w-[1280px] [&>iframe]:origin-top-left [&>iframe]:border-0" data-src={t.preview}>
+                                                                <span className="v3-ph absolute inset-0 flex items-center justify-center text-[9px] uppercase tracking-wide text-neutral-300">preview</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1">
+                                                                <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-neutral-800">{t.label}</span>
+                                                                <span className="flex-shrink-0 font-mono text-[8px] uppercase text-neutral-400">{t.letter}</span>
+                                                            </div>
+                                                        </button>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </section>
+                                <section className="border-b border-neutral-200 p-4">
+                                    <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-neutral-400">
+                                        Colors {m.activeFamily && <span className="font-normal normal-case tracking-normal text-neutral-400">· suggested for {m.activeFamily}</span>}
+                                    </h3>
+                                    <div className="grid grid-cols-4 gap-2">
+                                        {["auto", ...curatedSchemes].filter((v, i, a) => a.indexOf(v) === i).map((id) => {
+                                            const active = m.currentScheme === id;
+                                            return (
+                                                <button key={id} type="button" title={COLOR_SCHEMES.find((c) => c.id === id)?.label ?? id} aria-pressed={active}
+                                                    onClick={() => setThemeField("colorScheme", id)}
+                                                    className={`flex flex-col items-center gap-1 rounded-lg border p-1.5 transition-colors ${active ? "border-amber-500 ring-1 ring-amber-500" : "border-neutral-200 hover:border-neutral-300"}`}>
+                                                    <span className="h-5 w-full rounded" style={{ background: SCHEME_SWATCH[id] ?? "#999" }} />
+                                                    <span className="w-full truncate text-center text-[8.5px] capitalize text-neutral-500">{id}</span>
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </section>
+                                <section className="border-b border-neutral-200 p-4">
+                                    <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-neutral-400">Font</h3>
+                                    <div className="flex flex-wrap gap-1.5">
+                                        {FONT_PAIRINGS.map((f) => {
+                                            const active = m.currentFont === f.id;
+                                            return (
+                                                <button key={f.id} type="button" aria-pressed={active} onClick={() => setThemeField("fontPairing", f.id)}
+                                                    className={`rounded-full border px-2.5 py-1 text-[11px] transition-colors ${active ? "border-amber-500 bg-amber-50 font-semibold text-amber-700" : "border-neutral-200 text-neutral-600 hover:border-neutral-300"}`}>
+                                                    {f.label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </section>
+                                <section className="p-4">
+                                    <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-neutral-400">Sections</h3>
+                                    <div className="space-y-0.5">
+                                        {ALL_BLOCKS.map((b) => {
+                                            const on = m.isBlockEnabled(b.visKey);
+                                            const required = b.tag === "required";
+                                            return (
+                                                <button key={b.visKey} type="button" disabled={required} onClick={() => m.toggleBlock(b.visKey)} aria-checked={on} role="switch"
+                                                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${required ? "cursor-not-allowed opacity-60" : "hover:bg-neutral-100"}`}>
+                                                    <span className={`relative h-4 w-7 flex-shrink-0 rounded-full transition-colors ${on ? "bg-emerald-500" : "bg-neutral-300"}`}>
+                                                        <span className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform ${on ? "translate-x-3.5" : "translate-x-0.5"}`} />
+                                                    </span>
+                                                    <span className={`flex-1 text-[11px] font-medium ${on ? "text-neutral-700" : "text-neutral-400"}`}>{b.name}</span>
+                                                    {required && <span className="font-mono text-[8px] uppercase text-neutral-400">req</span>}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </section>
+                            </>
+                        )}
+
+                        {panel === "content" && (
+                            <div className="p-3">
+                                <p className="mb-2 px-1 text-[10px] leading-snug text-neutral-400">Edit any field here, or click text in the preview to jump to it. Lists, links &amp; images add/remove/reorder safely.</p>
+                                <ContentFieldsAuto getValue={m.getValue} setValue={m.setValue} openImagePicker={(path) => setImagePickerField(path)} pushLiveText={pushLiveText} />
+                            </div>
+                        )}
+
+                        {panel === "media" && (
+                            <section className="p-4">
+                                <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-neutral-400">Media</h3>
+                                <input ref={fileInputRef} type="file" accept="image/*" className="hidden"
+                                    onChange={(e) => { const f = e.target.files?.[0]; if (f) void handleUpload(f, pendingImageField); }} />
+                                <div className="flex flex-col gap-2">
+                                    <button type="button" disabled={uploadingPhoto} onClick={() => { setPendingImageField(null); fileInputRef.current?.click(); }} className={TB}>
+                                        {uploadingPhoto ? "Uploading…" : "Upload photo"}
+                                    </button>
+                                    <button type="button" disabled={uploadingPhoto} onClick={() => { setPendingImageField("favicon"); fileInputRef.current?.click(); }} className={TB}>
+                                        Set favicon
+                                    </button>
+                                    {uploadError && <p className="text-[11px] text-red-600">{uploadError}</p>}
+                                    <p className="text-[10px] leading-snug text-neutral-400">Tip: click any image in the preview to swap it from your photos.</p>
+                                </div>
+                                {photos && photos.length > 0 && (
+                                    <div className="mt-3 grid grid-cols-3 gap-2">
+                                        {photos.map((url, i) => (
+                                            <img key={i} src={url} alt="" loading="lazy" className="aspect-square w-full rounded-md border border-neutral-200 object-cover" />
+                                        ))}
+                                    </div>
+                                )}
+                            </section>
+                        )}
+                    </div>
+                </aside>
+
+                {/* ── Preview + toolbar ─────────────────────────────────── */}
+                <div className="flex min-w-0 flex-1 flex-col">
+                    <div className="flex flex-wrap items-center gap-2 border-b border-neutral-200 bg-white px-3 py-2">
+                        <button type="button" onClick={handleSave} disabled={busy} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 px-3.5 py-1.5 text-xs font-bold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-40">
+                            {saving ? "Saving…" : "Save changes"}
+                        </button>
+                        <button type="button" onClick={m.undo} disabled={!m.canUndo} className={TB} title="Undo (Ctrl/Cmd+Z)">Undo</button>
+                        <button type="button" onClick={m.redo} disabled={!m.canRedo} className={TB} title="Redo (Ctrl/Cmd+Shift+Z)">Redo</button>
+                        <div className="ml-1 flex overflow-hidden rounded-lg border border-neutral-200">
+                            {(Object.keys(VIEWPORTS) as Array<keyof typeof VIEWPORTS>).map((vp) => (
+                                <button key={vp} type="button" onClick={() => setViewport(vp)} className={`px-2.5 py-1.5 text-[11px] font-semibold capitalize transition-colors ${viewport === vp ? "bg-neutral-900 text-white" : "bg-white text-neutral-500 hover:bg-neutral-100"}`}>{vp}</button>
+                            ))}
+                        </div>
+                        <button type="button" onClick={onRegenerate} disabled={busy} className={TB}>Regenerate</button>
+                        <a href={websitePublishedUrl || `/api/preview/${submissionId}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 px-3 py-1.5 text-xs font-semibold text-neutral-700 hover:border-neutral-300">View site</a>
+                        <button type="button" onClick={onEnhanceImages} disabled={enhancing} className={TB}>{enhancing ? "Enhancing…" : "Enhance"}</button>
+                        <div className="ml-auto flex flex-wrap items-center gap-2">
+                            {onApprove && <button type="button" onClick={onApprove} className={TB}>Approve</button>}
+                            {onReject && <button type="button" onClick={onReject} className={`${TB} !text-red-600`}>Reject</button>}
+                            {websitePublishedUrl ? (
+                                <>
+                                    <button type="button" onClick={onRepublish} disabled={republishingWebsite} className={TB}>{republishingWebsite ? "Republishing…" : "Republish"}</button>
+                                    <button type="button" onClick={onUnpublish} disabled={unpublishingWebsite} className={TB}>{unpublishingWebsite ? "Unpublishing…" : "Unpublish"}</button>
+                                </>
+                            ) : (
+                                <button type="button" onClick={onPublish} disabled={publishingWebsite || !websiteGenerated} className="inline-flex items-center gap-1.5 rounded-lg bg-neutral-900 px-3 py-1.5 text-xs font-bold text-white hover:bg-neutral-700 disabled:opacity-40">{publishingWebsite ? "Publishing…" : "Publish"}</button>
+                            )}
+                            <button type="button" onClick={onSendToClient} disabled={sendingEmail} className={TB}>{sendingEmail ? "Sending…" : "Send to client"}</button>
+                            {onToggleDetails && <button type="button" onClick={onToggleDetails} className={TB}>Details</button>}
+                            <button type="button" onClick={onDelete} className={`${TB} !text-red-600`}>Delete</button>
+                        </div>
+                    </div>
+
+                    <div className="relative flex-1 overflow-auto bg-neutral-100">
+                        {busy && (
+                            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/70 backdrop-blur-sm">
+                                <div className="flex items-center gap-3 text-sm font-medium text-neutral-600">
+                                    <span className="h-5 w-5 animate-spin rounded-full border-b-2 border-amber-500" />
+                                    {saving ? "Saving + rebuilding…" : "Rebuilding website…"}
+                                </div>
+                            </div>
+                        )}
+                        {m.previewSrc && (
+                            <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 bg-amber-500/95 px-3 py-1.5 text-[11px] font-semibold text-white">
+                                <span className="truncate">Previewing this template with demo content — click “Save changes” to apply it to your site.</span>
+                                <button type="button" onClick={() => m.setPreviewSrc(null)} className="flex-shrink-0 rounded bg-white/20 px-2 py-0.5 hover:bg-white/30">Back to my site</button>
+                            </div>
+                        )}
+                        <div className="mx-auto h-full bg-white" style={vw ? { width: vw, maxWidth: "100%", boxShadow: "0 0 0 1px rgba(0,0,0,0.06)" } : { width: "100%" }}>
+                            {m.previewSrc ? (
+                                <iframe key="v3-static" ref={iframeRef} src={m.previewSrc} title="Template design preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={applyTheme} />
+                            ) : htmlContent ? (
+                                <iframe key="v3-built" ref={iframeRef} srcDoc={previewHtml} title="Website preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
+                            ) : (
+                                <div className="flex h-full items-center justify-center text-sm text-neutral-400">No website generated yet.</div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <ImagePickerModal
+                open={!!imagePickerField}
+                field={imagePickerField}
+                originals={photos ?? []}
+                enhanced={(enhancedImageUrls ?? []) as unknown as Record<string, any>}
+                onClose={() => setImagePickerField(null)}
+                onSelect={handleImagePick}
+            />
+            <LinkPopover open={!!linkData} initial={linkData} onClose={() => setLinkData(null)} onSave={handleLinkSave} />
+        </div>
+    );
+}

--- a/components/editor/editorImageSlots.ts
+++ b/components/editor/editorImageSlots.ts
@@ -1,0 +1,88 @@
+/**
+ * editorImageSlots — pure image helpers shared by the editors, extracted from
+ * v1 SandboxEditor so v3 can reuse them without importing the 4000-line v1 file.
+ *
+ * The slot vocabulary + upload contract are lifted verbatim from
+ * SandboxEditor.tsx (assignImageToSlot :784-835, handleAddPhoto :836-869, the
+ * ed:click image-field heuristic :609). Keep in sync with v1 if that changes.
+ */
+
+/**
+ * Return a NEW draft with `url` written into the image slot named by `slot`
+ * (a data-field / data-image-field path). Pure — does not touch the iframe.
+ *   hero.image            → images[0]
+ *   about.image           → about_images[0]
+ *   services.image        → services_image
+ *   services.list.N.image → services[N].image
+ *   gallery.tile.N        → featured_images[N]
+ *   favicon               → favicon
+ *   (anything else / null) → appended to images[]
+ */
+export function applyImageSlot(draft: any, slot: string | null, url: string): any {
+    const next = { ...(draft ?? {}) };
+    const images = ((next.images as string[]) ?? []).slice();
+
+    if (!slot) {
+        next.images = [...images, url];
+        return next;
+    }
+    if (slot === "favicon") {
+        next.favicon = url;
+    } else if (slot === "hero.image") {
+        if (images.length === 0) images.push(url);
+        else images[0] = url;
+        next.images = images;
+    } else if (slot === "about.image") {
+        const about = ((next.about_images as string[]) ?? []).slice();
+        if (about.length === 0) about.push(url);
+        else about[0] = url;
+        next.about_images = about;
+    } else if (slot === "services.image") {
+        next.services_image = url;
+    } else if (slot.startsWith("services.list.") && slot.endsWith(".image")) {
+        const idx = parseInt(slot.split(".")[2] || "0", 10);
+        const list = ((next.services as any[]) ?? []).slice();
+        while (list.length <= idx) list.push({ name: "", description: "" });
+        list[idx] = { ...(list[idx] || {}), image: url };
+        next.services = list;
+    } else if (slot.startsWith("gallery.tile.")) {
+        const idx = parseInt(slot.split(".")[2] || "0", 10);
+        const featured = ((next.featured_images as string[]) ?? []).slice();
+        while (featured.length <= idx) featured.push("");
+        featured[idx] = url;
+        next.featured_images = featured;
+    } else {
+        next.images = [...images, url];
+    }
+    return next;
+}
+
+/**
+ * Does this data-field path point at an image slot (route the click to the
+ * image picker rather than a text input)? Mirrors v1's heuristic.
+ */
+export function isImageField(field: string): boolean {
+    return /\.(image|photo|tile|thumb)(\.|$)|^hero\.image$|^about\.image$|^gallery\.tile\./.test(field);
+}
+
+/**
+ * Upload an image to the shared /api/upload-image endpoint (10MB, image/* —
+ * same limits v1 enforces) and return the stored URL. Throws a human message
+ * on validation / network / server failure so callers can toast it.
+ */
+export async function uploadImage(file: File, submissionId: string): Promise<string> {
+    if (!file.type.startsWith("image/")) throw new Error("Please choose an image file.");
+    if (file.size > 10 * 1024 * 1024) throw new Error("Image must be under 10MB.");
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("submissionId", submissionId);
+    const res = await fetch("/api/upload-image", { method: "POST", body: fd });
+    if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        throw new Error(errBody?.error || `Upload failed (HTTP ${res.status})`);
+    }
+    const data = await res.json();
+    const url: string | undefined = data?.url;
+    if (!url) throw new Error("Upload succeeded but no URL returned");
+    return url;
+}

--- a/components/editor/themeOverride.ts
+++ b/components/editor/themeOverride.ts
@@ -1,0 +1,303 @@
+/**
+ * themeOverride — CLIENT copy of the astro build's scheme/font → CSS override.
+ *
+ * ⚠️ SOURCE OF TRUTH: astro-site-template/src/lib/genericThemeOverrides.ts.
+ * That file runs at build time to bake the admin's Color Scheme / Font Pairing
+ * into every generated site. This is a byte-faithful port of its PURE parts
+ * (no astro/DOM/server deps) so the v2 editor can inject the SAME override live
+ * into the preview iframe for an instant, save-less recolour/refont. If you
+ * change the palettes or token mapping there, mirror the change here (and vice
+ * versa) or the live preview will drift from what Save actually renders.
+ *
+ * Only the pure subset is copied: buildOverrideCss + its palette/font tables +
+ * the auto-scheme resolver. resolveTheme/buildFontHref (build-only) are omitted.
+ */
+
+type Palette = {
+    paper: string;
+    paper2: string;
+    card: string;
+    ink: string;
+    inkSoft: string;
+    line: string;
+    primary: string;
+    primaryDeep: string;
+    accent: string;
+    paperRgb: string;
+    inkRgb: string;
+    accentRgb: string;
+};
+
+function parseHex(hex: string): [number, number, number] | null {
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) return null;
+    const v = m[1];
+    return [
+        parseInt(v.slice(0, 2), 16),
+        parseInt(v.slice(2, 4), 16),
+        parseInt(v.slice(4, 6), 16),
+    ];
+}
+
+function luminance(hex: string): number {
+    const rgb = parseHex(hex);
+    if (!rgb) return 0.5;
+    const lin = rgb.map((c) => {
+        const s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * lin[0]! + 0.7152 * lin[1]! + 0.0722 * lin[2]!;
+}
+
+function pickOn(bg: string): string {
+    return luminance(bg) > 0.5 ? '#0B0B0F' : '#FFFFFF';
+}
+
+const SCHEMES: Record<string, Palette> = {
+    blue: {
+        paper: '#F5F8FC', paper2: '#FFFFFF', card: '#E6EEF8',
+        ink: '#0F2C4A', inkSoft: '#3C5A7F', line: '#CDDBEF',
+        primary: '#3B82F6', primaryDeep: '#1E3A8A', accent: '#60A5FA',
+        paperRgb: '245,248,252', inkRgb: '15,44,74', accentRgb: '96,165,250',
+    },
+    green: {
+        paper: '#F2F7F2', paper2: '#FFFFFF', card: '#E1EDE3',
+        ink: '#14532D', inkSoft: '#3A6647', line: '#CCDFCF',
+        primary: '#16A34A', primaryDeep: '#14532D', accent: '#4ADE80',
+        paperRgb: '242,247,242', inkRgb: '20,83,45', accentRgb: '74,222,128',
+    },
+    purple: {
+        paper: '#F6F3FB', paper2: '#FFFFFF', card: '#E8E0F4',
+        ink: '#1E1B4B', inkSoft: '#4338CA', line: '#D3CAE5',
+        primary: '#8B5CF6', primaryDeep: '#4C1D95', accent: '#A78BFA',
+        paperRgb: '246,243,251', inkRgb: '30,27,75', accentRgb: '167,139,250',
+    },
+    orange: {
+        paper: '#FFF8F2', paper2: '#FFFFFF', card: '#FCE6D2',
+        ink: '#431407', inkSoft: '#7C2D12', line: '#F1D5BD',
+        primary: '#F97316', primaryDeep: '#7C2D12', accent: '#FB923C',
+        paperRgb: '255,248,242', inkRgb: '67,20,7', accentRgb: '251,146,60',
+    },
+    dark: {
+        paper: '#0F172A', paper2: '#1E293B', card: '#1E293B',
+        ink: '#F8FAFC', inkSoft: '#94A3B8', line: '#334155',
+        primary: '#D1D5DB', primaryDeep: '#FFFFFF', accent: '#9CA3AF',
+        paperRgb: '15,23,42', inkRgb: '248,250,252', accentRgb: '156,163,175',
+    },
+    pink: {
+        paper: '#FFF5F8', paper2: '#FFFFFF', card: '#FBE0EA',
+        ink: '#311B92', inkSoft: '#880E4F', line: '#F2CCD9',
+        primary: '#D81B60', primaryDeep: '#880E4F', accent: '#F48FB1',
+        paperRgb: '255,245,248', inkRgb: '49,27,146', accentRgb: '244,143,177',
+    },
+    brown: {
+        paper: '#FBF8F5', paper2: '#FFFFFF', card: '#EBE3DA',
+        ink: '#3E2723', inkSoft: '#5D4037', line: '#D5CABE',
+        primary: '#795548', primaryDeep: '#3E2723', accent: '#A1887F',
+        paperRgb: '251,248,245', inkRgb: '62,39,35', accentRgb: '161,136,127',
+    },
+    red: {
+        paper: '#FFF5F5', paper2: '#FFFFFF', card: '#F8D7D7',
+        ink: '#1A0000', inkSoft: '#7F0000', line: '#EAC2C2',
+        primary: '#D32F2F', primaryDeep: '#B71C1C', accent: '#EF5350',
+        paperRgb: '255,245,245', inkRgb: '26,0,0', accentRgb: '239,83,80',
+    },
+    yellow: {
+        paper: '#FEFCE8', paper2: '#FFFFFF', card: '#FAF3C8',
+        ink: '#1A1A1A', inkSoft: '#424242', line: '#EBE0A4',
+        primary: '#FBC02D', primaryDeep: '#F57F17', accent: '#D32F2F',
+        paperRgb: '254,252,232', inkRgb: '26,26,26', accentRgb: '211,47,47',
+    },
+    maroon: {
+        paper: '#2D0000', paper2: '#3D0000', card: '#3D0000',
+        ink: '#F5F5DC', inkSoft: '#E0C0C0', line: '#5A1010',
+        primary: '#800000', primaryDeep: '#5A0000', accent: '#A52A2A',
+        paperRgb: '45,0,0', inkRgb: '245,245,220', accentRgb: '165,42,42',
+    },
+    black: {
+        paper: '#000000', paper2: '#111111', card: '#1A1A1A',
+        ink: '#FFFFFF', inkSoft: '#A0A0A0', line: '#2A2A2A',
+        primary: '#FFFFFF', primaryDeep: '#E5E5E5', accent: '#A0A0A0',
+        paperRgb: '0,0,0', inkRgb: '255,255,255', accentRgb: '160,160,160',
+    },
+    gold: {
+        paper: '#F8F5F0', paper2: '#FFFFFF', card: '#EFE6D2',
+        ink: '#1A1A1A', inkSoft: '#4A4A4A', line: '#DCD0AD',
+        primary: '#C5A059', primaryDeep: '#9C7E3D', accent: '#E5C07B',
+        paperRgb: '248,245,240', inkRgb: '26,26,26', accentRgb: '197,160,89',
+    },
+    whitegold: {
+        paper: '#FFFFFF', paper2: '#FFFFFF', card: '#F8F1E0',
+        ink: '#1A1A1A', inkSoft: '#5A5A5A', line: '#E7D9B5',
+        primary: '#B89060', primaryDeep: '#8C6940', accent: '#D6B97A',
+        paperRgb: '255,255,255', inkRgb: '26,26,26', accentRgb: '184,144,96',
+    },
+};
+
+const FONT_PAIRINGS: Record<string, { heading: string; body: string; mono?: string; gfontFamily?: string[] }> = {
+    modern: { heading: 'Space Grotesk', body: 'Inter', gfontFamily: ['Space+Grotesk:wght@400;500;600;700', 'Inter:wght@300;400;500;600;700'] },
+    classic: { heading: 'Playfair Display', body: 'Source Sans Pro', gfontFamily: ['Playfair+Display:wght@400;500;600;700', 'Source+Sans+Pro:wght@300;400;500;600'] },
+    elegant: { heading: 'Cormorant Garamond', body: 'Montserrat', gfontFamily: ['Cormorant+Garamond:wght@400;500;600;700', 'Montserrat:wght@300;400;500;600'] },
+    bold: { heading: 'Bebas Neue', body: 'Roboto', gfontFamily: ['Bebas+Neue', 'Roboto:wght@300;400;500;700'] },
+    minimal: { heading: 'DM Sans', body: 'DM Sans', gfontFamily: ['DM+Sans:wght@400;500;600;700'] },
+    professional: { heading: 'Poppins', body: 'Open Sans', gfontFamily: ['Poppins:wght@400;500;600;700', 'Open+Sans:wght@300;400;500;600'] },
+    creative: { heading: 'Righteous', body: 'Nunito', gfontFamily: ['Righteous', 'Nunito:wght@300;400;500;600;700'] },
+    tech: { heading: 'Orbitron', body: 'Exo 2', gfontFamily: ['Orbitron:wght@400;500;600;700', 'Exo+2:wght@300;400;500;600'] },
+    friendly: { heading: 'Quicksand', body: 'Quicksand', gfontFamily: ['Quicksand:wght@400;500;600;700'] },
+    luxury: { heading: 'Cinzel', body: 'Lato', gfontFamily: ['Cinzel:wght@400;500;600;700', 'Lato:wght@300;400;700'] },
+    gourmet: { heading: 'Cormorant Garamond', body: 'Montserrat', gfontFamily: ['Cormorant+Garamond:wght@400;500;600;700', 'Montserrat:wght@300;400;500;600'] },
+};
+
+/**
+ * Google Fonts URL for a pairing (mirror of the build's buildFontHref) so the
+ * live preview can load the webfont it's switching to. null for unknown pairing.
+ */
+export function buildFontHref(pairing: string): string | null {
+    const p = FONT_PAIRINGS[pairing];
+    if (!p?.gfontFamily) return null;
+    const families = p.gfontFamily.map((f) => `family=${f}`).join('&');
+    return `https://fonts.googleapis.com/css2?${families}&display=swap`;
+}
+
+const AUTO_BY_BUSINESS_TYPE: Record<string, string> = {
+    barber: 'brown', barbershop: 'brown',
+    salon: 'pink', beauty: 'pink', spa: 'pink', nail: 'pink', hair: 'pink', aesthetic: 'pink',
+    auto: 'orange', autoshop: 'orange', automotive: 'orange', mechanic: 'orange', tire: 'orange', garage: 'orange', carshop: 'orange', carrepair: 'orange',
+    restaurant: 'orange', diner: 'orange', eatery: 'orange', bistro: 'orange', food: 'orange',
+    cafe: 'orange', coffee: 'brown', roaster: 'brown', tea: 'brown',
+    retail: 'brown', store: 'brown', shop: 'brown', boutique: 'brown', apparel: 'brown', clothing: 'brown',
+    clinic: 'green', dental: 'green', dentist: 'green', medical: 'green', doctor: 'green', veterinary: 'green', vet: 'green',
+    fitness: 'red', gym: 'red', yoga: 'red', pilates: 'red', crossfit: 'red', martialarts: 'red',
+    school: 'purple', tutor: 'purple', workshop: 'purple', academy: 'purple', education: 'purple', learning: 'purple',
+    trade: 'maroon', service: 'maroon', plumbing: 'maroon', electric: 'maroon', hvac: 'maroon',
+    landscaping: 'maroon', cleaning: 'maroon', laundry: 'maroon',
+};
+
+/**
+ * Resolve an 'auto'/unset scheme to a curated scheme by business type, matching
+ * the astro build's resolveAutoScheme so the live preview picks the same colour
+ * the rebuild will. Returns '' when unknown (template's native palette wins).
+ */
+export function resolveAutoScheme(businessType: string | undefined | null): string {
+    if (!businessType) return '';
+    const k = String(businessType).trim().toLowerCase().replace(/[^a-z]/g, '');
+    if (AUTO_BY_BUSINESS_TYPE[k]) return AUTO_BY_BUSINESS_TYPE[k];
+    for (const [key, schemeId] of Object.entries(AUTO_BY_BUSINESS_TYPE)) {
+        if (k.includes(key)) return schemeId;
+    }
+    return '';
+}
+
+/**
+ * Build the override CSS block. Returns '' when scheme is unset / unknown AND
+ * pairing is unset / unknown (template default). Mirror of the build-time fn.
+ */
+export function buildOverrideCss(scheme: string, pairing: string): string {
+    const palette = SCHEMES[scheme];
+    const font = FONT_PAIRINGS[pairing];
+    if (!palette && !font) return '';
+
+    const lines: string[] = [];
+    lines.push('html:root {');
+    if (palette) {
+        lines.push(`  --paper: ${palette.paper} !important;`);
+        lines.push(`  --paper-2: ${palette.paper2} !important;`);
+        lines.push(`  --card: ${palette.card} !important;`);
+        lines.push(`  --ink: ${palette.ink} !important;`);
+        lines.push(`  --ink-soft: ${palette.inkSoft} !important;`);
+        lines.push(`  --line: ${palette.line} !important;`);
+        lines.push(`  --paper-rgb: ${palette.paperRgb} !important;`);
+        lines.push(`  --ink-rgb: ${palette.inkRgb} !important;`);
+        lines.push(`  --accent-rgb: ${palette.accentRgb} !important;`);
+        lines.push(`  --gold: ${palette.primary} !important;`);
+        lines.push(`  --gold-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --peach: ${palette.primary} !important;`);
+        lines.push(`  --peach-soft: ${palette.accent} !important;`);
+        lines.push(`  --amber: ${palette.primary} !important;`);
+        lines.push(`  --amber-2: ${palette.accent} !important;`);
+        lines.push(`  --lime: ${palette.primary} !important;`);
+        lines.push(`  --lime-2: ${palette.accent} !important;`);
+        lines.push(`  --blue: ${palette.primary} !important;`);
+        lines.push(`  --blue-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --blue-soft: ${palette.accent} !important;`);
+        lines.push(`  --mint: ${palette.accent} !important;`);
+        lines.push(`  --mint-soft: ${palette.accent} !important;`);
+        lines.push(`  --yellow: ${palette.accent} !important;`);
+        lines.push(`  --yellow-soft: ${palette.accent} !important;`);
+        lines.push(`  --teal: ${palette.primary} !important;`);
+        lines.push(`  --teal-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --teal-soft: ${palette.accent} !important;`);
+        lines.push(`  --forest: ${palette.primaryDeep} !important;`);
+        lines.push(`  --forest-2: ${palette.primary} !important;`);
+        lines.push(`  --brass: ${palette.primary} !important;`);
+        lines.push(`  --brass-bright: ${palette.accent} !important;`);
+        lines.push(`  --brass-rgb: ${palette.accentRgb} !important;`);
+        lines.push(`  --accent: ${palette.primary} !important;`);
+        lines.push(`  --accent-rgb: ${palette.accentRgb} !important;`);
+        lines.push(`  --accent-light: ${palette.accent} !important;`);
+        lines.push(`  --accent-soft: ${palette.accent} !important;`);
+        lines.push(`  --accent-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --olive: ${palette.ink} !important;`);
+        lines.push(`  --olive-2: ${palette.primary} !important;`);
+        lines.push(`  --olive-rgb: ${palette.inkRgb} !important;`);
+        lines.push(`  --bg: ${palette.paper} !important;`);
+        lines.push(`  --bg-2: ${palette.paper2} !important;`);
+        lines.push(`  --bg-rgb: ${palette.paperRgb} !important;`);
+        lines.push(`  --panel: ${palette.card} !important;`);
+        lines.push(`  --panel-2: ${palette.card} !important;`);
+        lines.push(`  --muted: ${palette.inkSoft} !important;`);
+        lines.push(`  --stone: ${palette.line} !important;`);
+        lines.push(`  --clay: ${palette.primary} !important;`);
+        lines.push(`  --clay-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --ember: ${palette.accent} !important;`);
+        lines.push(`  --nude: ${palette.primary} !important;`);
+        lines.push(`  --nude-deep: ${palette.primaryDeep} !important;`);
+        lines.push(`  --red: ${palette.primary} !important;`);
+        lines.push(`  --red-d: ${palette.primaryDeep} !important;`);
+        lines.push(`  --teal-d: ${palette.primaryDeep} !important;`);
+        lines.push(`  --coral: ${palette.accent} !important;`);
+    }
+    if (palette) {
+        const onPrimary = pickOn(palette.primary);
+        const onInk = pickOn(palette.ink);
+        const onPaper = pickOn(palette.paper);
+        const onAccent = pickOn(palette.accent);
+        lines.push(`  --on-primary: ${onPrimary} !important;`);
+        lines.push(`  --on-ink: ${onInk} !important;`);
+        lines.push(`  --on-paper: ${onPaper} !important;`);
+        lines.push(`  --on-accent: ${onAccent} !important;`);
+        lines.push(`  --on-brass: ${onPrimary} !important;`);
+    }
+    if (font) {
+        const heading = `"${font.heading}", system-ui, sans-serif`;
+        const body = `"${font.body}", system-ui, sans-serif`;
+        const mono = font.mono ? `"${font.mono}", monospace` : `"${font.body}", system-ui, sans-serif`;
+        lines.push(`  --disp: ${heading} !important;`);
+        lines.push(`  --sans: ${body} !important;`);
+        lines.push(`  --serif: ${heading} !important;`);
+        lines.push(`  --mono: ${mono} !important;`);
+        lines.push(`  --display: ${heading} !important;`);
+        lines.push(`  --body: ${body} !important;`);
+        lines.push(`  --cond: ${heading} !important;`);
+    }
+    lines.push('}');
+    if (palette) {
+        const onPrimary = pickOn(palette.primary);
+        const onInk = pickOn(palette.ink);
+        lines.push('html, body { background: var(--paper) !important; color: var(--ink) !important; }');
+        lines.push(`.btn-primary, .btn-yellow, .nav-cta, button.btn-primary, a.btn-primary { color: ${onPrimary} !important; }`);
+        lines.push(`.testi .btn, .cta-band .btn, footer .btn { color: ${onInk} !important; }`);
+        lines.push(`.nav-right .btn, .nav-right .nav-cta { color: ${onPrimary} !important; }`);
+        lines.push(`.trust, .trust .num, .trust .lbl, .testi, .testi p { color: ${onInk} !important; }`);
+        lines.push(`.btn[class~="btn-primary"] { color: ${onPrimary} !important; }`);
+        lines.push('.hero .btn-ghost, .hero a.btn-ghost { color: #FFFFFF !important; border-color: rgba(255,255,255,0.55) !important; background: transparent !important; }');
+        lines.push('.hero .btn-ghost:hover, .hero a.btn-ghost:hover { background: transparent !important; color: #FFFFFF !important; border-color: rgba(255,255,255,0.55) !important; }');
+        lines.push('.hero .btn-primary:hover, .hero a.btn-primary:hover, .hero .btn-light:hover, .hero a.btn-light:hover, .hero .btn-yellow:hover, .hero a.btn-yellow:hover { color: ' + onPrimary + ' !important; }');
+    }
+    if (font) {
+        lines.push('html, body, .wrap, section, p, h1, h2, h3, h4, h5, h6, span, div, a, li, button, input, textarea, select { font-family: inherit; }');
+        lines.push('html, body { font-family: var(--sans) !important; }');
+        lines.push('h1, h2, h3, h4, h5, h6, .htitle, .giant, .brand { font-family: var(--disp) !important; }');
+    }
+    return lines.join('\n');
+}

--- a/components/editor/useEditorDraft.ts
+++ b/components/editor/useEditorDraft.ts
@@ -1,0 +1,347 @@
+"use client";
+
+/**
+ * useEditorDraft — the shared draft/customizations model for the sandbox editors.
+ *
+ * Extracts v2's proven batching contract (SandboxEditorV2.tsx:104-331) into a
+ * reusable hook so v3 (and, later, a v2 retrofit) can't drift on it, and layers
+ * on two v3 enhancements that live purely over the draft object:
+ *   • undo / redo — a bounded history of {draft, customizations} snapshots,
+ *     coalescing rapid same-field edits into one step.
+ *   • local draft recovery — autosaves {draft, customizations} (content JSON
+ *     only, never HTML) to localStorage; on mount, if the cache differs from the
+ *     server content it OFFERS a restore (never auto-adopts — that would clobber
+ *     newer server content).
+ *
+ * State only — no DOM/iframe work. The component owns the preview iframe, theme
+ * injection, inline-editing wiring, click routing, toolbar, and the actual Save
+ * orchestration (toast/spinner); it drives them off this hook's state + mutators.
+ *
+ * INVARIANTS preserved from v2 (do not weaken — they're load-bearing):
+ *   • draftRef mirrors draft synchronously so a blur-commit right before Save is
+ *     readable without a re-render.
+ *   • clean-sync guard: adopt incoming server content/customizations ONLY when
+ *     the editor is clean, else in-progress edits survive a reactive prop re-push.
+ *   • setDeepDraft never clobbers an object leaf and preserves a non-empty string
+ *     parent as { lead } when a dotted write upgrades it to an object.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SandboxEditorProps } from "./SandboxEditor";
+import { TEMPLATE_BUCKETS } from "./templateCatalog";
+import { familyOf, templateByCode, type TemplateFamily } from "./templateCatalog";
+
+// The 12 per-section style keys a template pick stamps (mirrors v2:46-50).
+const STYLE_KEYS = [
+    "aboutStyle", "servicesStyle", "galleryStyle", "contactStyle", "trustStyle",
+    "whyUsStyle", "howItWorksStyle", "testimonialsStyle", "faqStyle",
+    "serviceAreaStyle", "credentialsStyle", "ctaBandStyle",
+] as const;
+
+const HISTORY_CAP = 60;          // max undo steps
+const COALESCE_MS = 500;         // merge same-field edits within this window into one step
+const CACHE_PREFIX = "tendso.editorDraft.v3.";
+const CACHE_DEBOUNCE_MS = 800;
+
+type Snapshot = { draft: any; cust: any };
+
+function deepGet(obj: any, path: string): any {
+    let cur = obj;
+    for (const p of path.split(".")) {
+        if (cur == null) return undefined;
+        cur = cur[p];
+    }
+    return cur;
+}
+
+const j = (v: any) => JSON.stringify(v ?? null);
+
+export function useEditorDraft(props: SandboxEditorProps) {
+    const { content, customizations, businessType, submissionId } = props;
+
+    // ── Content draft (+ visibility) ──────────────────────────────────────
+    const [draft, setDraft] = useState<any>(() => ({ ...(content ?? {}) }));
+    const draftRef = useRef<any>(draft);
+    draftRef.current = draft;
+
+    // ── Customizations (template/theme/per-block *Style picks) ────────────
+    const [pendingCustomizations, setPendingCustomizations] = useState<any>(customizations);
+    const pendingCustRef = useRef<any>(pendingCustomizations);
+    pendingCustRef.current = pendingCustomizations;
+
+    // ── Template design-preview swap (demo content) ───────────────────────
+    const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+
+    // ── Undo/redo history over {draft, cust} snapshots ────────────────────
+    const historyRef = useRef<{ stack: Snapshot[]; index: number }>({
+        stack: [{ draft: draftRef.current, cust: pendingCustRef.current }],
+        index: 0,
+    });
+    const lastPushRef = useRef<{ at: number; key: string } | null>(null);
+    const [canUndo, setCanUndo] = useState(false);
+    const [canRedo, setCanRedo] = useState(false);
+    const refreshUndoFlags = () => {
+        const h = historyRef.current;
+        setCanUndo(h.index > 0);
+        setCanRedo(h.index < h.stack.length - 1);
+    };
+
+    // ── Local draft recovery ──────────────────────────────────────────────
+    const cacheKey = CACHE_PREFIX + submissionId;
+    const cacheTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const cachedRef = useRef<Snapshot | null>(null);
+    const [hasCachedDraft, setHasCachedDraft] = useState(false);
+
+    const clearCache = useCallback(() => {
+        try { window.localStorage.removeItem(cacheKey); } catch { /* ignore */ }
+        cachedRef.current = null;
+        setHasCachedDraft(false);
+    }, [cacheKey]);
+
+    const scheduleCache = useCallback((d: any, c: any) => {
+        if (cacheTimer.current) clearTimeout(cacheTimer.current);
+        cacheTimer.current = setTimeout(() => {
+            try {
+                // Only cache when it actually diverges from the server — a clean
+                // editor shouldn't leave a stale cache to offer next time.
+                if (j(d) === j(content) && j(c ?? null) === j(customizations ?? null)) {
+                    window.localStorage.removeItem(cacheKey);
+                } else {
+                    window.localStorage.setItem(cacheKey, JSON.stringify({ draft: d, cust: c, at: Date.now() }));
+                }
+            } catch { /* quota / disabled — non-fatal */ }
+        }, CACHE_DEBOUNCE_MS);
+    }, [cacheKey, content, customizations]);
+
+    // On mount: if a cache exists and diverges from the current server content,
+    // OFFER a restore. Never auto-adopt (a stale cache must not beat newer data).
+    useEffect(() => {
+        try {
+            const raw = window.localStorage.getItem(cacheKey);
+            if (!raw) return;
+            const parsed = JSON.parse(raw) as Snapshot & { at?: number };
+            if (parsed && j(parsed.draft) !== j(content)) {
+                cachedRef.current = { draft: parsed.draft, cust: parsed.cust };
+                setHasCachedDraft(true);
+            } else {
+                window.localStorage.removeItem(cacheKey);
+            }
+        } catch { /* ignore */ }
+        // mount-only
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // ── Central commit — updates state, records history, schedules cache ──
+    const commitState = useCallback((nextDraft: any, nextCust: any, opts?: { coalesceKey?: string; noHistory?: boolean }) => {
+        draftRef.current = nextDraft;
+        pendingCustRef.current = nextCust;
+        setDraft(nextDraft);
+        setPendingCustomizations(nextCust);
+
+        if (!opts?.noHistory) {
+            const h = historyRef.current;
+            const snap: Snapshot = { draft: nextDraft, cust: nextCust };
+            const now = Date.now();
+            const last = lastPushRef.current;
+            const canCoalesce = !!opts?.coalesceKey && !!last && last.key === opts.coalesceKey
+                && now - last.at < COALESCE_MS && h.index === h.stack.length - 1;
+            if (canCoalesce) {
+                h.stack[h.index] = snap; // replace top — collapse a typing burst
+            } else {
+                h.stack = h.stack.slice(0, h.index + 1);
+                h.stack.push(snap);
+                if (h.stack.length > HISTORY_CAP) h.stack.shift();
+                h.index = h.stack.length - 1;
+            }
+            lastPushRef.current = { at: now, key: opts?.coalesceKey ?? "" };
+            refreshUndoFlags();
+        }
+        scheduleCache(nextDraft, nextCust);
+    }, [scheduleCache]);
+
+    const applySnapshot = useCallback((s: Snapshot) => {
+        draftRef.current = s.draft;
+        pendingCustRef.current = s.cust;
+        setDraft(s.draft);
+        setPendingCustomizations(s.cust);
+        lastPushRef.current = null; // never coalesce across an undo/redo boundary
+        refreshUndoFlags();
+        scheduleCache(s.draft, s.cust);
+    }, [scheduleCache]);
+
+    const undo = useCallback(() => {
+        const h = historyRef.current;
+        if (h.index <= 0) return;
+        h.index -= 1;
+        applySnapshot(h.stack[h.index]);
+    }, [applySnapshot]);
+
+    const redo = useCallback(() => {
+        const h = historyRef.current;
+        if (h.index >= h.stack.length - 1) return;
+        h.index += 1;
+        applySnapshot(h.stack[h.index]);
+    }, [applySnapshot]);
+
+    const restoreCachedDraft = useCallback(() => {
+        const c = cachedRef.current;
+        if (!c) return;
+        commitState({ ...(c.draft ?? {}) }, c.cust);
+        setHasCachedDraft(false);
+    }, [commitState]);
+
+    // ── Clean-sync guards: adopt server props only when the editor is clean ─
+    const syncedContentRef = useRef<any>(content);
+    useEffect(() => {
+        const clean = j(draftRef.current) === j(syncedContentRef.current);
+        syncedContentRef.current = content;
+        if (clean) {
+            const next = { ...(content ?? {}) };
+            commitState(next, pendingCustRef.current, { noHistory: true });
+            historyRef.current = { stack: [{ draft: next, cust: pendingCustRef.current }], index: 0 };
+            refreshUndoFlags();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [content]);
+
+    const syncedCustRef = useRef<any>(customizations);
+    useEffect(() => {
+        // Improve on v2's unconditional adopt: keep pending theme/template picks
+        // if the editor is mid-edit; only take server customizations when clean.
+        const clean = j(pendingCustRef.current ?? null) === j(syncedCustRef.current ?? null);
+        syncedCustRef.current = customizations;
+        if (clean) {
+            pendingCustRef.current = customizations;
+            setPendingCustomizations(customizations);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [customizations]);
+
+    // ── setDeepDraft — dotted-path writer (v2:166-187, guards preserved) ──
+    const setDeepDraft = useCallback((path: string, value: any) => {
+        const prev = draftRef.current;
+        const parts = path.split(".");
+        // Clobber guard: never write a scalar over an existing OBJECT leaf.
+        let peek: any = prev;
+        for (const p of parts) { if (peek == null) break; peek = peek[p]; }
+        if (peek !== null && typeof peek === "object") return;
+        const root = prev ? { ...prev } : {};
+        let cur: any = root;
+        for (let i = 0; i < parts.length - 1; i++) {
+            const k = parts[i];
+            const numeric = /^\d+$/.test(parts[i + 1]);
+            if (Array.isArray(cur[k])) cur[k] = [...cur[k]];
+            else if (cur[k] && typeof cur[k] === "object") cur[k] = { ...cur[k] };
+            else if (typeof cur[k] === "string" && cur[k].trim()) cur[k] = numeric ? [] : { lead: cur[k] };
+            else cur[k] = numeric ? [] : {};
+            cur = cur[k];
+        }
+        cur[parts[parts.length - 1]] = value;
+        commitState(root, pendingCustRef.current, { coalesceKey: `field:${path}` });
+    }, [commitState]);
+
+    // Unguarded dotted-path writer for the sidebar FORM / link popover / image
+    // picker — these legitimately write arrays and objects (list add/remove/
+    // reorder, image URLs), so unlike setDeepDraft they must NOT bail on an
+    // existing object leaf. (setDeepDraft's clobber guard exists only to protect
+    // the conservative inline-contenteditable path.) Mirrors v1's setDeepDraft.
+    const setValue = useCallback((path: string, value: any) => {
+        const prev = draftRef.current;
+        const parts = path.split(".");
+        const root = prev ? { ...prev } : {};
+        let cur: any = root;
+        for (let i = 0; i < parts.length - 1; i++) {
+            const k = parts[i];
+            const numeric = /^\d+$/.test(parts[i + 1]);
+            if (Array.isArray(cur[k])) cur[k] = [...cur[k]];
+            else if (cur[k] && typeof cur[k] === "object") cur[k] = { ...cur[k] };
+            else if (typeof cur[k] === "string" && cur[k].trim()) cur[k] = numeric ? [] : { lead: cur[k] };
+            else cur[k] = numeric ? [] : {};
+            cur = cur[k];
+        }
+        cur[parts[parts.length - 1]] = value;
+        commitState(root, pendingCustRef.current, { coalesceKey: `field:${path}` });
+    }, [commitState]);
+
+    const getValue = useCallback((path: string) => deepGet(draftRef.current, path), []);
+
+    // Commit a whole new draft object (used by image-slot writes / normalization
+    // that rebuild the draft rather than set one dotted path).
+    const replaceDraft = useCallback((nextDraft: any, coalesceKey?: string) => {
+        commitState(nextDraft, pendingCustRef.current, coalesceKey ? { coalesceKey } : undefined);
+    }, [commitState]);
+
+    // ── Section visibility (v2:256-263) ───────────────────────────────────
+    const isBlockEnabled = useCallback((visKey: string): boolean => (draftRef.current?.visibility ?? {})[visKey] !== false, []);
+    const toggleBlock = useCallback((visKey: string) => {
+        const prev = draftRef.current;
+        const next = {
+            ...(prev ?? {}),
+            visibility: { ...(prev?.visibility ?? {}), [visKey]: (prev?.visibility ?? {})[visKey] === false ? true : false },
+        };
+        commitState(next, pendingCustRef.current, { coalesceKey: `block:${visKey}` });
+    }, [commitState]);
+
+    // ── Theme + template pickers (v2:210-233) ─────────────────────────────
+    const setThemeField = useCallback((field: "colorScheme" | "fontPairing", value: string) => {
+        const base = pendingCustRef.current ?? customizations ?? {};
+        const next = { ...base, [field]: value, [`${field}Id`]: value };
+        commitState(draftRef.current, next, { coalesceKey: `theme:${field}` });
+    }, [commitState, customizations]);
+
+    const savedHero = String((customizations as any)?.heroStyle ?? "");
+    const onPickTemplate = useCallback((code: string) => {
+        const tpl = templateByCode(code);
+        const letter = tpl?.letter ?? "A";
+        const isBranded = familyOf(code) !== "generic";
+        const base = pendingCustRef.current ?? customizations ?? {};
+        const styles = Object.fromEntries(STYLE_KEYS.map((k) => [k, code]));
+        const next = {
+            ...base,
+            heroStyle: code,
+            ...styles,
+            navbarStyle: letter,
+            ...(isBranded ? { colorScheme: "auto", colorSchemeId: "auto", fontPairing: "auto", fontPairingId: "auto" } : {}),
+        };
+        commitState(draftRef.current, next);
+        // Instant demo-content design preview; re-picking the saved template
+        // returns to the real built site.
+        setPreviewSrc(code === savedHero ? null : (tpl?.preview ?? null));
+    }, [commitState, customizations, savedHero]);
+
+    // ── Derived (mirror v2:91-99) ─────────────────────────────────────────
+    const effectiveCustomizations = pendingCustomizations ?? customizations ?? {};
+    const currentHeroStyle = String((effectiveCustomizations as any)?.heroStyle ?? "");
+    const activeFamily: TemplateFamily | null = familyOf(currentHeroStyle);
+    const currentScheme = String((effectiveCustomizations as any)?.colorScheme ?? (effectiveCustomizations as any)?.colorSchemeId ?? "auto");
+    const currentFont = String((effectiveCustomizations as any)?.fontPairing ?? (effectiveCustomizations as any)?.fontPairingId ?? "modern");
+    const btForTheme = businessType || (content as any)?.business_type || "";
+
+    const selectedBucket = (() => {
+        const initial = (businessType || (content as any)?.business_type || "").toLowerCase();
+        const match = TEMPLATE_BUCKETS.find((b) => b.id === initial || b.label.toLowerCase() === initial);
+        return match?.id ?? "services";
+    })();
+
+    const contentDirty = j(draft) !== j(content);
+    const customizationsDirty = j(pendingCustomizations ?? null) !== j(customizations ?? null);
+    const dirty = contentDirty || customizationsDirty;
+
+    // Cleanup the debounce timer on unmount.
+    useEffect(() => () => { if (cacheTimer.current) clearTimeout(cacheTimer.current); }, []);
+
+    return {
+        // state
+        draft, draftRef, pendingCustomizations, previewSrc, setPreviewSrc,
+        // mutators
+        setDeepDraft, setValue, replaceDraft, getValue, isBlockEnabled, toggleBlock, setThemeField, onPickTemplate,
+        // derived
+        effectiveCustomizations, currentHeroStyle, activeFamily, currentScheme, currentFont,
+        savedHero, btForTheme, selectedBucket,
+        contentDirty, customizationsDirty, dirty,
+        // undo/redo
+        undo, redo, canUndo, canRedo,
+        // draft recovery
+        hasCachedDraft, restoreCachedDraft, dismissCachedDraft: clearCache, clearCache,
+    };
+}


### PR DESCRIPTION
## What

A new **v3** website editor for the admin — a drop-in third option behind the existing `tendso.editorVersion` toggle (default stays **v1**; **v1 and v2 are untouched** as fallbacks). No backend changes: same `SandboxEditorProps`, same `onSaveContent(content, customizations)`, same astro build + `ed:*` bridge.

**Thesis:** v3 = v2's design surface **+** v1's structured power, unified. Everything v2 defers to v1 (lists, links, images, rich headlines) is recovered by **routing preview clicks to the tested sidebar editors** — arrays/links/images are still written whole by v1's logic, so there is **no new data-loss surface**.

## Parity (v1 ∪ v2 in one surface)
- **Design panel** (v2): template grid + instant design-preview swap, curated colors, fonts, section toggles, **live recolor/refont on the real content**.
- **Content panel**: the real `ContentFieldsAuto` schema form — every field, add/remove/reorder lists.
- **Click-routing** (v1): click text → focus its sidebar field; click a list item/link/image → open `LinkPopover` / `ImagePickerModal`.
- Safe inline `contenteditable`, full toolbar (save/regenerate/publish/enhance/approve/…), batched **save-once → single rebuild**.

## The 4 approved enhancements
1. **Unified click-to-edit**
2. **Desktop / tablet / mobile** preview toggle
3. **Undo/redo** (Ctrl/Cmd+Z / +Shift+Z, coalesced) + Ctrl/Cmd+S save
4. **Local draft recovery** — autosaves content JSON to localStorage; offers "Restore" on reload, never auto-adopts

## Files
- **new** `SandboxEditorV3.tsx` — the shell
- **new** `useEditorDraft.ts` — shared draft/save model (v2's, extracted) + undo/redo + draft recovery. Exposes a guarded `setDeepDraft` (inline) **and** an unguarded `setValue` (form/link/image) — the guard would block list add/remove/reorder, so the form uses the unguarded writer like v1.
- **new** `editorImageSlots.ts` — pure image-slot helpers from v1
- **new** `themeOverride.ts` — client mirror of the build's scheme/font override (shared by the live preview)
- `app/admin/submissions/[id]/page.tsx` — 6 small edits: add "v3" to the toggle + mount branch

## Not done yet (fast-follow)
- Port v1 `normalizeDraft` so a **brand-new** build's AI-flat sections (why/how/testimonials/faq) show in the sidebar form *before* the first save. Small.
- Reset button, scroll-to-top (minor v1 extras).
- Design-exploration features (multi-scheme small-multiples, side-by-side compare) — deferred to a later phase as agreed.

## Verification
`npx tsc --noEmit` **clean**. **Not runtime-tested locally** (Next build won't finish on the dev box) — please verify on the **Vercel preview** with a throwaway submission (`localStorage.tendso.editorVersion = 'v3'`):

- [ ] Pick templates across families → design-preview swap + banner; "Back to my site" restores; branded family resets theme to auto.
- [ ] Change color + font → recolors/refonts instantly (no rebuild).
- [ ] **Services list: add / remove / reorder / edit one item → siblings intact after Save** (core anti-regression).
- [ ] Edit a link (text + href + platform) → live-updates, persists.
- [ ] Swap a hero image + a gallery image + favicon → persists.
- [ ] Click a list item / link / image in the preview → routes to the right sidebar editor, focused.
- [ ] Undo/redo reverses inline edits + list ops; ⌘S saves.
- [ ] Device toggle changes frame width only; reload mid-edit → "Restore unsaved edits" offered.
- [ ] Save (content-only vs theme-dirty) → correct single rebuild; all toolbar actions fire the same handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)