### PR TITLE
feat(editor): real-content 'Preview my site' + fix generatedWebsites 1 MiB save error

### DIFF
--- a/app/admin/submissions/[id]/page.tsx
+++ b/app/admin/submissions/[id]/page.tsx
@@ -319,13 +319,30 @@ export default function SubmissionDetailPage() {
         : null;
 
     useEffect(() => {
-        if (existingWebsite) {
-            setWebsiteHtmlContent(existingWebsite.htmlContent || "");
-            setWebsiteContent(existingWebsite.extractedContent);
-            setWebsiteCustomizations(existingWebsite.customizations || {});
-            setWebsitePublishedUrl(existingWebsite.publishedUrl || null);
-            if (existingWebsite.htmlContent) setWebsiteGenerated(true);
+        if (!existingWebsite) return;
+        // Guard against out-of-order async resolution: two quick saves produce two
+        // different htmlUrls; without this an older fetch could win and show a
+        // stale build in the editor.
+        let ignore = false;
+        // HTML is inline (legacy) or in file storage (htmlUrl). Prefer inline;
+        // otherwise fetch the stored HTML so the editor iframe still has it.
+        const inlineHtml = existingWebsite.htmlContent || "";
+        const htmlUrl = (existingWebsite as any).htmlUrl as string | null | undefined;
+        if (inlineHtml) {
+            setWebsiteHtmlContent(inlineHtml);
+        } else if (htmlUrl) {
+            fetch(htmlUrl)
+                .then((r) => (r.ok ? r.text() : ""))
+                .then((html) => { if (!ignore) setWebsiteHtmlContent(html); })
+                .catch(() => { if (!ignore) setWebsiteHtmlContent(""); });
+        } else {
+            setWebsiteHtmlContent("");
         }
+        setWebsiteContent(existingWebsite.extractedContent);
+        setWebsiteCustomizations(existingWebsite.customizations || {});
+        setWebsitePublishedUrl(existingWebsite.publishedUrl || null);
+        if (inlineHtml || htmlUrl) setWebsiteGenerated(true);
+        return () => { ignore = true; };
     }, [existingWebsite]);
 
     // (Auto-open the Details sidebar on no-website submissions used to be

--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -871,7 +871,15 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
         }
 
         // Save to Convex using mutations
-        const { fetchMutation } = await import('convex/nextjs')
+        const { fetchMutation, fetchAction } = await import('convex/nextjs')
+
+        // Store the built HTML in Convex file storage (it can exceed the 1 MiB
+        // per-document limit, which was throwing "Value is too large" on upsert)
+        // and keep only the reference on the row. Readers resolve it via the
+        // htmlUrl the getBySubmission* queries return — see lib/website-html.ts.
+        const htmlStorageId = await fetchAction(api.generatedWebsites.storeHtml, {
+            html: generatedHtml,
+        })
 
         // Save generated website to Convex (legacy table - kept for backward compatibility)
         const websiteId = await fetchMutation(api.generatedWebsites.upsert, {
@@ -879,7 +887,7 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             templateName: selectedTemplate,
             extractedContent: contentWithContact,
             customizations: finalCustomizations,
-            htmlContent: generatedHtml,
+            htmlStorageId,
             status: 'draft',
         })
 

--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -41,7 +41,11 @@ export async function POST(request: NextRequest) {
         }
 
         const body = await request.json()
-        const { submissionId, templateName, customizations } = body
+        // `preview` + `content` power the editor's "Preview my site" — build the
+        // admin's UNSAVED draft into HTML and return it WITHOUT persisting (see the
+        // early return after buildAstroSite below). Everything else is identical to
+        // a real generate, so the preview matches exactly what Save would produce.
+        const { submissionId, templateName, customizations, content: draftContent, preview } = body
 
         if (!submissionId) {
             return NextResponse.json({ error: 'Submission ID is required' }, { status: 400 })
@@ -81,10 +85,14 @@ export async function POST(request: NextRequest) {
         })
 
         // Get or extract content - prioritization:
+        // 0. In PREVIEW mode, the admin's UNSAVED draft (from the request body) — so
+        //    the preview reflects edits that haven't been saved to Convex yet.
         // 1. Edited content from generated_websites (if exists)
         // 2. Previously extracted content from submissions
         // 3. Fresh extraction via Groq
-        let extractedContent = existingWebsite?.extractedContent || submission.website_content
+        let extractedContent = (preview && draftContent)
+            ? draftContent
+            : (existingWebsite?.extractedContent || submission.website_content)
 
         // When regenerating with existing content, override with fresh submission data
         // so admin edits to business info are reflected in the regenerated website
@@ -853,6 +861,14 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
         }
 
         const generatedHtml = await buildAstroSite(contentWithContact, finalCustomizations, photos)
+
+        // PREVIEW mode: hand the built HTML back to the editor's "Preview my site"
+        // WITHOUT persisting anything — no generatedWebsites / websiteContent upsert,
+        // no publish, no touch to the live site. Same assembly + build as a real
+        // save, so what the admin previews is exactly what Save will produce.
+        if (preview) {
+            return NextResponse.json({ success: true, html: generatedHtml })
+        }
 
         // Save to Convex using mutations
         const { fetchMutation } = await import('convex/nextjs')

--- a/app/api/preview/[id]/route.ts
+++ b/app/api/preview/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { fetchQuery } from 'convex/nextjs'
 import { api } from '@/convex/_generated/api'
+import { resolveWebsiteHtml } from '@/lib/website-html'
 
 export async function GET(
     request: NextRequest,
@@ -25,12 +26,13 @@ export async function GET(
             submissionId: submissionId as any
         })
 
-        if (!website || !website.htmlContent) {
+        const html = website ? await resolveWebsiteHtml(website) : ''
+        if (!html) {
             return new NextResponse('Website not found', { status: 404 })
         }
 
         // Return HTML content with security headers
-        return new NextResponse(website.htmlContent, {
+        return new NextResponse(html, {
             headers: {
                 'Content-Type': 'text/html',
                 'X-Content-Type-Options': 'nosniff',

--- a/app/api/publish-website/route.ts
+++ b/app/api/publish-website/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@clerk/nextjs/server'
 import { fetchQuery, fetchMutation } from 'convex/nextjs'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
+import { resolveWebsiteHtml } from '@/lib/website-html'
 
 /**
  * Publish a generated website to Cloudflare Pages
@@ -46,7 +47,8 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: 'Website not found. Generate it first.' }, { status: 404 })
         }
 
-        if (!website.htmlContent) {
+        const htmlToDeploy = await resolveWebsiteHtml(website)
+        if (!htmlToDeploy) {
             return NextResponse.json({ error: 'No HTML content to deploy' }, { status: 400 })
         }
 
@@ -76,7 +78,7 @@ export async function POST(request: NextRequest) {
 
         // Deploy as a Cloudflare Worker (simple PUT request, no Pages Direct Upload hassles)
         const workerName = website.cfPagesProjectName || projectName
-        await deployAsWorker(cfApiToken, cfAccountId, workerName, website.htmlContent)
+        await deployAsWorker(cfApiToken, cfAccountId, workerName, htmlToDeploy)
 
         // Get the workers.dev subdomain for this account
         const workerSubdomain = await getWorkersSubdomain(cfApiToken, cfAccountId)

--- a/app/api/save-content/route.ts
+++ b/app/api/save-content/route.ts
@@ -38,7 +38,12 @@ export async function POST(request: NextRequest) {
             templateName: existingWebsite.templateName || 'default',
             extractedContent: content,
             customizations: customizations || existingWebsite.customizations,
+            // Preserve whatever HTML the row currently has — inline htmlContent
+            // for legacy rows, htmlStorageId for migrated rows — so a legacy site
+            // is NOT left with no HTML during (or after a failed) regenerate. This
+            // upsert is transient; generate-website re-saves the fresh HTML below.
             htmlContent: existingWebsite.htmlContent,
+            htmlStorageId: existingWebsite.htmlStorageId,
             status: existingWebsite.status,
         })
 

--- a/app/preview/[id]/page.tsx
+++ b/app/preview/[id]/page.tsx
@@ -110,7 +110,8 @@ export default function WebsitePreviewPage() {
             {/* Website Content */}
             <div className="pt-14">
                 <iframe
-                    srcDoc={website?.htmlContent || ''}
+                    src={(website as any)?.htmlUrl || undefined}
+                    srcDoc={(website as any)?.htmlUrl ? undefined : (website?.htmlContent || '')}
                     className="w-full h-[calc(100vh-3.5rem)] border-0"
                     title="Website Preview"
                     sandbox="allow-scripts allow-same-origin"

--- a/app/website/[id]/page.tsx
+++ b/app/website/[id]/page.tsx
@@ -16,7 +16,10 @@ export default function WebsitePage() {
 
     const loading = website === undefined
     const error = website === null ? 'Website not found' : null
+    // HTML is either inline (legacy) or in file storage (htmlUrl). Load the URL
+    // directly into the iframe when present; fall back to inline srcDoc.
     const htmlContent = website?.htmlContent || ''
+    const htmlUrl = (website as any)?.htmlUrl as string | null | undefined
 
 
     if (loading) {
@@ -71,7 +74,8 @@ export default function WebsitePage() {
     // Use iframe with srcdoc for proper rendering
     return (
         <iframe
-            srcDoc={htmlContent}
+            src={htmlUrl || undefined}
+            srcDoc={htmlUrl ? undefined : htmlContent}
             style={{
                 width: '100%',
                 height: '100vh',

--- a/components/editor/SandboxEditorV3.tsx
+++ b/components/editor/SandboxEditorV3.tsx
@@ -92,6 +92,11 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
     panelRef.current = panel;
     const [viewport, setViewport] = useState<keyof typeof VIEWPORTS>("desktop");
     const [saving, setSaving] = useState(false);
+    // Real-content preview: `previewBuildHtml` is the built HTML of the UNSAVED
+    // draft in the picked template/theme (from /api/generate-website?preview) —
+    // shown until "Back to saved" or Save. `previewing` gates the ~30–60s build.
+    const [previewing, setPreviewing] = useState(false);
+    const [previewBuildHtml, setPreviewBuildHtml] = useState<string | null>(null);
     const [imagePickerField, setImagePickerField] = useState<string | null>(null);
     const [linkData, setLinkData] = useState<LinkPopoverData | null>(null);
     const [pendingImageField, setPendingImageField] = useState<string | null>(null);
@@ -257,7 +262,7 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
 
     // ── Save (v2:301-331) — batched, single rebuild ───────────────────────
     const handleSave = useCallback(async () => {
-        if (busy) return;
+        if (busy || previewing) return; // don't save while a preview build is in flight
         try { (iframeRef.current?.contentDocument?.activeElement as HTMLElement | null)?.blur?.(); } catch { /* ignore */ }
         const currentDraft = m.draftRef.current;
         if (m.contentDirty === false && m.customizationsDirty === false) return;
@@ -265,7 +270,7 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
         const toastId = toast.loading(m.customizationsDirty ? "Saving changes · regenerating site…" : "Saving content…", { duration: Infinity });
         try {
             await onSaveContent({ ...currentDraft, business_type: m.selectedBucket }, m.customizationsDirty ? m.pendingCustomizations : undefined);
-            m.setPreviewSrc(null);
+            setPreviewBuildHtml(null);
             m.clearCache();
             toast.success("Changes saved", { id: toastId, description: m.customizationsDirty ? "Theme + content applied. Refreshing preview." : "Content updated." });
         } catch (err: any) {
@@ -273,7 +278,42 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
         } finally {
             setSaving(false);
         }
-    }, [busy, m, onSaveContent]);
+    }, [busy, previewing, m, onSaveContent]);
+
+    // ── "Preview my site" — build the UNSAVED draft into real HTML and show it,
+    // persisting nothing. This is the only way to see real content in a picked
+    // template (structural change needs the astro build, ~30–60s). Colour/font/
+    // text/image edits already preview live, so this is mainly for template picks.
+    const handlePreviewBuild = useCallback(async () => {
+        if (busy || previewing) return;
+        try { (iframeRef.current?.contentDocument?.activeElement as HTMLElement | null)?.blur?.(); } catch { /* ignore */ }
+        setPreviewing(true);
+        const toastId = toast.loading("Building a preview with your content… (~30–60s)", { duration: Infinity });
+        try {
+            const res = await fetch("/api/generate-website", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    submissionId,
+                    preview: true,
+                    content: { ...m.draftRef.current, business_type: m.selectedBucket },
+                    customizations: m.pendingCustomizations,
+                }),
+            });
+            if (!res.ok) {
+                const e = await res.json().catch(() => ({}));
+                throw new Error(e?.error || `Preview failed (HTTP ${res.status})`);
+            }
+            const data = await res.json();
+            if (!data?.html) throw new Error("Preview returned no HTML");
+            setPreviewBuildHtml(data.html as string);
+            toast.success("Preview ready", { id: toastId, description: "Your content in the picked template. Save to keep it." });
+        } catch (err: any) {
+            toast.error("Preview failed", { id: toastId, description: err?.message ?? "Please try again." });
+        } finally {
+            setPreviewing(false);
+        }
+    }, [busy, previewing, submissionId, m]);
 
     // ── Keyboard shortcuts: ⌘S save · ⌘Z undo · ⌘⇧Z redo ──────────────────
     useEffect(() => {
@@ -478,8 +518,11 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                 {/* ── Preview + toolbar ─────────────────────────────────── */}
                 <div className="flex min-w-0 flex-1 flex-col">
                     <div className="flex flex-wrap items-center gap-2 border-b border-neutral-200 bg-white px-3 py-2">
-                        <button type="button" onClick={handleSave} disabled={busy} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 px-3.5 py-1.5 text-xs font-bold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-40">
+                        <button type="button" onClick={handleSave} disabled={busy || previewing} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 px-3.5 py-1.5 text-xs font-bold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-40">
                             {saving ? "Saving…" : "Save changes"}
+                        </button>
+                        <button type="button" onClick={handlePreviewBuild} disabled={busy || previewing || !m.dirty} className={TB} title="Build your real content into the current picks (~30–60s) without saving">
+                            {previewing ? "Building…" : "Preview my site"}
                         </button>
                         <button type="button" onClick={m.undo} disabled={!m.canUndo} className={TB} title="Undo (Ctrl/Cmd+Z)">Undo</button>
                         <button type="button" onClick={m.redo} disabled={!m.canRedo} className={TB} title="Redo (Ctrl/Cmd+Shift+Z)">Redo</button>
@@ -488,7 +531,7 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                                 <button key={vp} type="button" onClick={() => setViewport(vp)} className={`px-2.5 py-1.5 text-[11px] font-semibold capitalize transition-colors ${viewport === vp ? "bg-neutral-900 text-white" : "bg-white text-neutral-500 hover:bg-neutral-100"}`}>{vp}</button>
                             ))}
                         </div>
-                        <button type="button" onClick={onRegenerate} disabled={busy} className={TB}>Regenerate</button>
+                        <button type="button" onClick={onRegenerate} disabled={busy || previewing} className={TB}>Regenerate</button>
                         <a href={websitePublishedUrl || `/api/preview/${submissionId}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 px-3 py-1.5 text-xs font-semibold text-neutral-700 hover:border-neutral-300">View site</a>
                         <button type="button" onClick={onEnhanceImages} disabled={enhancing} className={TB}>{enhancing ? "Enhancing…" : "Enhance"}</button>
                         <div className="ml-auto flex flex-wrap items-center gap-2">
@@ -509,25 +552,25 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                     </div>
 
                     <div className="relative flex-1 overflow-auto bg-neutral-100">
-                        {busy && (
+                        {(busy || previewing) && (
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/70 backdrop-blur-sm">
                                 <div className="flex items-center gap-3 text-sm font-medium text-neutral-600">
                                     <span className="h-5 w-5 animate-spin rounded-full border-b-2 border-amber-500" />
-                                    {saving ? "Saving + rebuilding…" : "Rebuilding website…"}
+                                    {saving ? "Saving + rebuilding…" : previewing ? "Building a preview with your content…" : "Rebuilding website…"}
                                 </div>
                             </div>
                         )}
-                        {m.previewSrc && (
+                        {previewBuildHtml && (
                             <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 bg-amber-500/95 px-3 py-1.5 text-[11px] font-semibold text-white">
-                                <span className="truncate">Previewing this template with demo content — click “Save changes” to apply it to your site.</span>
-                                <button type="button" onClick={() => m.setPreviewSrc(null)} className="flex-shrink-0 rounded bg-white/20 px-2 py-0.5 hover:bg-white/30">Back to my site</button>
+                                <span className="truncate">Previewing your unsaved changes (real content) — click “Save changes” to keep them.</span>
+                                <button type="button" onClick={() => setPreviewBuildHtml(null)} className="flex-shrink-0 rounded bg-white/20 px-2 py-0.5 hover:bg-white/30">Back to saved</button>
                             </div>
                         )}
                         <div className="mx-auto h-full bg-white" style={vw ? { width: vw, maxWidth: "100%", boxShadow: "0 0 0 1px rgba(0,0,0,0.06)" } : { width: "100%" }}>
-                            {m.previewSrc ? (
-                                <iframe key="v3-static" ref={iframeRef} src={m.previewSrc} title="Template design preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={applyTheme} />
+                            {previewBuildHtml ? (
+                                <iframe key="v3-preview" ref={iframeRef} srcDoc={injectEditorBridge(previewBuildHtml)} title="Unsaved preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
                             ) : htmlContent ? (
-                                <iframe key="v3-built" ref={iframeRef} srcDoc={previewHtml} title="Website preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
+                                <iframe key="v3-saved" ref={iframeRef} srcDoc={previewHtml} title="Website preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
                             ) : (
                                 <div className="flex h-full items-center justify-center text-sm text-neutral-400">No website generated yet.</div>
                             )}

--- a/components/editor/useEditorDraft.ts
+++ b/components/editor/useEditorDraft.ts
@@ -69,9 +69,6 @@ export function useEditorDraft(props: SandboxEditorProps) {
     const pendingCustRef = useRef<any>(pendingCustomizations);
     pendingCustRef.current = pendingCustomizations;
 
-    // ── Template design-preview swap (demo content) ───────────────────────
-    const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-
     // ── Undo/redo history over {draft, cust} snapshots ────────────────────
     const historyRef = useRef<{ stack: Snapshot[]; index: number }>({
         stack: [{ draft: draftRef.current, cust: pendingCustRef.current }],
@@ -303,11 +300,12 @@ export function useEditorDraft(props: SandboxEditorProps) {
             navbarStyle: letter,
             ...(isBranded ? { colorScheme: "auto", colorSchemeId: "auto", fontPairing: "auto", fontPairingId: "auto" } : {}),
         };
+        // Picking a template only updates the pending customizations (the grid
+        // highlights it). The real WYSIWYG preview happens when the admin clicks
+        // "Preview my site" in the editor, which builds the draft into real HTML —
+        // no placeholder swap here.
         commitState(draftRef.current, next);
-        // Instant demo-content design preview; re-picking the saved template
-        // returns to the real built site.
-        setPreviewSrc(code === savedHero ? null : (tpl?.preview ?? null));
-    }, [commitState, customizations, savedHero]);
+    }, [commitState, customizations]);
 
     // ── Derived (mirror v2:91-99) ─────────────────────────────────────────
     const effectiveCustomizations = pendingCustomizations ?? customizations ?? {};
@@ -332,7 +330,7 @@ export function useEditorDraft(props: SandboxEditorProps) {
 
     return {
         // state
-        draft, draftRef, pendingCustomizations, previewSrc, setPreviewSrc,
+        draft, draftRef, pendingCustomizations,
         // mutators
         setDeepDraft, setValue, replaceDraft, getValue, isBlockEnabled, toggleBlock, setThemeField, onPickTemplate,
         // derived

--- a/convex/drive.ts
+++ b/convex/drive.ts
@@ -397,12 +397,19 @@ export const syncSubmissionToDrive = internalAction({
                 }
             }
 
-            if (website?.htmlContent) {
+            // HTML is inline (legacy) or in file storage (htmlStorageId). Read
+            // the blob directly since this is an action with ctx.storage.
+            const siteHtml: string = website?.htmlContent
+                ? website.htmlContent
+                : ((website as any)?.htmlStorageId
+                    ? ((await (await ctx.storage.get((website as any).htmlStorageId))?.text()) ?? "")
+                    : "");
+            if (siteHtml) {
                 try {
                     await writeTextFile(
                         drive,
                         "index.html",
-                        website.htmlContent,
+                        siteHtml,
                         siteFolder.id,
                     );
                 } catch (e: any) {

--- a/convex/generatedWebsites.ts
+++ b/convex/generatedWebsites.ts
@@ -1,14 +1,22 @@
 import { v } from 'convex/values';
-import { mutation, query, internalQuery } from './_generated/server';
+import { mutation, query, internalQuery, action, internalAction } from './_generated/server';
+import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
 
-// Get generated website by submission ID
+// Get generated website by submission ID.
+// `htmlUrl` resolves the file-storage HTML (when the row uses htmlStorageId
+// instead of inline htmlContent — the built HTML can exceed Convex's 1 MiB
+// document limit). Readers use htmlContent when present, else fetch htmlUrl.
 export const getBySubmissionId = query({
     args: { submissionId: v.id('submissions') },
     handler: async (ctx, args) => {
-        return await ctx.db
+        const doc = await ctx.db
             .query('generatedWebsites')
             .withIndex('by_submissionId', (q) => q.eq('submissionId', args.submissionId))
             .first();
+        if (!doc) return null;
+        const htmlUrl = doc.htmlStorageId ? await ctx.storage.getUrl(doc.htmlStorageId) : null;
+        return { ...doc, htmlUrl };
     },
 });
 
@@ -16,10 +24,37 @@ export const getBySubmissionId = query({
 export const getBySubmissionInternal = internalQuery({
     args: { submissionId: v.id('submissions') },
     handler: async (ctx, args) => {
-        return await ctx.db
+        const doc = await ctx.db
             .query('generatedWebsites')
             .withIndex('by_submissionId', (q) => q.eq('submissionId', args.submissionId))
             .first();
+        if (!doc) return null;
+        const htmlUrl = doc.htmlStorageId ? await ctx.storage.getUrl(doc.htmlStorageId) : null;
+        return { ...doc, htmlUrl };
+    },
+});
+
+// Store built HTML in Convex file storage (the built HTML can exceed the 1 MiB
+// per-document limit, so it can't be inlined on the row). Returns the storageId
+// to save as `htmlStorageId`. STORE-ONLY — it never deletes: the previous blob
+// is GC'd by `upsert` (via the internal `deleteBlob`) AFTER the new reference is
+// committed, so a failed upsert can never strand a row on a deleted blob.
+// SECURITY follow-up: like every generatedWebsites mutation this is a public,
+// ungated action; a later pass should gate the whole table's API (shared secret
+// / internal-only caller) so anonymous callers can't spam orphan blobs.
+export const storeHtml = action({
+    args: { html: v.string() },
+    handler: async (ctx, args): Promise<Id<'_storage'>> => {
+        return await ctx.storage.store(new Blob([args.html], { type: 'text/html' }));
+    },
+});
+
+// Best-effort delete of a superseded HTML blob. Internal (not a public delete
+// vector) and scheduled by `upsert` only once the row points at the new blob.
+export const deleteBlob = internalAction({
+    args: { storageId: v.id('_storage') },
+    handler: async (ctx, args) => {
+        try { await ctx.storage.delete(args.storageId); } catch { /* already gone — ignore */ }
     },
 });
 
@@ -43,6 +78,7 @@ export const upsert = mutation({
             .first();
 
         if (existing) {
+            const oldBlob = existing.htmlStorageId;
             // Update existing
             await ctx.db.patch(existing._id, {
                 templateName: args.templateName,
@@ -53,6 +89,11 @@ export const upsert = mutation({
                 htmlStorageId: args.htmlStorageId,
                 status: args.status || existing.status,
             });
+            // GC the superseded HTML blob AFTER the new reference is committed
+            // (covers both replace → new id and remove → undefined).
+            if (oldBlob && oldBlob !== args.htmlStorageId) {
+                await ctx.scheduler.runAfter(0, internal.generatedWebsites.deleteBlob, { storageId: oldBlob });
+            }
             return existing._id;
         } else {
             // Create new

--- a/lib/website-html.ts
+++ b/lib/website-html.ts
@@ -1,0 +1,26 @@
+/**
+ * resolveWebsiteHtml — get a generatedWebsites row's HTML, from either the
+ * legacy inline `htmlContent` field OR Convex file storage (`htmlUrl`, resolved
+ * by the getBySubmission* queries from `htmlStorageId`).
+ *
+ * The built HTML can exceed Convex's 1 MiB document limit, so new saves store it
+ * as a file and keep only a reference on the row. Existing rows still have inline
+ * `htmlContent` — this helper prefers that, so nothing breaks during the
+ * transition; rows convert to storage on their next save. Server-side only
+ * (does a fetch); Convex functions read the blob directly via ctx.storage.
+ */
+export async function resolveWebsiteHtml(
+    website: { htmlContent?: string | null; htmlUrl?: string | null } | null | undefined,
+): Promise<string> {
+    if (!website) return '';
+    if (website.htmlContent) return website.htmlContent;
+    if (website.htmlUrl) {
+        try {
+            const res = await fetch(website.htmlUrl);
+            return res.ok ? await res.text() : '';
+        } catch {
+            return '';
+        }
+    }
+    return '';
+}


### PR DESCRIPTION
Follow-up to the v3 editor (#278, merged). These two commits were pushed after #278 merged, so they need their own PR. Both build on the merged base v3.

## 1. Real-content "Preview my site" (no placeholder)
Picking a template just highlights it; a **"Preview my site"** button builds the admin's **unsaved draft** into real HTML and shows their content in the picked template — Save to keep, "Back to saved" to discard. Persists nothing.

- `/api/generate-website` gains a `preview` mode: takes the draft `content` from the body, runs the SAME assembly + `buildAstroSite`, returns `{ html }` **before** any upsert (no DB write, no publish, no live-site touch).
- v3: `previewBuildHtml`/`previewing` state, the button, an unsaved-preview banner; Save + Regenerate are gated on `previewing` (can't double-build).
- ~30–60s (it IS the build) — unavoidable for a template switch; colour/font/text/image edits still preview instantly.
- Adversarially verified (persists nothing, no regression); fixed a Save-during-preview concurrency gap the review caught.

## 2. Fix the generatedWebsites 1 MiB save error
`generatedWebsites:upsert` was throwing **"Value is too large (1.02 MiB > 1 MiB)"** on content-heavy sites. The built HTML now moves out of the document into **Convex file storage** (`htmlStorageId`), keeping only a reference on the row.

- **Back-compat:** every reader falls back to inline `htmlContent`, so existing rows are untouched; rows convert to storage on next save.
- `storeHtml` (store-only) action; the superseded blob is GC'd by `upsert` via an internal `deleteBlob` scheduled **after** the new reference commits (safe ordering, no public delete vector).
- `lib/website-html.ts resolveWebsiteHtml` gives readers the inline→storage fallback.
- Readers updated: publish-website, `/api/preview/[id]`, both preview pages (iframe `src=htmlUrl` else `srcDoc`), the admin editor HTML load (stale-fetch guarded), `drive.ts`.
- Adversarially verified (2 reviewers) — caught + fixed a `save-content` data-loss regression, an unsafe delete-before-commit ordering, and a stale-fetch race.

## Deploy / verify
- **Backend deploy required:** the storage fix (`storeHtml`/`deleteBlob` + query changes) needs `npx convex deploy` to take effect. The preview mode is frontend + an existing route, ships on merge.
- `npx tsc --noEmit` clean. **Not runtime-tested locally** — verify on the Vercel preview with a throwaway submission (`localStorage.tendso.editorVersion='v3'`): Preview my site renders your content in a picked template; a content-heavy site saves with no 1 MiB error; publish still works.
- **Follow-up (noted in code):** `storeHtml` and the rest of the `generatedWebsites` API are public/ungated (pre-existing pattern) — a later pass should gate the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)