### PR TITLE
feat(templates): Filipino-market template family — 7 designs (filipino:BB–BH)

### DIFF
--- a/astro-site-template/src/components/filipino/PageBB.astro
+++ b/astro-site-template/src/components/filipino/PageBB.astro
@@ -1,0 +1,202 @@
+---
+/**
+ * filipino / PageBB — "Suki Storefront" (sari-sari corner store).
+ *
+ * Ported from Landing Pages v01 / lp-101-sarisari.html. A warm, polychrome
+ * Filipino barangay-store look: Bricolage Grotesque display over Hanken Grotesk
+ * body with Space Mono labels, on paper-cream, with a deliberately four-colour
+ * accent set — vermilion, turquoise, marigold and grape — one accent per band.
+ *
+ * Design isolation: lp-101's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BB"]` in the global block below so no sister wrapper
+ * inherits BB's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is deliberately POLYCHROME. It reads the override-
+ * aligned neutral tokens (`--paper` / `--ink` / `--disp` / `--sans` / `--mono`)
+ * so an explicit admin scheme/font pick recolours the ground + type, but its
+ * four hand-tuned accent hues (`--vermilion` / `--turq` / `--marigold` /
+ * `--grape`) are fixed identity — a single scheme can't sensibly remap four
+ * accents. `lockVariant: true` keeps the hand-tuned palette on "auto".
+ */
+import HeaderBB from './header/HeaderBB.astro';
+import HeroBB from './hero/HeroBB.astro';
+import TrustBB from './trust/TrustBB.astro';
+import AboutBB from './about/AboutBB.astro';
+import ServicesBB from './services/ServicesBB.astro';
+import WhyBB from './why/WhyBB.astro';
+import HowBB from './how/HowBB.astro';
+import TestimonialsBB from './testimonials/TestimonialsBB.astro';
+import GalleryBB from './gallery/GalleryBB.astro';
+import FaqBB from './faq/FaqBB.astro';
+import AreaBB from './area/AreaBB.astro';
+import CredentialsBB from './credentials/CredentialsBB.astro';
+import LocationBB from './location/LocationBB.astro';
+import CtaBandBB from './ctaBand/CtaBandBB.astro';
+import FooterBB from './footer/FooterBB.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BB">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#e2482e" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-101 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing (unlike AS's system Courier). -->
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,700;12..96,800&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-101 "Suki Storefront" palette + shared base primitives, scoped to
+       html[data-page="BB"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BB"] {
+      /* lp-101 native palette */
+      --paper: #fbf4e6; --paper-2: #fffaf0;
+      --ink: #231a24; --ink-2: #4a3d4a;
+      --vermilion: #e2482e; --turq: #1a9c8e; --marigold: #f0a821; --grape: #7a3b8f;
+      --mid: #8a7d84; --rule: rgba(35,26,36,0.14);
+      --disp: "Bricolage Grotesque", system-ui, sans-serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1280px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own accent tokens. */
+      --accent: #e2482e; --serif: "Bricolage Grotesque", system-ui, sans-serif;
+      --paper-rgb: 251,244,230; --ink-rgb: 35,26,36; --accent-rgb: 226,72,46;
+      --on-accent: #fffaf0; --on-ink: #fbf4e6; --on-paper: #231a24;
+    }
+    html[data-page="BB"] *, html[data-page="BB"] *::before, html[data-page="BB"] *::after { box-sizing: border-box; }
+    html[data-page="BB"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BB"] { scroll-behavior: auto; } }
+    html[data-page="BB"] body {
+      margin: 0; padding: 0; background: var(--paper); color: var(--ink);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BB"] img { max-width: 100%; display: block; }
+    html[data-page="BB"] a { color: inherit; text-decoration: none; }
+    html[data-page="BB"] a:hover { color: var(--vermilion); }
+    html[data-page="BB"] ::selection { background: var(--marigold); color: var(--ink); }
+
+    html[data-page="BB"] .wrap { width: min(var(--maxw), 93vw); margin-inline: auto; }
+    html[data-page="BB"] section { padding: clamp(72px,9vw,124px) 0; position: relative; }
+
+    html[data-page="BB"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--vermilion); font-weight: 700;
+    }
+    html[data-page="BB"] .h2 {
+      font-family: var(--disp); font-weight: 800; font-size: clamp(38px,5.4vw,78px);
+      line-height: 0.98; margin: 0 0 0.3em; letter-spacing: -0.015em; color: var(--ink);
+    }
+    html[data-page="BB"] .h2 em { font-style: normal; color: var(--vermilion); }
+    html[data-page="BB"] .body { color: var(--ink-2); line-height: 1.7; }
+
+    /* Rounded pill buttons — vermilion fill + ink ghost. */
+    html[data-page="BB"] .btn {
+      display: inline-flex; align-items: center; padding: 15px 30px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 999px;
+    }
+    html[data-page="BB"] .btn-primary { background: var(--vermilion); color: var(--paper-2); }
+    html[data-page="BB"] .btn-primary:hover { background: var(--grape); color: var(--paper-2); }
+    html[data-page="BB"] .btn-ghost { border: 2px solid var(--ink); color: var(--ink); }
+    html[data-page="BB"] .btn-ghost:hover { background: var(--ink); color: var(--paper-2); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BB"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mid); border-bottom: 2px solid var(--rule);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,58px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBB boot toggles .in) */
+    html[data-page="BB"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BB"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BB"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BB"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BB"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BB"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BB"] .skip { position: absolute; left: -999px; top: 0; background: var(--vermilion); color: var(--paper-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BB"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BB"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BB"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBB layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBB content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBB content={content} />}
+    {visibility.aboutSection !== false && <AboutBB content={content} />}
+    {visibility.servicesSection !== false && <ServicesBB content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBB content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBB content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBB content={content} />}
+    {visibility.gallerySection !== false && <GalleryBB content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBB content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBB content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBB content={content} />}
+    {visibility.locationBlock !== false && <LocationBB content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBB content={content} layout={layout} />}
+  <FooterBB layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BB Leaflet boot — accepts (lat, lng, label) from LocationBB.
+      window.__filipinoBBInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#e2482e;box-shadow:0 0 0 3px #fffaf0;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBC.astro
+++ b/astro-site-template/src/components/filipino/PageBC.astro
@@ -1,0 +1,203 @@
+---
+/**
+ * filipino / PageBC — "Lutong Bahay" (turo-turo carinderia).
+ *
+ * Ported from Landing Pages v01 / lp-103-carinderia.html. A warm Filipino
+ * neighbourhood-eatery look: Archivo display over Hanken Grotesk body with
+ * Space Mono labels, on coconut-cream, framed in leaf-green, with a
+ * deliberately four-colour accent set — tomato-red, leaf-green, kalamansi-gold
+ * and pandan — one accent per band.
+ *
+ * Design isolation: lp-103's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BC"]` in the global block below so no sister wrapper
+ * inherits BC's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is deliberately POLYCHROME. It reads the override-
+ * aligned neutral tokens (`--paper` / `--ink` / `--disp` / `--sans` / `--mono`)
+ * so an explicit admin scheme/font pick recolours the ground + type, but its
+ * four hand-tuned accent hues (`--tomato` / `--leaf` / `--kalamansi` /
+ * `--pandan`) are fixed identity — a single scheme can't sensibly remap four
+ * accents. `lockVariant: true` keeps the hand-tuned palette on "auto".
+ */
+import HeaderBC from './header/HeaderBC.astro';
+import HeroBC from './hero/HeroBC.astro';
+import TrustBC from './trust/TrustBC.astro';
+import AboutBC from './about/AboutBC.astro';
+import ServicesBC from './services/ServicesBC.astro';
+import WhyBC from './why/WhyBC.astro';
+import HowBC from './how/HowBC.astro';
+import TestimonialsBC from './testimonials/TestimonialsBC.astro';
+import GalleryBC from './gallery/GalleryBC.astro';
+import FaqBC from './faq/FaqBC.astro';
+import AreaBC from './area/AreaBC.astro';
+import CredentialsBC from './credentials/CredentialsBC.astro';
+import LocationBC from './location/LocationBC.astro';
+import CtaBandBC from './ctaBand/CtaBandBC.astro';
+import FooterBC from './footer/FooterBC.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BC">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#d63c2a" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-103 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-103 "Lutong Bahay" palette + shared base primitives, scoped to
+       html[data-page="BC"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BC"] {
+      /* lp-103 native palette */
+      --paper: #faf3e2; --paper-2: #fffaef;
+      --ink: #20291f; --ink-2: #43503f;
+      --tomato: #d63c2a; --leaf: #1f4d2e; --leaf-2: #173d24; --kalamansi: #e0a92b; --pandan: #4f8f4a;
+      --mid: #7f8a79; --rule: rgba(32,41,31,0.14);
+      --disp: "Archivo", system-ui, sans-serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1280px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own accent tokens. */
+      --accent: #d63c2a; --serif: "Archivo", system-ui, sans-serif;
+      --paper-rgb: 250,243,226; --ink-rgb: 32,41,31; --accent-rgb: 214,60,42;
+      --on-accent: #fffaef; --on-ink: #faf3e2; --on-paper: #20291f;
+    }
+    html[data-page="BC"] *, html[data-page="BC"] *::before, html[data-page="BC"] *::after { box-sizing: border-box; }
+    html[data-page="BC"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BC"] { scroll-behavior: auto; } }
+    html[data-page="BC"] body {
+      margin: 0; padding: 0; background: var(--paper); color: var(--ink);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BC"] img { max-width: 100%; display: block; }
+    html[data-page="BC"] a { color: inherit; text-decoration: none; }
+    html[data-page="BC"] a:hover { color: var(--tomato); }
+    html[data-page="BC"] ::selection { background: var(--kalamansi); color: var(--ink); }
+
+    html[data-page="BC"] .wrap { width: min(var(--maxw), 93vw); margin-inline: auto; }
+    html[data-page="BC"] section { padding: clamp(74px,9vw,126px) 0; position: relative; }
+
+    html[data-page="BC"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--tomato); font-weight: 700;
+    }
+    html[data-page="BC"] .h2 {
+      font-family: var(--disp); font-weight: 900; font-size: clamp(38px,5.4vw,80px);
+      line-height: 0.96; margin: 0 0 0.3em; letter-spacing: -0.02em; color: var(--ink);
+    }
+    html[data-page="BC"] .h2 em { font-style: normal; color: var(--tomato); }
+    html[data-page="BC"] .body { color: var(--ink-2); line-height: 1.7; }
+
+    /* Square-cornered stamp buttons — tomato fill + leaf ghost. */
+    html[data-page="BC"] .btn {
+      display: inline-flex; align-items: center; padding: 16px 32px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 2px;
+    }
+    html[data-page="BC"] .btn-primary { background: var(--tomato); color: var(--paper-2); }
+    html[data-page="BC"] .btn-primary:hover { background: var(--leaf); color: var(--paper-2); }
+    html[data-page="BC"] .btn-ghost { border: 2px solid var(--leaf); color: var(--leaf); }
+    html[data-page="BC"] .btn-ghost:hover { background: var(--leaf); color: var(--paper-2); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BC"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mid); border-bottom: 2px solid var(--rule);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,58px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBC boot toggles .in) */
+    html[data-page="BC"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BC"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BC"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BC"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BC"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BC"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BC"] .skip { position: absolute; left: -999px; top: 0; background: var(--tomato); color: var(--paper-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BC"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BC"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BC"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBC layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBC content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBC content={content} />}
+    {visibility.aboutSection !== false && <AboutBC content={content} />}
+    {visibility.servicesSection !== false && <ServicesBC content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBC content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBC content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBC content={content} />}
+    {visibility.gallerySection !== false && <GalleryBC content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBC content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBC content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBC content={content} />}
+    {visibility.locationBlock !== false && <LocationBC content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBC content={content} layout={layout} />}
+  <FooterBC layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BC Leaflet boot — accepts (lat, lng, label) from LocationBC.
+      window.__filipinoBCInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#d63c2a;box-shadow:0 0 0 3px #fffaef;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBD.astro
+++ b/astro-site-template/src/components/filipino/PageBD.astro
@@ -1,0 +1,201 @@
+---
+/**
+ * filipino / PageBD — "Panaderia de San Roque" (neighbourhood bakery).
+ *
+ * Ported from Landing Pages v01 / lp-102-panaderia.html. A warm, dark-crust
+ * Filipino panaderia look: DM Serif Display (italic accents) over Hanken Grotesk
+ * body with Space Mono labels, on a deep-brown crust ground, with pandesal gold
+ * as the signature highlight, brick red for the primary actions, and cream light
+ * bands for the About / Why / Gallery sections.
+ *
+ * Design isolation: lp-102's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BD"]` in the global block below so no sister wrapper
+ * inherits BD's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant reads the override-aligned neutral font tokens
+ * (`--disp` / `--sans` / `--mono`) so an explicit admin font pick recolours the
+ * type, but its hand-tuned bakery hues (`--crust` / `--cream` / `--pandesal` /
+ * `--brick`) are fixed identity. `lockVariant: true` keeps the palette on "auto".
+ */
+import HeaderBD from './header/HeaderBD.astro';
+import HeroBD from './hero/HeroBD.astro';
+import TrustBD from './trust/TrustBD.astro';
+import AboutBD from './about/AboutBD.astro';
+import ServicesBD from './services/ServicesBD.astro';
+import WhyBD from './why/WhyBD.astro';
+import HowBD from './how/HowBD.astro';
+import TestimonialsBD from './testimonials/TestimonialsBD.astro';
+import GalleryBD from './gallery/GalleryBD.astro';
+import FaqBD from './faq/FaqBD.astro';
+import AreaBD from './area/AreaBD.astro';
+import CredentialsBD from './credentials/CredentialsBD.astro';
+import LocationBD from './location/LocationBD.astro';
+import CtaBandBD from './ctaBand/CtaBandBD.astro';
+import FooterBD from './footer/FooterBD.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BD">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#b0472f" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-102 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-102 "Panaderia de San Roque" palette + shared base primitives, scoped
+       to html[data-page="BD"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BD"] {
+      /* lp-102 native palette */
+      --crust: #2a1c12; --crust-2: #35251829;
+      --cream: #f4e7cf; --cream-2: #fbf2df;
+      --pandesal: #d99a4e; --brick: #b0472f; --sage: #7d8b5a;
+      --mid: #8a7355; --mid-d: #c9b48f; --rule-d: rgba(244,231,207,0.16);
+      --disp: "DM Serif Display", Georgia, serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1240px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own bakery tokens. */
+      --accent: #d99a4e; --serif: "DM Serif Display", Georgia, serif;
+      --paper-rgb: 244,231,207; --ink-rgb: 42,28,18; --accent-rgb: 217,154,78;
+      --on-accent: #2a1c12; --on-ink: #f4e7cf; --on-paper: #2a1c12;
+    }
+    html[data-page="BD"] *, html[data-page="BD"] *::before, html[data-page="BD"] *::after { box-sizing: border-box; }
+    html[data-page="BD"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BD"] { scroll-behavior: auto; } }
+    html[data-page="BD"] body {
+      margin: 0; padding: 0; background: var(--crust); color: var(--cream);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BD"] img { max-width: 100%; display: block; }
+    html[data-page="BD"] a { color: inherit; text-decoration: none; }
+    html[data-page="BD"] a:hover { color: var(--pandesal); }
+    html[data-page="BD"] ::selection { background: var(--pandesal); color: var(--crust); }
+
+    html[data-page="BD"] .wrap { width: min(var(--maxw), 92vw); margin-inline: auto; }
+    html[data-page="BD"] section { padding: clamp(76px,9vw,130px) 0; position: relative; }
+
+    html[data-page="BD"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--pandesal); font-weight: 700;
+    }
+    html[data-page="BD"] .h2 {
+      font-family: var(--disp); font-weight: 400; font-size: clamp(40px,5.6vw,82px);
+      line-height: 1.0; margin: 0 0 0.3em; letter-spacing: -0.005em; color: var(--cream);
+    }
+    html[data-page="BD"] .h2 em { font-style: italic; color: var(--pandesal); }
+    html[data-page="BD"] .body { color: var(--mid-d); line-height: 1.7; }
+
+    /* Squared bakery buttons — brick fill + cream ghost on the dark ground. */
+    html[data-page="BD"] .btn {
+      display: inline-flex; align-items: center; padding: 16px 32px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 3px;
+    }
+    html[data-page="BD"] .btn-primary { background: var(--brick); color: var(--cream); }
+    html[data-page="BD"] .btn-primary:hover { background: var(--pandesal); color: var(--crust); }
+    html[data-page="BD"] .btn-ghost { border: 1.5px solid rgba(244,231,207,0.4); color: var(--cream); }
+    html[data-page="BD"] .btn-ghost:hover { background: var(--cream); color: var(--crust); border-color: var(--cream); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BD"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mid-d); border-bottom: 1.5px solid var(--rule-d);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,60px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBD boot toggles .in) */
+    html[data-page="BD"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BD"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BD"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BD"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BD"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BD"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BD"] .skip { position: absolute; left: -999px; top: 0; background: var(--brick); color: var(--cream); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BD"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BD"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BD"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBD layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBD content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBD content={content} />}
+    {visibility.aboutSection !== false && <AboutBD content={content} />}
+    {visibility.servicesSection !== false && <ServicesBD content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBD content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBD content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBD content={content} />}
+    {visibility.gallerySection !== false && <GalleryBD content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBD content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBD content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBD content={content} />}
+    {visibility.locationBlock !== false && <LocationBD content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBD content={content} layout={layout} />}
+  <FooterBD layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BD Leaflet boot — accepts (lat, lng, label) from LocationBD.
+      window.__filipinoBDInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#b0472f;box-shadow:0 0 0 3px #f4e7cf;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBE.astro
+++ b/astro-site-template/src/components/filipino/PageBE.astro
@@ -1,0 +1,207 @@
+---
+/**
+ * filipino / PageBE — "Barako Roastery" (Filipino kapehan / heritage coffee).
+ *
+ * Ported from Landing Pages v01 / lp-111-barako.html. A warm, roasted-earth
+ * Batangas coffee look: Zilla Slab slab-serif display over Hanken Grotesk body
+ * with Space Mono labels, on oat-cream, with dark "bean" bands and a barako-
+ * vermilion + gold + leaf accent set — one accent tone per band.
+ *
+ * Design isolation: lp-111's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BE"]` in the global block below so no sister wrapper
+ * inherits BE's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is deliberately WARM & POLYCHROME. It reads the
+ * override-aligned neutral tokens (`--paper` / `--ink` / `--disp` / `--sans` /
+ * `--mono`) so an explicit admin scheme/font pick recolours the ground + type,
+ * but its hand-tuned accent hues (`--barako` / `--gold` / `--leaf` / `--bean`)
+ * are fixed identity — a single scheme can't sensibly remap them.
+ * `lockVariant: true` keeps the hand-tuned palette on "auto".
+ */
+import HeaderBE from './header/HeaderBE.astro';
+import HeroBE from './hero/HeroBE.astro';
+import TrustBE from './trust/TrustBE.astro';
+import AboutBE from './about/AboutBE.astro';
+import ServicesBE from './services/ServicesBE.astro';
+import WhyBE from './why/WhyBE.astro';
+import HowBE from './how/HowBE.astro';
+import TestimonialsBE from './testimonials/TestimonialsBE.astro';
+import GalleryBE from './gallery/GalleryBE.astro';
+import FaqBE from './faq/FaqBE.astro';
+import AreaBE from './area/AreaBE.astro';
+import CredentialsBE from './credentials/CredentialsBE.astro';
+import LocationBE from './location/LocationBE.astro';
+import CtaBandBE from './ctaBand/CtaBandBE.astro';
+import FooterBE from './footer/FooterBE.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BE">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#b5471f" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-111 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=Zilla+Slab:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-111 "Barako Roastery" palette + shared base primitives, scoped to
+       html[data-page="BE"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BE"] {
+      /* lp-111 native palette */
+      --bean: #241812; --bean-2: #1a110c;
+      --oat: #efe4d0; --oat-2: #f7efdf;
+      --ink: #2c2119; --ink-2: #52443a;
+      --barako: #b5471f; --gold: #cf9137; --leaf: #5f7a44;
+      --mid: #8a7963; --mid-d: #c9b393;
+      --rule: rgba(44,33,25,0.14); --rule-d: rgba(239,228,208,0.16);
+      --disp: "Zilla Slab", Georgia, serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1240px;
+      /* Override-aligned ground aliases so an explicit admin scheme recolours
+         the paper + default text (mapped to lp-111's oat tones). */
+      --paper: #efe4d0; --paper-2: #f7efdf;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own accent tokens. */
+      --accent: #b5471f; --serif: "Zilla Slab", Georgia, serif;
+      --paper-rgb: 239,228,208; --ink-rgb: 44,33,25; --accent-rgb: 181,71,31;
+      --on-accent: #f7efdf; --on-ink: #efe4d0; --on-paper: #2c2119;
+    }
+    html[data-page="BE"] *, html[data-page="BE"] *::before, html[data-page="BE"] *::after { box-sizing: border-box; }
+    html[data-page="BE"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BE"] { scroll-behavior: auto; } }
+    html[data-page="BE"] body {
+      margin: 0; padding: 0; background: var(--paper); color: var(--ink);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BE"] img { max-width: 100%; display: block; }
+    html[data-page="BE"] a { color: inherit; text-decoration: none; }
+    html[data-page="BE"] a:hover { color: var(--barako); }
+    html[data-page="BE"] ::selection { background: var(--gold); color: var(--bean); }
+
+    html[data-page="BE"] .wrap { width: min(var(--maxw), 92vw); margin-inline: auto; }
+    html[data-page="BE"] section { padding: clamp(76px,9vw,130px) 0; position: relative; }
+
+    html[data-page="BE"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--barako); font-weight: 700;
+    }
+    html[data-page="BE"] .h2 {
+      font-family: var(--disp); font-weight: 700; font-size: clamp(38px,5.4vw,78px);
+      line-height: 1.04; margin: 0 0 0.32em; letter-spacing: -0.01em; color: var(--ink);
+    }
+    html[data-page="BE"] .h2 em { font-style: normal; color: var(--barako); }
+    html[data-page="BE"] .body { color: var(--mid); line-height: 1.7; }
+
+    /* Slab-cut buttons — barako fill + bean ghost. */
+    html[data-page="BE"] .btn {
+      display: inline-flex; align-items: center; padding: 16px 32px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 3px;
+    }
+    html[data-page="BE"] .btn-primary { background: var(--barako); color: var(--oat-2); }
+    html[data-page="BE"] .btn-primary:hover { background: var(--bean); color: var(--oat-2); }
+    html[data-page="BE"] .btn-ghost { border: 1.5px solid var(--bean); color: var(--bean); }
+    html[data-page="BE"] .btn-ghost:hover { background: var(--bean); color: var(--oat-2); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BE"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--mid); border-bottom: 1.5px solid var(--rule);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,60px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBE boot toggles .in) */
+    html[data-page="BE"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BE"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BE"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BE"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BE"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BE"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BE"] .skip { position: absolute; left: -999px; top: 0; background: var(--barako); color: var(--oat-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BE"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BE"] section { padding: clamp(52px,11vw,76px) 0; }
+      html[data-page="BE"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBE layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBE content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBE content={content} />}
+    {visibility.aboutSection !== false && <AboutBE content={content} />}
+    {visibility.servicesSection !== false && <ServicesBE content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBE content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBE content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBE content={content} />}
+    {visibility.gallerySection !== false && <GalleryBE content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBE content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBE content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBE content={content} />}
+    {visibility.locationBlock !== false && <LocationBE content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBE content={content} layout={layout} />}
+  <FooterBE layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BE Leaflet boot — accepts (lat, lng, label) from LocationBE.
+      window.__filipinoBEInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#b5471f;box-shadow:0 0 0 3px #f7efdf;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBF.astro
+++ b/astro-site-template/src/components/filipino/PageBF.astro
@@ -1,0 +1,205 @@
+---
+/**
+ * filipino / PageBF — "Kanto Grill" (roadside lechon-manok rotisserie).
+ *
+ * Ported from Landing Pages v01 / lp-117-lechonmanok.html. A dark, warm
+ * charcoal grill look: Archivo display over Hanken Grotesk body with Space
+ * Mono labels, on near-black charcoal, lit by two fire hues — a marigold-gold
+ * "skin" and a rust "glaze" — with cream bone type and a live-coals band.
+ *
+ * Design isolation: lp-117's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BF"]` in the global block below so no sister wrapper
+ * inherits BF's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is a fixed DARK art-direction; its dark ground + bands
+ * are keyed to native tokens (`--char` / `--bone` / `--skin` / `--glaze`) the
+ * scheme override cannot fully remap. An explicit admin FONT pick works; an
+ * explicit COLOR-scheme pick is imperfect on a dark design (KNOWN LIMITATION —
+ * the intended experience is the hand-tuned palette, which `lockVariant: true`
+ * keeps on "auto"; the proper fix rekeys the ground onto themeable
+ * --paper/--ink, cf. autoshop/PageAP).
+ */
+import HeaderBF from './header/HeaderBF.astro';
+import HeroBF from './hero/HeroBF.astro';
+import TrustBF from './trust/TrustBF.astro';
+import AboutBF from './about/AboutBF.astro';
+import ServicesBF from './services/ServicesBF.astro';
+import WhyBF from './why/WhyBF.astro';
+import HowBF from './how/HowBF.astro';
+import TestimonialsBF from './testimonials/TestimonialsBF.astro';
+import GalleryBF from './gallery/GalleryBF.astro';
+import FaqBF from './faq/FaqBF.astro';
+import AreaBF from './area/AreaBF.astro';
+import CredentialsBF from './credentials/CredentialsBF.astro';
+import LocationBF from './location/LocationBF.astro';
+import CtaBandBF from './ctaBand/CtaBandBF.astro';
+import FooterBF from './footer/FooterBF.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BF">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#c2451f" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-117 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-117 "Kanto Grill" palette + shared base primitives, scoped to
+       html[data-page="BF"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BF"] {
+      /* lp-117 native palette */
+      --char: #171310; --char-2: #0f0c0a;
+      --bone: #f6efe3; --bone-2: #fdf8ef;
+      --ink: #231c16; --ink-2: #4b3f34;
+      --skin: #d9902f; --glaze: #c2451f; --calamansi: #8fa63c;
+      --mid: #8b7c6a; --mid-d: #c7b49a; --rule-d: rgba(246,239,227,0.15);
+      --disp: "Archivo", system-ui, sans-serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1280px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own fire tokens. Modelled on
+         the dark ground: paper = charcoal, ink = bone, accent = glaze. */
+      --accent: #c2451f; --serif: "Archivo", system-ui, sans-serif;
+      --paper-rgb: 23,19,16; --ink-rgb: 246,239,227; --accent-rgb: 194,69,31;
+      --on-accent: #fdf8ef; --on-ink: #171310; --on-paper: #f6efe3;
+    }
+    html[data-page="BF"] *, html[data-page="BF"] *::before, html[data-page="BF"] *::after { box-sizing: border-box; }
+    html[data-page="BF"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BF"] { scroll-behavior: auto; } }
+    html[data-page="BF"] body {
+      margin: 0; padding: 0; background: var(--char); color: var(--bone);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BF"] img { max-width: 100%; display: block; }
+    html[data-page="BF"] a { color: inherit; text-decoration: none; }
+    html[data-page="BF"] a:hover { color: var(--skin); }
+    html[data-page="BF"] ::selection { background: var(--skin); color: var(--char); }
+
+    html[data-page="BF"] .wrap { width: min(var(--maxw), 93vw); margin-inline: auto; }
+    html[data-page="BF"] section { padding: clamp(74px,9vw,126px) 0; position: relative; }
+
+    html[data-page="BF"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--skin); font-weight: 700;
+    }
+    html[data-page="BF"] .h2 {
+      font-family: var(--disp); font-weight: 900; font-size: clamp(38px,5.4vw,80px);
+      line-height: 0.98; margin: 0 0 0.3em; letter-spacing: -0.025em; color: var(--bone);
+    }
+    html[data-page="BF"] .h2 em { font-style: normal; color: var(--glaze); }
+    html[data-page="BF"] .body { color: var(--mid-d); line-height: 1.7; }
+
+    /* Squared fire buttons — glaze fill + bone ghost. */
+    html[data-page="BF"] .btn {
+      display: inline-flex; align-items: center; padding: 16px 32px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 2px;
+    }
+    html[data-page="BF"] .btn-primary { background: var(--glaze); color: var(--bone-2); }
+    html[data-page="BF"] .btn-primary:hover { background: var(--skin); color: var(--char); }
+    html[data-page="BF"] .btn-ghost { border: 1.5px solid rgba(246,239,227,0.4); color: var(--bone); }
+    html[data-page="BF"] .btn-ghost:hover { background: var(--bone); color: var(--char); border-color: var(--bone); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BF"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--mid-d); border-bottom: 1.5px solid var(--rule-d);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,58px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBF boot toggles .in) */
+    html[data-page="BF"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BF"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BF"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BF"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BF"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BF"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BF"] .skip { position: absolute; left: -999px; top: 0; background: var(--glaze); color: var(--bone-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BF"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BF"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BF"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBF layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBF content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBF content={content} />}
+    {visibility.aboutSection !== false && <AboutBF content={content} />}
+    {visibility.servicesSection !== false && <ServicesBF content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBF content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBF content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBF content={content} />}
+    {visibility.gallerySection !== false && <GalleryBF content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBF content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBF content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBF content={content} />}
+    {visibility.locationBlock !== false && <LocationBF content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBF content={content} layout={layout} />}
+  <FooterBF layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BF Leaflet boot — accepts (lat, lng, label) from LocationBF.
+      window.__filipinoBFInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/dark_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#c2451f;box-shadow:0 0 0 3px #171310;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBG.astro
+++ b/astro-site-template/src/components/filipino/PageBG.astro
@@ -1,0 +1,207 @@
+---
+/**
+ * filipino / PageBG — "Roadside Vulcanizing" (24-hour tire-repair / vulcanizing shop).
+ *
+ * Ported from Landing Pages v01 / lp-115-vulcanizing.html. A dark, industrial
+ * Filipino roadside look: heavy Archivo display over Hanken Grotesk body with
+ * Space Mono labels, on asphalt-black, with a two-signal accent set — hazard
+ * yellow (the "light that's always on") for labels/emphasis and alert red for
+ * action bands (services live on dark, about/why/gallery drop to a steel "bay"
+ * of daylight).
+ *
+ * Design isolation: lp-115's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BG"]` in the global block below so no sister wrapper
+ * inherits BG's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is a fixed DARK industrial art-direction; its dark
+ * ground + bands are keyed to native tokens (`--asphalt` / `--steel`) the scheme
+ * override cannot fully remap, so an explicit admin COLOR-scheme pick is
+ * imperfect on this design (KNOWN LIMITATION — the intended experience is the
+ * hand-tuned palette, which `lockVariant: true` keeps on "auto"; the proper fix
+ * rekeys the ground onto themeable --paper/--ink, cf. autoshop/PageAP). Font
+ * picks work. The "hazard + alert" signal hues are fixed identity.
+ */
+import HeaderBG from './header/HeaderBG.astro';
+import HeroBG from './hero/HeroBG.astro';
+import TrustBG from './trust/TrustBG.astro';
+import AboutBG from './about/AboutBG.astro';
+import ServicesBG from './services/ServicesBG.astro';
+import WhyBG from './why/WhyBG.astro';
+import HowBG from './how/HowBG.astro';
+import TestimonialsBG from './testimonials/TestimonialsBG.astro';
+import GalleryBG from './gallery/GalleryBG.astro';
+import FaqBG from './faq/FaqBG.astro';
+import AreaBG from './area/AreaBG.astro';
+import CredentialsBG from './credentials/CredentialsBG.astro';
+import LocationBG from './location/LocationBG.astro';
+import CtaBandBG from './ctaBand/CtaBandBG.astro';
+import FooterBG from './footer/FooterBG.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BG">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#191b1e" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-115 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-115 "Roadside Vulcanizing" palette + shared base primitives, scoped to
+       html[data-page="BG"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BG"] {
+      /* lp-115 native palette */
+      --asphalt: #191b1e; --asphalt-2: #0f1113;
+      --steel: #eceff2; --steel-2: #f6f8fa;
+      --ink: #1e2226; --ink-2: #454b52;
+      --hazard: #f5c518; --alert: #e23b2e; --go: #2f9e57;
+      --mid: #83898f; --mid-d: #b5bcc3; --rule-d: rgba(236,239,242,0.15);
+      --disp: "Archivo", system-ui, sans-serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1280px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own hazard/alert tokens.
+         "paper" = the steel daylight band, "ink" = the dark band type. */
+      --accent: #e23b2e; --serif: "Archivo", system-ui, sans-serif;
+      --paper-rgb: 236,239,242; --ink-rgb: 30,34,38; --accent-rgb: 226,59,46;
+      --on-accent: #f6f8fa; --on-ink: #f6f8fa; --on-paper: #1e2226;
+    }
+    html[data-page="BG"] *, html[data-page="BG"] *::before, html[data-page="BG"] *::after { box-sizing: border-box; }
+    html[data-page="BG"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BG"] { scroll-behavior: auto; } }
+    html[data-page="BG"] body {
+      margin: 0; padding: 0; background: var(--asphalt); color: var(--steel);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BG"] img { max-width: 100%; display: block; }
+    html[data-page="BG"] a { color: inherit; text-decoration: none; }
+    html[data-page="BG"] a:hover { color: var(--hazard); }
+    html[data-page="BG"] ::selection { background: var(--hazard); color: var(--asphalt); }
+
+    html[data-page="BG"] .wrap { width: min(var(--maxw), 93vw); margin-inline: auto; }
+    html[data-page="BG"] section { padding: clamp(74px,9vw,126px) 0; position: relative; }
+
+    html[data-page="BG"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--hazard); font-weight: 700;
+    }
+    html[data-page="BG"] .h2 {
+      font-family: var(--disp); font-weight: 900; font-size: clamp(38px,5.4vw,80px);
+      line-height: 0.98; margin: 0 0 0.3em; letter-spacing: -0.02em; color: var(--steel);
+    }
+    html[data-page="BG"] .h2 em { font-style: normal; color: var(--hazard); }
+    html[data-page="BG"] .body { color: var(--mid-d); line-height: 1.7; }
+
+    /* Sharp industrial buttons — alert-red fill + steel ghost. */
+    html[data-page="BG"] .btn {
+      display: inline-flex; align-items: center; padding: 16px 32px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 2px;
+    }
+    html[data-page="BG"] .btn-primary { background: var(--alert); color: var(--steel-2); }
+    html[data-page="BG"] .btn-primary:hover { background: var(--hazard); color: var(--asphalt); }
+    html[data-page="BG"] .btn-ghost { border: 1.5px solid rgba(236,239,242,0.4); color: var(--steel); }
+    html[data-page="BG"] .btn-ghost:hover { background: var(--steel); color: var(--asphalt); border-color: var(--steel); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BG"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--mid-d); border-bottom: 1.5px solid var(--rule-d);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,58px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBG boot toggles .in) */
+    html[data-page="BG"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BG"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BG"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BG"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BG"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BG"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BG"] .skip { position: absolute; left: -999px; top: 0; background: var(--alert); color: var(--steel-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 4px 0; }
+    html[data-page="BG"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BG"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BG"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBG layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBG content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBG content={content} />}
+    {visibility.aboutSection !== false && <AboutBG content={content} />}
+    {visibility.servicesSection !== false && <ServicesBG content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBG content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBG content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBG content={content} />}
+    {visibility.gallerySection !== false && <GalleryBG content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBG content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBG content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBG content={content} />}
+    {visibility.locationBlock !== false && <LocationBG content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBG content={content} layout={layout} />}
+  <FooterBG layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BG Leaflet boot — accepts (lat, lng, label) from LocationBG.
+      window.__filipinoBGInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/dark_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#e23b2e;box-shadow:0 0 0 3px #f6f8fa;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/PageBH.astro
+++ b/astro-site-template/src/components/filipino/PageBH.astro
@@ -1,0 +1,203 @@
+---
+/**
+ * filipino / PageBH — "Halo Haus" (halo-halo shaved-ice dessert stall).
+ *
+ * Ported from Landing Pages v01 / lp-104-halohalo.html. A cold, sweet, purple
+ * Filipino dessert-haus look: Unbounded display over Hanken Grotesk body with
+ * Space Mono labels, on milk-pink paper, with a layered accent set — ube grape,
+ * a deeper ube, leche marigold, mango and rosa — one accent per band, sections
+ * numbered as "Layers" the way a halo-halo glass is built.
+ *
+ * Design isolation: lp-104's palette tokens + shared base primitives are scoped
+ * to `html[data-page="BH"]` in the global block below so no sister wrapper
+ * inherits BH's tokens or its base classes (`.wrap` / `.kick` / `.h2` / `.btn`
+ * / `.sw-head`), and vice-versa. Per-section classes live in each section
+ * component's own (Astro-scoped) <style>.
+ *
+ * Theming: this variant is deliberately POLYCHROME. It reads the override-
+ * aligned neutral tokens (`--paper` / `--ink` / `--disp` / `--sans` / `--mono`)
+ * so an explicit admin scheme/font pick recolours the ground + type, but its
+ * hand-tuned accent hues (`--ube` / `--ube-2` / `--leche` / `--mango` /
+ * `--rosa`) are fixed identity — a single scheme can't sensibly remap five
+ * accents. `lockVariant: true` keeps the hand-tuned palette on "auto".
+ */
+import HeaderBH from './header/HeaderBH.astro';
+import HeroBH from './hero/HeroBH.astro';
+import TrustBH from './trust/TrustBH.astro';
+import AboutBH from './about/AboutBH.astro';
+import ServicesBH from './services/ServicesBH.astro';
+import WhyBH from './why/WhyBH.astro';
+import HowBH from './how/HowBH.astro';
+import TestimonialsBH from './testimonials/TestimonialsBH.astro';
+import GalleryBH from './gallery/GalleryBH.astro';
+import FaqBH from './faq/FaqBH.astro';
+import AreaBH from './area/AreaBH.astro';
+import CredentialsBH from './credentials/CredentialsBH.astro';
+import LocationBH from './location/LocationBH.astro';
+import CtaBandBH from './ctaBand/CtaBandBH.astro';
+import FooterBH from './footer/FooterBH.astro';
+import { resolveTheme, buildFontHref, buildOverrideCss } from '../../lib/genericThemeOverrides';
+
+interface Props { siteData: any; }
+const { siteData } = Astro.props;
+const layout = siteData.layout ?? {};
+const content = siteData.content ?? {};
+const visibility = siteData.visibility ?? {};
+const title = layout.businessName
+  ? `${layout.businessName}${layout.tagline ? ' — ' + layout.tagline : ''}`
+  : 'Welcome';
+const { scheme: __themeScheme, pairing: __themePairing } = resolveTheme(layout, (content as any).business_type, { lockVariant: true });
+const __overrideCss = buildOverrideCss(__themeScheme, __themePairing);
+const __fontHref = buildFontHref(__themePairing);
+---
+
+<!DOCTYPE html>
+<html lang="en" data-page="BH">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  {content.description && <meta name="description" content={content.description} />}
+  <meta name="theme-color" content="#5b2a86" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <!-- lp-104 native fonts. Always loaded so the variant reads as designed even
+       when the admin hasn't picked a font pairing. -->
+  <link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@500;700;800&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  {layout.favicon && <link rel="icon" href={layout.favicon} />}
+  {(layout.ogImage || layout.favicon) && <meta property="og:image" content={layout.ogImage || layout.favicon} />}
+
+  <!-- lp-104 "Halo Haus" palette + shared base primitives, scoped to
+       html[data-page="BH"] so they never leak to sister variants. -->
+  <style is:global>
+    html[data-page="BH"] {
+      /* lp-104 native palette */
+      --paper: #fbf1f5; --paper-2: #fff8fb;
+      --ink: #2c1c33; --ink-2: #584663;
+      --ube: #5b2a86; --ube-2: #43206a; --leche: #e8b23e; --mango: #f28b3c; --rosa: #e5568f;
+      --mid: #96849c; --rule: rgba(44,28,51,0.12);
+      --disp: "Unbounded", system-ui, sans-serif;
+      --sans: "Hanken Grotesk", system-ui, sans-serif;
+      --mono: "Space Mono", ui-monospace, monospace;
+      --maxw: 1240px;
+      /* Generic aliases so the theme-override machinery + WCAG contrast stay
+         legible even though the design reads its own accent tokens. */
+      --accent: #5b2a86; --serif: "Unbounded", system-ui, sans-serif;
+      --paper-rgb: 251,241,245; --ink-rgb: 44,28,51; --accent-rgb: 91,42,134;
+      --on-accent: #fff8fb; --on-ink: #fbf1f5; --on-paper: #2c1c33;
+    }
+    html[data-page="BH"] *, html[data-page="BH"] *::before, html[data-page="BH"] *::after { box-sizing: border-box; }
+    html[data-page="BH"] { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BH"] { scroll-behavior: auto; } }
+    html[data-page="BH"] body {
+      margin: 0; padding: 0; background: var(--paper); color: var(--ink);
+      font-family: var(--sans); font-size: 16.5px; line-height: 1.6;
+      -webkit-font-smoothing: antialiased; overflow-x: hidden;
+    }
+    html[data-page="BH"] img { max-width: 100%; display: block; }
+    html[data-page="BH"] a { color: inherit; text-decoration: none; }
+    html[data-page="BH"] a:hover { color: var(--rosa); }
+    html[data-page="BH"] ::selection { background: var(--leche); color: var(--ink); }
+
+    html[data-page="BH"] .wrap { width: min(var(--maxw), 92vw); margin-inline: auto; }
+    html[data-page="BH"] section { padding: clamp(74px,9vw,126px) 0; position: relative; }
+
+    html[data-page="BH"] .kick {
+      font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--rosa); font-weight: 700;
+    }
+    html[data-page="BH"] .h2 {
+      font-family: var(--disp); font-weight: 800; font-size: clamp(34px,4.8vw,68px);
+      line-height: 1.04; margin: 0 0 0.34em; letter-spacing: -0.02em; color: var(--ink);
+    }
+    html[data-page="BH"] .h2 em { font-style: normal; color: var(--rosa); }
+    html[data-page="BH"] .body { color: var(--ink-2); line-height: 1.7; }
+
+    /* Rounded pill buttons — ube fill + ube ghost, rosa on hover. */
+    html[data-page="BH"] .btn {
+      display: inline-flex; align-items: center; padding: 15px 30px;
+      font-family: var(--mono); font-weight: 700; font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; text-decoration: none; transition: 0.16s; border-radius: 999px;
+    }
+    html[data-page="BH"] .btn-primary { background: var(--ube); color: var(--paper-2); }
+    html[data-page="BH"] .btn-primary:hover { background: var(--rosa); color: var(--paper-2); }
+    html[data-page="BH"] .btn-ghost { border: 2px solid var(--ube); color: var(--ube); }
+    html[data-page="BH"] .btn-ghost:hover { background: var(--ube); color: var(--paper-2); }
+
+    /* Section header rule — mono label / meta split with a bottom border. */
+    html[data-page="BH"] .sw-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.14em;
+      text-transform: uppercase; color: var(--mid); border-bottom: 2px solid var(--rule);
+      padding-bottom: 12px; margin-bottom: clamp(34px,4.5vw,58px); font-weight: 700; gap: 16px; flex-wrap: wrap;
+    }
+
+    /* scroll reveal (class-based; PageBH boot toggles .in) */
+    html[data-page="BH"] .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+    html[data-page="BH"] .reveal.in { opacity: 1; transform: none; }
+    html[data-page="BH"] .reveal[data-delay="1"] { transition-delay: .08s; }
+    html[data-page="BH"] .reveal[data-delay="2"] { transition-delay: .16s; }
+    html[data-page="BH"] .reveal[data-delay="3"] { transition-delay: .24s; }
+    @media (prefers-reduced-motion: reduce) { html[data-page="BH"] .reveal { opacity: 1 !important; transform: none !important; transition: none !important; } }
+
+    /* skip link */
+    html[data-page="BH"] .skip { position: absolute; left: -999px; top: 0; background: var(--ube); color: var(--paper-2); padding: 12px 18px; z-index: 100; border-radius: 0 0 8px 0; }
+    html[data-page="BH"] .skip:focus { left: 0; top: 0; }
+
+    /* Mobile rhythm — tighter gutters + section padding on phones. */
+    @media (max-width: 760px) {
+      html[data-page="BH"] section { padding: clamp(52px,11vw,72px) 0; }
+      html[data-page="BH"] .h2 { font-size: clamp(30px,7.6vw,46px); overflow-wrap: anywhere; }
+    }
+  </style>
+
+  {__fontHref && <link href={__fontHref} rel="stylesheet" />}
+  <style is:global set:html={__overrideCss}></style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <HeaderBH layout={layout} content={content} />
+  <main id="main">
+    {visibility.heroSection !== false && <HeroBH content={content} layout={layout} />}
+    {visibility.trustBlock !== false && <TrustBH content={content} />}
+    {visibility.aboutSection !== false && <AboutBH content={content} />}
+    {visibility.servicesSection !== false && <ServicesBH content={content} />}
+    {visibility.whyUsBlock !== false && <WhyBH content={content} />}
+    {visibility.howItWorksBlock !== false && <HowBH content={content} />}
+    {visibility.testimonialsBlock !== false && <TestimonialsBH content={content} />}
+    {visibility.gallerySection !== false && <GalleryBH content={content} layout={layout} />}
+    {visibility.faqBlock !== false && <FaqBH content={content} />}
+    {visibility.serviceAreaBlock !== false && <AreaBH content={content} />}
+    {visibility.credentialsBlock !== false && <CredentialsBH content={content} />}
+    {visibility.locationBlock !== false && <LocationBH content={content} layout={layout} />}
+  </main>
+  {visibility.ctaBandBlock !== false && <CtaBandBH content={content} layout={layout} />}
+  <FooterBH layout={layout} content={content} />
+
+  <script is:inline src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script is:inline>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (!reduce && !document.hidden) {
+        var io = new IntersectionObserver(function (es) {
+          es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+      } else {
+        document.querySelectorAll('.reveal').forEach(function (el) { el.classList.add('in'); });
+      }
+      // Filipino-BH Leaflet boot — accepts (lat, lng, label) from LocationBH.
+      window.__filipinoBHInitMap = function (lat, lng, label) {
+        if (!window.L) return;
+        var el = document.getElementById('map'); if (!el) return;
+        el.innerHTML = '';
+        var map = L.map('map', { scrollWheelZoom: false }).setView([lat, lng], 15);
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}{r}.png', { attribution: '&copy; OpenStreetMap &copy; CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+        var icon = L.divIcon({ className: '', html: '<div style="width:16px;height:16px;border-radius:50%;background:#5b2a86;box-shadow:0 0 0 3px #fff8fb;border:0;"></div>', iconSize: [16, 16], iconAnchor: [8, 8] });
+        L.marker([lat, lng], { icon: icon }).addTo(map).bindPopup('<b>' + label + '</b>');
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/astro-site-template/src/components/filipino/about/AboutBB.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBB.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / AboutBB — lp-101's "the store" split on the light band: prose left
+ * (headline + paragraphs), an art-directed portrait right. The photo keeps a warm
+ * gradient fallback until about.image is set; about.quote / about.signature are
+ * optional extras that stay hidden when unset. Mirrors AboutAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Aisle 01 / The store</span><span>A window in the house</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Store photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--paper-2); color: var(--ink); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.76; margin: 0 0 1em; color: var(--ink-2); }
+  .about-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--grape); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--vermilion); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 14px; border: 3px solid var(--ink); background-color: var(--paper); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(122,59,143,.4), rgba(226,72,46,.3)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBC.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBC.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / AboutBC — lp-103's "the carinderia" split on the light band: prose
+ * left (headline + paragraphs), an art-directed portrait right. The photo keeps a
+ * warm gradient fallback until about.image is set; about.quote / about.signature
+ * are optional extras that stay hidden when unset. Mirrors AboutAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Tray 01 / The carinderia</span><span>No menu, just what Nanay cooked</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Carinderia photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--paper-2); color: var(--ink); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.76; margin: 0 0 1em; color: var(--ink-2); }
+  .about-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--leaf); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--tomato); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 10px; border: 3px solid var(--leaf); background-color: var(--paper); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(31,77,46,.4), rgba(214,60,42,.3)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBD.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBD.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * filipino / AboutBD — lp-102's "the bakery" split on the cream band: prose left
+ * (headline + paragraphs), an art-directed portrait right. The photo keeps a warm
+ * gradient fallback until about.image is set; about.quote / about.signature are
+ * optional extras that stay hidden when unset. Mirrors AboutAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Batch 01 / The bakery</span><span>Three generations, one oven</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Bakery photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--cream); color: var(--crust); }
+  .about .sw-head { color: var(--mid); border-color: rgba(42,28,18,0.16); }
+  .about .h2 { color: var(--crust); }
+  .about .h2 :global(em) { color: var(--brick); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.78; margin: 0 0 1em; color: #4d3826; }
+  .about-quote { font-family: var(--disp); font-weight: 400; font-style: italic; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--brick); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--pandesal); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 4px; background-color: var(--cream-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(176,71,47,.35), rgba(217,154,78,.4)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBE.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBE.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * filipino / AboutBE — lp-111's "the roastery" split on the light oat-2 band:
+ * prose left (headline + paragraphs), an art-directed portrait right. The photo
+ * keeps a warm roasted-earth gradient fallback until about.image is set;
+ * about.quote / about.signature are optional extras that stay hidden when unset.
+ * Mirrors AboutAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Roast 01 / The roastery</span><span>Slopes of Mt. Malarayat</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Roastery photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--oat-2); color: var(--ink); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.78; margin: 0 0 1em; color: #4d3d31; }
+  .about-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--barako); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--gold); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 4px; background-color: var(--oat); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(207,145,55,.42), rgba(181,71,31,.4)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBF.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBF.astro
@@ -1,0 +1,49 @@
+---
+/**
+ * filipino / AboutBF — lp-117's "the grill" split on the light bone band: prose
+ * left (headline + paragraphs), an art-directed portrait right. The photo keeps
+ * a warm ember gradient fallback until about.image is set; about.quote /
+ * about.signature are optional extras that stay hidden when unset. Mirrors
+ * AboutBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Spit 01 / The grill</span><span>On the Maharlika highway</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Grill photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--bone); color: var(--ink); }
+  .about .sw-head { color: var(--mid); border-color: rgba(35,28,22,0.16); }
+  .about .h2 { color: var(--ink); }
+  .about .h2 :global(em) { color: var(--glaze); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.76; margin: 0 0 1em; color: #463a2e; }
+  .about-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--glaze); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--skin); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 3px; background-color: var(--bone-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(194,69,31,.34), rgba(217,144,47,.32)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBG.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBG.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * filipino / AboutBG — lp-115's "the shop" split on a steel daylight band: prose
+ * left (headline + paragraphs), an art-directed portrait right. The photo keeps a
+ * dark gradient fallback until about.image is set; about.quote / about.signature
+ * are optional extras that stay hidden when unset. Mirrors AboutBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Bay 01 / The shop</span><span>Km 22, Marcos Highway</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Shop photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--steel); color: var(--ink); }
+  .about .sw-head { color: var(--mid); border-color: rgba(30,34,38,0.16); }
+  .about .h2 { color: var(--ink); }
+  .about .h2 :global(em) { color: var(--alert); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.76; margin: 0 0 1em; color: #3b4148; }
+  .about-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--alert); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--hazard); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 3px; background-color: var(--asphalt-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(30,34,38,.55), rgba(226,59,46,.28)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/about/AboutBH.astro
+++ b/astro-site-template/src/components/filipino/about/AboutBH.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / AboutBH — lp-104's "the haus" split on the light band: prose left
+ * (headline + paragraphs), an art-directed portrait right. The photo keeps a cold
+ * gradient fallback until about.image is set; about.quote / about.signature are
+ * optional extras that stay hidden when unset. Mirrors AboutAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const about = content.about || {};
+const headline = about.headline || '';
+const paragraphs: string[] = Array.isArray(about.paragraphs) ? about.paragraphs : (about.body ? [about.body] : []);
+const image = about.image || (Array.isArray(about.images) && about.images[0]) || '';
+const quote = about.quote || '';
+const signature = about.signature || '';
+---
+<section class="about" id="about">
+  <div class="wrap">
+    <div class="sw-head"><span>Layer 01 / The haus</span><span>Halo means mix</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        {headline && <h2 class="h2 reveal" data-field="about.headline" set:html={headline}></h2>}
+        {paragraphs.map((p: string, i: number) => (
+          <p class="reveal" data-field={`about.paragraphs.${i}`} set:html={p}></p>
+        ))}
+        {quote && <blockquote class="about-quote reveal" data-field="about.quote">“{quote}”</blockquote>}
+        {signature && <p class="about-sign reveal" data-field="about.signature">{signature}</p>}
+      </div>
+      <div class="about-fig reveal" data-delay="1">
+        <div class="ph" role="img" aria-label="Haus photo" data-image-field="about.image" style={image ? `background-image:url('${image}');` : ''}></div>
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .about { background: var(--paper-2); color: var(--ink); }
+  .about-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(38px,5vw,84px); align-items: center; }
+  .about-prose p { font-size: clamp(16px,1.55vw,19px); line-height: 1.76; margin: 0 0 1em; color: var(--ink-2); }
+  .about-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(18px,2.2vw,24px); line-height: 1.3; color: var(--ube); margin: 24px 0 0; padding-left: 16px; border-left: 3px solid var(--rosa); }
+  .about-sign { margin-top: 16px; font-style: italic; color: var(--mid); }
+  .about-fig { aspect-ratio: 4/5; }
+  .about-fig .ph { width: 100%; height: 100%; border-radius: 18px; border: 3px solid var(--ube); background-color: var(--paper); background-size: cover; background-position: center;
+    background-image: linear-gradient(160deg, rgba(91,42,134,.4), rgba(229,86,143,.3)); }
+  @media (max-width: 820px) { .about-grid { grid-template-columns: 1fr; gap: 32px; } .about-fig { aspect-ratio: 5/4; } }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBB.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBB.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * filipino / AreaBB — lp-101's "the neighbourhood" strip: ink-outlined pill tags
+ * of the places served. Reads content.area.places (legacy `items`); optional
+ * headline / sub render above. Auto-hides when empty. Mirrors AreaAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 08 / The neighbourhood</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; padding: 10px 20px; border: 2px solid var(--ink); border-radius: 999px; font-weight: 700; color: var(--ink-2); transition: .2s; }
+  .area-list li:hover { background: var(--ink); color: var(--paper-2); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBC.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBC.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * filipino / AreaBC — lp-103's "we feed" strip: leaf-outlined tags of the places
+ * served. Reads content.area.places (legacy `items`); optional headline / sub
+ * render above. Auto-hides when empty. Mirrors AreaAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 08 / We feed</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; padding: 10px 20px; border: 2px solid var(--leaf); border-radius: 2px; font-weight: 700; color: var(--ink-2); transition: .2s; }
+  .area-list li:hover { background: var(--leaf); color: var(--paper-2); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBD.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBD.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * filipino / AreaBD — lp-102's "we bake for" strip on the dark crust band:
+ * cream-outlined pill tags of the places served. Reads content.area.places
+ * (legacy `items`); optional headline / sub render above. Auto-hides when empty.
+ * Mirrors AreaAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 08 / We bake for</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area { padding-top: 0; }
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; padding: 10px 20px; border: 1.5px solid rgba(244,231,207,0.3); border-radius: 3px; font-weight: 700; color: var(--mid-d); transition: .2s; }
+  .area-list li:hover { background: var(--cream); color: var(--crust); border-color: var(--cream); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBE.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBE.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * filipino / AreaBE — lp-111's "we serve" strip: bean-outlined pill tags of the
+ * places served. Reads content.area.places (legacy `items`); optional headline /
+ * sub render above. Auto-hides when empty. Mirrors AreaAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 08 / We serve</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 10px 20px; border: 1.5px solid var(--bean); border-radius: 3px; font-weight: 700; color: var(--mid); transition: .2s; }
+  .area-list li:hover { background: var(--bean); color: var(--oat-2); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBF.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBF.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * filipino / AreaBF — lp-117's "we deliver to" strip: bone-outlined pill tags of
+ * the places served. Reads content.area.places (legacy `items`); optional
+ * headline / sub render above. Auto-hides when empty. Mirrors AreaBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 08 / We deliver to</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 10px 20px; border: 1.5px solid rgba(246,239,227,0.3); border-radius: 2px; font-weight: 700; color: var(--mid-d); transition: .2s; }
+  .area-list li:hover { background: var(--skin); border-color: var(--skin); color: var(--char); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBG.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBG.astro
@@ -1,0 +1,35 @@
+---
+/**
+ * filipino / AreaBG — lp-115's "we cover" strip on asphalt: steel-outlined pill
+ * tags of the places served. Reads content.area.places (legacy `items`); optional
+ * headline / sub render above. Auto-hides when empty. Mirrors AreaBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 08 / We cover</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area { padding-top: 0; }
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 10px 20px; border: 1.5px solid rgba(236,239,242,0.3); border-radius: 2px; font-weight: 700; color: var(--mid-d); transition: .2s; }
+  .area-list li:hover { background: var(--hazard); border-color: var(--hazard); color: var(--asphalt); }
+</style>

--- a/astro-site-template/src/components/filipino/area/AreaBH.astro
+++ b/astro-site-template/src/components/filipino/area/AreaBH.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * filipino / AreaBH — lp-104's "we're sweet on" strip: ube-outlined pill tags
+ * of the places served. Reads content.area.places (legacy `items`); optional
+ * headline / sub render above. Auto-hides when empty. Mirrors AreaAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const area = content.area || {};
+const tag = area.tag || '';
+const headline = area.headline || '';
+const sub = area.sub || '';
+const places: string[] = Array.isArray(area.places) ? area.places : (Array.isArray(area.items) ? area.items : []);
+---
+{places.length > 0 && (
+  <section class="area">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 08 / We're sweet on</span>{tag && <span data-field="area.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="area.headline" set:html={headline}></h2>}
+      {sub && <p class="area-sub body reveal" data-field="area.sub">{sub}</p>}
+      <ul class="area-list reveal">
+        {places.map((place, i) => (
+          <li data-field={`area.places.${i}`}>{place}</li>
+        ))}
+      </ul>
+    </div>
+  </section>
+)}
+<style>
+  .area-sub { max-width: 56ch; margin: -8px 0 8px; }
+  .area-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; }
+  .area-list li { list-style: none; font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; padding: 10px 20px; border: 2px solid var(--ube); border-radius: 999px; font-weight: 700; color: var(--ink-2); transition: .2s; }
+  .area-list li:hover { background: var(--ube); color: var(--paper-2); border-color: var(--ube); }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBB.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBB.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * filipino / CredentialsBB — lp-101's "the essentials" row: a four-up set of
+ * turquoise-topped cells, each a small vermilion mono label over a Bricolage
+ * detail line. Reads content.credentials.items ({title, desc}); title rides the
+ * label, desc the detail. Auto-hides when empty. Mirrors CredentialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 3px solid var(--turq); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vermilion); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 700; font-size: 19px; line-height: 1.14; letter-spacing: -0.015em; color: var(--ink); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBC.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBC.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * filipino / CredentialsBC — lp-103's "the essentials" row: a four-up set of
+ * pandan-topped cells, each a small tomato mono label over an Archivo detail
+ * line. Reads content.credentials.items ({title, desc}); title rides the label,
+ * desc the detail. Auto-hides when empty. Mirrors CredentialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 3px solid var(--pandan); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--tomato); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 800; font-size: 19px; line-height: 1.12; letter-spacing: -0.02em; color: var(--leaf); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBD.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBD.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / CredentialsBD — lp-102's "the essentials" row on the dark crust
+ * band: a four-up set of rule-topped cells, each a small pandesal mono label over
+ * a DM Serif detail line. Reads content.credentials.items ({title, desc}); title
+ * rides the label, desc the detail. Auto-hides when empty. Mirrors CredentialsAS.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds-sec { padding-top: 0; }
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 1.5px solid var(--rule-d); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pandesal); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 400; font-size: 20px; line-height: 1.16; color: var(--cream); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBE.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBE.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * filipino / CredentialsBE — lp-111's "the essentials" row: a four-up set of
+ * rule-topped cells, each a small barako mono label over a Zilla Slab detail
+ * line. Reads content.credentials.items ({title, desc}); title rides the label,
+ * desc the detail. Auto-hides when empty. Mirrors CredentialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 1.5px solid var(--rule); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--barako); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 700; font-size: 20px; line-height: 1.18; letter-spacing: -0.01em; color: var(--ink); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBF.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBF.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * filipino / CredentialsBF — lp-117's "the essentials" row: a four-up set of
+ * skin-topped cells, each a small skin mono label over an Archivo detail line.
+ * Reads content.credentials.items ({title, desc}); title rides the label, desc
+ * the detail. Auto-hides when empty. Mirrors CredentialsBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 1.5px solid var(--rule-d); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--skin); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 800; font-size: 19px; line-height: 1.12; letter-spacing: -0.025em; color: var(--bone); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBG.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBG.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / CredentialsBG — lp-115's "the essentials" row on asphalt: a four-up
+ * set of rule-topped cells, each a small hazard mono label over an Archivo detail
+ * line. Reads content.credentials.items ({title, desc}); title rides the label,
+ * desc the detail. Auto-hides when empty. Mirrors CredentialsBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds-sec { padding-top: 0; }
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 1.5px solid var(--rule-d); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--hazard); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 800; font-size: 19px; line-height: 1.14; letter-spacing: -0.02em; color: var(--steel); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/credentials/CredentialsBH.astro
+++ b/astro-site-template/src/components/filipino/credentials/CredentialsBH.astro
@@ -1,0 +1,42 @@
+---
+/**
+ * filipino / CredentialsBH — lp-104's "the essentials" row: a four-up set of
+ * mango-topped cells, each a small rosa mono label over an Unbounded detail
+ * line. Reads content.credentials.items ({title, desc}); title rides the label,
+ * desc the detail. Auto-hides when empty. Mirrors CredentialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const cred = content.credentials || {};
+const tag = cred.tag || '';
+const headline = cred.headline || '';
+type Item = { title?: string; desc?: string; label?: string; detail?: string };
+const items: Item[] = Array.isArray(cred.items) ? cred.items : (Array.isArray(cred) ? cred : []);
+---
+{items.length > 0 && (
+  <section class="creds-sec">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 09 / The essentials</span>{tag && <span data-field="credentials.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="credentials.headline" set:html={headline}></h2>}
+      <div class="creds reveal">
+        {items.map((item, i) => {
+          const labelText = item.title ?? item.label ?? '';
+          const detailText = item.desc ?? item.detail ?? '';
+          return (
+            <div>
+              {labelText && <div class="label" data-field={`credentials.items.${i}.title`}>{labelText}</div>}
+              {detailText && <div class="detail" data-field={`credentials.items.${i}.desc`}>{detailText}</div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .creds { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(18px,2.5vw,36px); margin-top: clamp(10px,2vw,20px); }
+  .creds > div { border-top: 3px solid var(--mango); padding-top: 14px; }
+  .creds .label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--rosa); margin-bottom: 8px; font-weight: 700; }
+  .creds .detail { font-family: var(--disp); font-weight: 700; font-size: 17px; line-height: 1.18; letter-spacing: -0.02em; color: var(--ube); }
+  @media (max-width: 760px) { .creds { grid-template-columns: 1fr 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBB.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBB.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBB — lp-101's vermilion closing band, centred: a paper
+ * eyebrow, an oversized Bricolage headline, a lede and up to three CTAs
+ * (recoloured paper-fill + paper ghosts for the warm ground). Anchors #book for
+ * the hero / nav CTA. Mirrors CtaBandAS's content contract, with a fallback to
+ * the derived single `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--vermilion); color: var(--paper-2); padding: clamp(80px,10vw,144px) 0; text-align: center; }
+  .cta-band .kick { color: var(--paper-2); }
+  .cta-h { font-family: var(--disp); font-weight: 800; font-size: clamp(42px,6.5vw,106px); line-height: 0.96; margin: 14px auto 18px; max-width: 16ch; letter-spacing: -0.025em; color: var(--paper-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--marigold); }
+  .cta-sub { color: rgba(255,250,240,0.92); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--paper-2); color: var(--vermilion); }
+  .cta-band .btn-primary:hover { background: var(--grape); color: var(--paper-2); }
+  .cta-band .btn-ghost { border-color: var(--paper-2); color: var(--paper-2); }
+  .cta-band .btn-ghost:hover { background: var(--paper-2); color: var(--vermilion); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBC.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBC.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBC — lp-103's tomato closing band, centred: a paper eyebrow,
+ * an oversized Archivo headline, a lede and up to three CTAs (recoloured paper-
+ * fill + paper ghosts for the warm ground). Anchors #book for the hero / nav CTA.
+ * Mirrors CtaBandAS's content contract, with a fallback to the derived single
+ * `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--tomato); color: var(--paper-2); padding: clamp(80px,10vw,144px) 0; text-align: center; }
+  .cta-band .kick { color: var(--paper-2); }
+  .cta-h { font-family: var(--disp); font-weight: 900; font-size: clamp(42px,6.5vw,106px); line-height: 0.94; margin: 14px auto 18px; max-width: 15ch; letter-spacing: -0.03em; color: var(--paper-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--kalamansi); }
+  .cta-sub { color: rgba(255,250,239,0.92); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--paper-2); color: var(--tomato); }
+  .cta-band .btn-primary:hover { background: var(--leaf); color: var(--paper-2); }
+  .cta-band .btn-ghost { border-color: var(--paper-2); color: var(--paper-2); }
+  .cta-band .btn-ghost:hover { background: var(--paper-2); color: var(--tomato); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBD.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBD.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBD — lp-102's brick closing band, centred: a cream eyebrow,
+ * an oversized DM Serif headline (italic pandesal accent), a lede and up to three
+ * CTAs (cream-fill + cream ghosts for the warm ground). Anchors #book for the
+ * hero / nav CTA. Mirrors CtaBandAS's content contract, with a fallback to the
+ * derived single `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--brick); color: var(--cream); padding: clamp(84px,10vw,150px) 0; text-align: center; }
+  .cta-band .kick { color: var(--cream); }
+  .cta-h { font-family: var(--disp); font-weight: 400; font-size: clamp(44px,6.5vw,110px); line-height: 1.0; margin: 14px auto 18px; max-width: 15ch; color: var(--cream); }
+  .cta-h :global(em) { font-style: italic; color: var(--pandesal); }
+  .cta-sub { color: rgba(244,231,207,0.9); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--cream); color: var(--brick); }
+  .cta-band .btn-primary:hover { background: var(--pandesal); color: var(--crust); }
+  .cta-band .btn-ghost { border-color: rgba(244,231,207,0.6); color: var(--cream); }
+  .cta-band .btn-ghost:hover { background: var(--cream); color: var(--brick); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBE.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBE.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBE — lp-111's barako closing band, centred: an oat eyebrow,
+ * an oversized Zilla Slab headline, a lede and up to three CTAs (recoloured
+ * oat-fill + oat ghosts for the warm barako ground). Anchors #book for the hero /
+ * nav CTA. Mirrors CtaBandAS's content contract, with a fallback to the derived
+ * single `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--barako); color: var(--oat-2); padding: clamp(84px,10vw,150px) 0; text-align: center; }
+  .cta-band .kick { color: var(--oat-2); }
+  .cta-h { font-family: var(--disp); font-weight: 700; font-size: clamp(44px,6.5vw,106px); line-height: 1.0; margin: 14px auto 18px; max-width: 15ch; letter-spacing: -0.02em; color: var(--oat-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--gold); }
+  .cta-sub { color: rgba(247,239,223,0.92); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--oat-2); color: var(--barako); }
+  .cta-band .btn-primary:hover { background: var(--bean); color: var(--oat-2); }
+  .cta-band .btn-ghost { border-color: var(--oat-2); color: var(--oat-2); }
+  .cta-band .btn-ghost:hover { background: var(--oat-2); color: var(--barako); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBF.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBF.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBF — lp-117's glaze closing band, centred: a bone eyebrow,
+ * an oversized Archivo headline, a lede and up to three CTAs (recoloured bone-
+ * fill + bone ghosts for the warm ground). Anchors #book for the hero / nav CTA.
+ * Mirrors CtaBandBB's content contract, with a fallback to the derived single
+ * `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--glaze); color: var(--bone-2); padding: clamp(80px,10vw,144px) 0; text-align: center; }
+  .cta-band .kick { color: var(--bone-2); }
+  .cta-h { font-family: var(--disp); font-weight: 900; font-size: clamp(42px,6.2vw,102px); line-height: 0.94; margin: 14px auto 18px; max-width: 15ch; letter-spacing: -0.03em; color: var(--bone-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--skin); }
+  .cta-sub { color: rgba(253,248,239,0.92); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--bone-2); color: var(--glaze); }
+  .cta-band .btn-primary:hover { background: var(--skin); color: var(--char); }
+  .cta-band .btn-ghost { border-color: var(--bone-2); color: var(--bone-2); }
+  .cta-band .btn-ghost:hover { background: var(--bone-2); color: var(--glaze); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBG.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBG.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBG — lp-115's alert-red closing band, centred: a paper
+ * eyebrow, an oversized Archivo headline, a lede and up to three CTAs (recoloured
+ * steel-fill + steel ghosts for the red ground). Anchors #book for the hero / nav
+ * CTA. Mirrors CtaBandBB's content contract, with a fallback to the derived single
+ * `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--alert); color: var(--steel-2); padding: clamp(80px,10vw,144px) 0; text-align: center; }
+  .cta-band .kick { color: var(--steel-2); }
+  .cta-h { font-family: var(--disp); font-weight: 900; font-size: clamp(42px,6.2vw,102px); line-height: 0.94; margin: 14px auto 18px; max-width: 15ch; letter-spacing: -0.03em; color: var(--steel-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--hazard); }
+  .cta-sub { color: rgba(246,248,250,0.92); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--steel-2); color: var(--alert); }
+  .cta-band .btn-primary:hover { background: var(--hazard); color: var(--asphalt); }
+  .cta-band .btn-ghost { border-color: var(--steel-2); color: var(--steel-2); }
+  .cta-band .btn-ghost:hover { background: var(--steel-2); color: var(--alert); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/ctaBand/CtaBandBH.astro
+++ b/astro-site-template/src/components/filipino/ctaBand/CtaBandBH.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * filipino / CtaBandBH — lp-104's rosa closing band, centred: a paper eyebrow,
+ * an oversized Unbounded headline, a lede and up to three CTAs (recoloured
+ * paper-fill + paper ghosts for the rosa ground). Anchors #book for the hero /
+ * nav CTA. Mirrors CtaBandAS's content contract, with a fallback to the derived
+ * single `ctaBand.cta` so a first build always shows one action.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const cta = content.ctaBand || content.closing || {};
+const tag = cta.tag || '';
+const headline = cta.headline || '';
+const sub = cta.sub || '';
+const cta1Text = cta.cta1?.text || cta.cta?.text || '';
+const cta1Href = cta.cta1?.href || cta.cta?.href || '#book';
+const cta2Text = cta.cta2?.text || '';
+const cta2Href = cta.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '');
+const cta3Text = cta.cta3?.text || '';
+const cta3Href = cta.cta3?.href || '#location';
+const hasButtons = !!(cta1Text || cta2Text || cta3Text);
+---
+{(headline || hasButtons) && (
+  <section class="cta-band" id="book">
+    <div class="wrap">
+      {tag && <div class="kick" data-field="ctaBand.tag">{tag}</div>}
+      {headline && <h2 class="cta-h" data-field="ctaBand.headline" set:html={headline}></h2>}
+      {sub && <p class="cta-sub" data-field="ctaBand.sub">{sub}</p>}
+      {hasButtons && (
+        <div class="ctas">
+          {cta1Text && <a class="btn btn-primary" href={cta1Href} rel="noopener" data-field="ctaBand.cta1.text" data-href-field="ctaBand.cta1.href">{cta1Text}</a>}
+          {cta2Text && <a class="btn btn-ghost" href={cta2Href} rel="noopener" data-field="ctaBand.cta2.text" data-href-field="ctaBand.cta2.href">{cta2Text}</a>}
+          {cta3Text && <a class="btn btn-ghost" href={cta3Href} rel="noopener" data-field="ctaBand.cta3.text" data-href-field="ctaBand.cta3.href">{cta3Text}</a>}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .cta-band { background: var(--rosa); color: var(--paper-2); padding: clamp(80px,10vw,144px) 0; text-align: center; }
+  .cta-band .kick { color: var(--paper-2); }
+  .cta-h { font-family: var(--disp); font-weight: 800; font-size: clamp(36px,5.6vw,92px); line-height: 1.0; margin: 14px auto 18px; max-width: 15ch; letter-spacing: -0.03em; color: var(--paper-2); }
+  .cta-h :global(em) { font-style: normal; color: var(--leche); }
+  .cta-sub { color: rgba(255,248,251,0.94); max-width: 52ch; margin: 0 auto 34px; font-size: 17px; }
+  .ctas { display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+  .cta-band .btn-primary { background: var(--paper-2); color: var(--rosa); }
+  .cta-band .btn-primary:hover { background: var(--ube); color: var(--paper-2); }
+  .cta-band .btn-ghost { border-color: var(--paper-2); color: var(--paper-2); }
+  .cta-band .btn-ghost:hover { background: var(--paper-2); color: var(--rosa); }
+  @media (max-width: 520px) { .cta-band .ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBB.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBB.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * filipino / FaqBB — lp-101's "good to know" split: an intro column (headline +
+ * a contact line) beside a stacked <details> accordion whose Bricolage summaries
+ * carry a vermilion "+" that rotates to "×" on open. First item opens by default.
+ * Reads content.faq.items ({q, a}). Auto-hides when empty. Mirrors FaqAS.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Or just come to the window.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--vermilion); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 2px solid var(--ink); }
+  .faq-list summary { font-family: var(--disp); font-weight: 700; font-size: 22px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.14; letter-spacing: -0.015em; color: var(--ink); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--vermilion); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--ink-2); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBC.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBC.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * filipino / FaqBC — lp-103's "good to know" split: an intro column (headline +
+ * a contact line) beside a stacked <details> accordion whose Archivo summaries
+ * carry a tomato "+" that rotates to "×" on open. First item opens by default.
+ * Reads content.faq.items ({q, a}). Auto-hides when empty. Mirrors FaqAS.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Or just come to the glass and point.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--tomato); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 2px solid var(--leaf); }
+  .faq-list summary { font-family: var(--disp); font-weight: 800; font-size: 22px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.12; letter-spacing: -0.02em; color: var(--leaf); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--tomato); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--ink-2); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBD.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBD.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * filipino / FaqBD — lp-102's "good to know" split on the dark crust band: an
+ * intro column (headline + a contact line) beside a stacked <details> accordion
+ * whose DM Serif summaries carry a pandesal "+" that rotates to "×" on open. First
+ * item opens by default. Reads content.faq.items ({q, a}). Auto-hides when empty.
+ * Mirrors FaqAS.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Or just follow the smell to the corner.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--pandesal); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule-d); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 1.5px solid var(--rule-d); }
+  .faq-list summary { font-family: var(--disp); font-weight: 400; font-size: 24px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.14; color: var(--cream); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--pandesal); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--mid-d); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBE.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBE.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * filipino / FaqBE — lp-111's "good to know" split: an intro column (headline +
+ * a contact line) beside a stacked <details> accordion whose Zilla Slab summaries
+ * carry a barako "+" that rotates to "×" on open. First item opens by default.
+ * Reads content.faq.items ({q, a}). Auto-hides when empty. Mirrors FaqAS.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. New to Liberica? Come to the café and let us brew you a proper cup.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--barako); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 1.5px solid var(--bean); }
+  .faq-list summary { font-family: var(--disp); font-weight: 700; font-size: 22px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.16; letter-spacing: -0.01em; color: var(--ink); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--barako); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--mid); font-size: 14.5px; max-width: 64ch; line-height: 1.74; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBF.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBF.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * filipino / FaqBF — lp-117's "before you order" split on the dark ground: an
+ * intro column (headline + a contact line) beside a stacked <details> accordion
+ * whose Archivo summaries carry a skin "+" that rotates to "×" on open. First
+ * item opens by default. Reads content.faq.items ({q, a}). Auto-hides when empty.
+ * Mirrors FaqBB.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 07 / Before you order</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Or just follow the smoke to the kanto.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--skin); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule-d); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 1.5px solid var(--rule-d); }
+  .faq-list summary { font-family: var(--disp); font-weight: 800; font-size: 21px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.14; letter-spacing: -0.025em; color: var(--bone); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--skin); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--mid-d); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBG.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBG.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * filipino / FaqBG — lp-115's "good to know" split on asphalt: an intro column
+ * (headline + a contact line) beside a stacked <details> accordion whose Archivo
+ * summaries carry a hazard "+" that rotates to "×" on open. First item opens by
+ * default. Reads content.faq.items ({q, a}). Auto-hides when empty. Mirrors FaqBB.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Save it before you need it.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--hazard); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule-d); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 1.5px solid var(--rule-d); }
+  .faq-list summary { font-family: var(--disp); font-weight: 800; font-size: 21px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.14; letter-spacing: -0.02em; color: var(--steel); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--hazard); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--mid-d); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/faq/FaqBH.astro
+++ b/astro-site-template/src/components/filipino/faq/FaqBH.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * filipino / FaqBH — lp-104's "good to know" split: an intro column (headline +
+ * a contact line) beside a stacked <details> accordion whose Unbounded summaries
+ * carry a rosa "+" that rotates to "×" on open. First item opens by default.
+ * Reads content.faq.items ({q, a}). Auto-hides when empty. Mirrors FaqAS.
+ */
+interface Props { content: any; layout?: any; }
+const { content } = Astro.props;
+const faq = content.faq || {};
+const tag = faq.tag || '';
+const headline = faq.headline || 'Good to know.';
+type Item = { q: string; a: string };
+const items: Item[] = Array.isArray(faq.items) ? faq.items : (Array.isArray(faq) ? faq : []);
+const phone = content.location?.phone || (content as any).contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+---
+{items.length > 0 && (
+  <section class="faq">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 07 / Good to know</span>{tag && <span data-field="faq.tag">{tag}</span>}</div>
+      <div class="faq-grid">
+        <div class="faq-intro reveal">
+          <h2 class="h2" data-field="faq.headline" set:html={headline}></h2>
+          {phone && (
+            <p class="body">Anything else — message us or ring <a href={`tel:${phoneDigits}`} class="faq-tel">{phone}</a>. Or just come in, take a booth, and stir.</p>
+          )}
+        </div>
+        <div class="faq-list reveal">
+          {items.map((item, i) => (
+            <details open={i === 0}>
+              <summary><span data-field={`faq.items.${i}.q`}>{item.q}</span></summary>
+              <p data-field={`faq.items.${i}.a`} set:html={item.a}></p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .faq-grid { display: grid; grid-template-columns: 2fr 3fr; gap: clamp(36px,5vw,88px); }
+  .faq-tel { color: var(--rosa); font-weight: 700; }
+  .faq-list details { border-bottom: 1px solid var(--rule); padding: 22px 0; }
+  .faq-list details:first-child { border-top: 2px solid var(--ube); }
+  .faq-list summary { font-family: var(--disp); font-weight: 700; font-size: 18px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; gap: 20px; line-height: 1.2; letter-spacing: -0.02em; color: var(--ube); }
+  .faq-list summary::-webkit-details-marker { display: none; }
+  .faq-list summary::after { content: "+"; color: var(--rosa); font-size: 24px; flex-shrink: 0; transition: 0.2s; }
+  .faq-list details[open] summary::after { transform: rotate(45deg); }
+  .faq-list p { margin: 14px 0 0; color: var(--ink-2); font-size: 14.5px; max-width: 62ch; line-height: 1.72; }
+  @media (max-width: 760px) { .faq-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBB.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBB.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBB — lp-101's ink footer: a Bricolage wordmark + blurb, a
+ * "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-101's
+ * floating turquoise message pill (reuses the hero's primary CTA so it stays in
+ * sync). Every column auto-hides when empty. Mirrors FooterAS's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Bukas · Open · Suki welcome</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the store" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--ink); color: var(--paper); border-top: 3px solid var(--vermilion); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 800; font-size: 22px; letter-spacing: -0.02em; color: var(--paper); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--marigold); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: rgba(251,244,230,0.72); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: rgba(251,244,230,0.72); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: rgba(251,244,230,0.72); }
+  .footer-grid a:hover { color: var(--marigold); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 2px dashed rgba(251,244,230,0.28); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--marigold); border-color: var(--marigold); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid rgba(251,244,230,0.16); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(251,244,230,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--turq); color: var(--paper-2); padding: 13px 20px; border-radius: 999px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(26,156,142,0.4); border: 2.5px solid var(--ink); }
+  .msg-fab a:hover { background: var(--vermilion); color: var(--paper-2); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBC.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBC.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBC — lp-103's leaf-green footer: an Archivo wordmark + blurb, a
+ * "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-103's
+ * floating leaf message pill (reuses the hero's primary CTA so it stays in sync).
+ * Every column auto-hides when empty. Mirrors FooterAS's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Sarap · Mabilis · Sulit · Sampaloc</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the carinderia" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--leaf-2); color: var(--paper); border-top: 3px solid var(--kalamansi); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 900; font-size: 20px; letter-spacing: -0.03em; color: var(--paper); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--kalamansi); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: rgba(250,243,226,0.72); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: rgba(250,243,226,0.72); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: rgba(250,243,226,0.72); }
+  .footer-grid a:hover { color: var(--kalamansi); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 2px dashed rgba(250,243,226,0.28); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--kalamansi); border-color: var(--kalamansi); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid rgba(250,243,226,0.16); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(250,243,226,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--leaf); color: var(--paper-2); padding: 13px 20px; border-radius: 999px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(31,77,46,0.4); border: 2.5px solid var(--kalamansi); }
+  .msg-fab a:hover { background: var(--tomato); color: var(--paper-2); border-color: var(--paper-2); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBD.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBD.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBD — lp-102's crust footer: a DM Serif wordmark + blurb, a
+ * "The bakery" NAP column, an "Index" links column, a colophon rule, plus
+ * lp-102's floating brick message pill (reuses the hero's primary CTA so it stays
+ * in sync). Every column auto-hides when empty. Mirrors FooterAS's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>The bakery</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Hot pandesal from five</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the bakery" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--crust); color: var(--cream); border-top: 1.5px solid var(--rule-d); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 400; font-size: 26px; letter-spacing: 0; color: var(--cream); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pandesal); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: var(--mid-d); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: var(--mid-d); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: var(--mid-d); }
+  .footer-grid a:hover { color: var(--pandesal); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 1.5px dashed rgba(244,231,207,0.28); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--pandesal); border-color: var(--pandesal); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--rule-d); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--brick); color: var(--cream); padding: 13px 20px; border-radius: 3px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(176,71,47,0.4); }
+  .msg-fab a:hover { background: var(--cream); color: var(--crust); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBE.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBE.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBE — lp-111's bean footer: a Zilla Slab wordmark + blurb, a
+ * "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-111's
+ * floating barako message pill (reuses the hero's primary CTA so it stays in
+ * sync). Every column auto-hides when empty. Mirrors FooterAS's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Heritage Liberica · Batangas</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the roastery" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--bean-2); color: var(--oat); border-top: 1.5px solid var(--rule-d); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 700; font-size: 23px; letter-spacing: -0.01em; color: var(--oat); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--gold); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: var(--mid-d); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: var(--mid-d); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: var(--mid-d); }
+  .footer-grid a:hover { color: var(--gold); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 1.5px dashed var(--rule-d); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--gold); border-color: var(--gold); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--rule-d); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--barako); color: var(--oat-2); padding: 13px 20px; border-radius: 3px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(181,71,31,0.4); }
+  .msg-fab a:hover { background: var(--bean); color: var(--oat-2); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBF.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBF.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBF — lp-117's charcoal footer: an Archivo wordmark + blurb, a
+ * "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-117's
+ * floating glaze message pill (reuses the hero's primary CTA so it stays in
+ * sync). Every column auto-hides when empty. Mirrors FooterBB's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Over live coals · Off the spit</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the grill" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--char); color: var(--bone); border-top: 1.5px solid var(--rule-d); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 900; font-size: 21px; letter-spacing: -0.03em; text-transform: uppercase; color: var(--bone); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--skin); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: var(--mid-d); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: var(--mid-d); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: var(--mid-d); }
+  .footer-grid a:hover { color: var(--skin); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 1.5px dashed rgba(246,239,227,0.28); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--skin); border-color: var(--skin); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--rule-d); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--glaze); color: var(--bone-2); padding: 13px 20px; border-radius: 2px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(194,69,31,0.4); }
+  .msg-fab a:hover { background: var(--skin); color: var(--char); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBG.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBG.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBG — lp-115's asphalt footer: an Archivo wordmark + blurb, a
+ * "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-115's
+ * floating alert-red message pill (reuses the hero's primary CTA so it stays in
+ * sync). Every column auto-hides when empty. Mirrors FooterBB's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Open 24 hours · Antipolo</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the shop" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--asphalt); color: var(--steel); border-top: 1.5px solid var(--rule-d); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 900; font-size: 21px; letter-spacing: -0.03em; text-transform: uppercase; color: var(--steel); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--hazard); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: var(--mid-d); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: var(--mid-d); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: var(--mid-d); }
+  .footer-grid a:hover { color: var(--hazard); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 1.5px solid var(--rule-d); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--hazard); border-color: var(--hazard); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--rule-d); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--alert); color: var(--steel-2); padding: 13px 20px; border-radius: 2px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(226,59,46,0.4); }
+  .msg-fab a:hover { background: var(--hazard); color: var(--asphalt); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/footer/FooterBH.astro
+++ b/astro-site-template/src/components/filipino/footer/FooterBH.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * filipino / FooterBH — lp-104's deep-ube footer: an Unbounded wordmark + blurb,
+ * a "Visit" NAP column, an "Index" links column, a colophon rule, plus lp-104's
+ * floating ube message pill (reuses the hero's primary CTA so it stays in sync).
+ * Every column auto-hides when empty. Mirrors FooterAS's content contract.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const f = (content as any).footer || {};
+const brand = f.brand || layout.businessName || 'Your Business';
+const blurb = f.blurb || f.brand_blurb || '';
+const visitLines: string[] = Array.isArray(f.visit?.lines) && f.visit.lines.length
+  ? f.visit.lines
+  : ([layout.contact?.address, layout.contact?.phone].filter(Boolean) as string[]);
+const explore: Array<{ text: string; href: string }> = Array.isArray(f.explore?.links) && f.explore.links.length
+  ? f.explore.links
+  : (Array.isArray(layout.navLinks) ? layout.navLinks.map((l: any) => ({ text: l.label, href: l.href })) : []);
+const social: Array<{ platform: string; url: string }> = Array.isArray(f.social) && f.social.length
+  ? f.social
+  : (Array.isArray(layout.socialLinks) ? layout.socialLinks : []);
+const phone = layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const year = new Date().getFullYear();
+
+// Floating message pill — reuse the hero's primary CTA (falls back to CTA-band).
+const hero = (content as any).hero || {};
+const cband = (content as any).ctaBand || {};
+const msgHref = hero.cta1?.href || cband.cta1?.href || '';
+const msgText = hero.cta1?.text || cband.cta1?.text || 'Message';
+---
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="fcol">
+        <div class="wm" data-field="footer.brand">{brand}</div>
+        {blurb && <p class="fblurb" data-field="footer.blurb">{blurb}</p>}
+        {social.length > 0 && (
+          <div class="foot-social">
+            {social.map((s, i) => (
+              <a href={s.url} target="_blank" rel="noopener noreferrer" data-field={`footer.social.${i}.platform`} data-href-field={`footer.social.${i}.url`}>{s.platform}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {visitLines.length > 0 && (
+        <div class="fcol">
+          <h4>Visit</h4>
+          <address>
+            {visitLines.map((line, i) => (
+              line === phone && phone
+                ? <a href={`tel:${phoneDigits}`} data-field={`footer.visit.lines.${i}`}>{line}</a>
+                : <span data-field={`footer.visit.lines.${i}`}>{line}<br /></span>
+            ))}
+          </address>
+        </div>
+      )}
+      {explore.length > 0 && (
+        <div class="fcol">
+          <h4>Index</h4>
+          {explore.map((l, i) => (
+            <a href={l.href} data-field={`footer.explore.links.${i}.text`} data-href-field={`footer.explore.links.${i}.href`}>{l.text}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    <div class="colophon">
+      <span>© {year} {String(brand).toUpperCase()}</span>
+      <span>Halo, halo · Mix it · Made to order</span>
+    </div>
+  </div>
+</footer>
+{msgHref && (
+  <div class="msg-fab">
+    <a href={msgHref} rel="noopener" aria-label="Message the haus" data-field="hero.cta1.text" data-href-field="hero.cta1.href">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+      {msgText}
+    </a>
+  </div>
+)}
+<style>
+  footer { background: var(--ube-2); color: var(--paper); border-top: 3px solid var(--leche); padding: 56px 0 30px; }
+  .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr; gap: 40px; }
+  .footer-grid .wm { font-family: var(--disp); font-weight: 800; font-size: 22px; letter-spacing: -0.02em; color: var(--paper); }
+  .footer-grid h4 { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--leche); margin: 0 0 14px; font-weight: 700; }
+  .fblurb { font-family: var(--sans); margin-top: 12px; max-width: 34ch; color: rgba(251,241,245,0.72); line-height: 1.6; }
+  .footer-grid address { font-style: normal; font-size: 14.5px; line-height: 1.7; color: rgba(251,241,245,0.72); }
+  .footer-grid a { text-decoration: none; display: block; padding: 3px 0; font-size: 14.5px; color: rgba(251,241,245,0.72); }
+  .footer-grid a:hover { color: var(--leche); }
+  .foot-social { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .foot-social a { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; border: 2px dashed rgba(251,241,245,0.28); padding: 6px 12px; display: inline-block; }
+  .foot-social a:hover { color: var(--leche); border-color: var(--leche); }
+  .colophon { margin-top: 48px; padding-top: 18px; border-top: 1px solid rgba(251,241,245,0.16); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(251,241,245,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+
+  .msg-fab { position: fixed; right: 20px; bottom: 20px; z-index: 100; }
+  .msg-fab a { display: inline-flex; align-items: center; gap: 8px; background: var(--ube); color: var(--paper-2); padding: 13px 20px; border-radius: 999px; text-decoration: none; font-family: var(--mono); font-size: 12px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; box-shadow: 0 8px 24px rgba(91,42,134,0.4); border: 2.5px solid var(--leche); }
+  .msg-fab a:hover { background: var(--rosa); color: var(--paper-2); }
+  .msg-fab svg { width: 14px; height: 14px; }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBB.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBB.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / GalleryBB — lp-101's "at the window" mosaic: a three-up grid of
+ * bordered photo tiles with a vermilion mono caption chip. Tiles are art-directed
+ * .ph frames (warm gradient fallback until an image is set, layered via
+ * data-image-field). Reads content.gallery.items ({image, caption}). Auto-hides
+ * only when there are no items. Mirrors GalleryAS's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 06 / At the window</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 12px; border: 3px solid var(--ink); }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--paper-2); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(26,156,142,.35), rgba(240,168,33,.4)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--vermilion); color: var(--paper-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBC.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBC.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / GalleryBC — lp-103's "on the plate" mosaic: a three-up grid of
+ * leaf-bordered photo tiles with a tomato mono caption chip. Tiles are art-
+ * directed .ph frames (warm gradient fallback until an image is set, layered via
+ * data-image-field). Reads content.gallery.items ({image, caption}). Auto-hides
+ * only when there are no items. Mirrors GalleryAS's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 06 / On the plate</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 8px; border: 3px solid var(--leaf); }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--paper-2); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(79,143,74,.35), rgba(224,169,43,.4)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--tomato); color: var(--paper-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBD.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBD.astro
@@ -1,0 +1,49 @@
+---
+/**
+ * filipino / GalleryBD — lp-102's "from the oven" mosaic on the cream band: a
+ * three-up grid of photo tiles with a brick mono caption chip. Tiles are
+ * art-directed .ph frames (warm gradient fallback until an image is set, layered
+ * via data-image-field). Reads content.gallery.items ({image, caption}).
+ * Auto-hides only when there are no items. Mirrors GalleryAS's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 06 / From the oven</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gallery { background: var(--cream); color: var(--crust); }
+  .gallery .sw-head { color: var(--mid); border-color: rgba(42,28,18,0.16); }
+  .gallery .h2 { color: var(--crust); }
+  .gallery .h2 :global(em) { color: var(--brick); }
+  .gallery .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); color: #4d3826; }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 4px; }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--cream-2); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(217,154,78,.4), rgba(176,71,47,.35)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--brick); color: var(--cream); font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBE.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBE.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * filipino / GalleryBE — lp-111's "cherry to cup" mosaic on the light oat-2
+ * band: a three-up grid of photo tiles with a barako mono caption chip. Tiles are
+ * art-directed .ph frames (warm roasted-earth gradient fallback until an image is
+ * set, layered via data-image-field). Reads content.gallery.items ({image,
+ * caption}). Auto-hides only when there are no items. Mirrors GalleryAS's contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 06 / Cherry to cup</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gallery { background: var(--oat-2); color: var(--ink); }
+  .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 4px; }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--oat); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(95,122,68,.4), rgba(207,145,55,.42)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--barako); color: var(--oat-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBF.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBF.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * filipino / GalleryBF — lp-117's "at the fire" mosaic on the light bone band: a
+ * three-up grid of photo tiles with a glaze mono caption chip. Tiles are art-
+ * directed .ph frames (warm ember gradient fallback until an image is set,
+ * layered via data-image-field). Reads content.gallery.items ({image, caption}).
+ * Auto-hides only when there are no items. Mirrors GalleryBB's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 06 / At the fire</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gallery { background: var(--bone); color: var(--ink); }
+  .gallery .sw-head { color: var(--mid); border-color: rgba(35,28,22,0.16); }
+  .gallery .h2 { color: var(--ink); }
+  .gallery .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); color: var(--mid); }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 3px; }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--bone-2); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(217,144,47,.4), rgba(194,69,31,.42)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--glaze); color: var(--bone-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBG.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBG.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * filipino / GalleryBG — lp-115's "in the bay" mosaic on a steel daylight band: a
+ * three-up grid of photo tiles with an alert-red mono caption chip. Tiles are
+ * art-directed .ph frames (dark gradient fallback until an image is set, layered
+ * via data-image-field). Reads content.gallery.items ({image, caption}).
+ * Auto-hides only when there are no items. Mirrors GalleryBB's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 06 / In the bay</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gallery { background: var(--steel); color: var(--ink); }
+  .gallery .sw-head { color: var(--mid); border-color: rgba(30,34,38,0.16); }
+  .gallery .h2 { color: var(--ink); }
+  .gallery .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); color: #3b4148; }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 3px; }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--asphalt-2); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(30,34,38,.5), rgba(245,197,24,.24)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--alert); color: var(--steel-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/gallery/GalleryBH.astro
+++ b/astro-site-template/src/components/filipino/gallery/GalleryBH.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * filipino / GalleryBH — lp-104's "at the counter" mosaic on the light band: a
+ * three-up grid of bordered photo tiles with a rosa mono caption chip. Tiles are
+ * art-directed .ph frames (cold gradient fallback until an image is set, layered
+ * via data-image-field). Reads content.gallery.items ({image, caption}).
+ * Auto-hides only when there are no items. Mirrors GalleryAS's content contract.
+ */
+interface Props { content: any; layout: any; }
+const { content } = Astro.props;
+const gallery = content.gallery || {};
+const tag = gallery.tag || '';
+const headline = gallery.headline || '';
+const sub = gallery.sub || '';
+type Tile = { image?: string; caption?: string };
+const items: Tile[] = Array.isArray(gallery.items) ? gallery.items : (Array.isArray(content.gallery) ? content.gallery : []);
+---
+{items.length > 0 && (
+  <section class="gallery">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 06 / At the counter</span>{tag && <span data-field="gallery.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="gallery.headline" set:html={headline}></h2>}
+      {sub && <p class="gal-sub body reveal" data-field="gallery.sub">{sub}</p>}
+      <div class="g-grid reveal">
+        {items.map((item, i) => (
+          <figure>
+            <div class="ph" role="img" aria-label={item.caption || 'Gallery photo'} data-image-field={`gallery.items.${i}.image`} style={item.image ? `background-image:url('${item.image}');` : ''}></div>
+            {item.caption && <figcaption data-field={`gallery.items.${i}.caption`}>{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .gallery { background: var(--paper-2); }
+  .gal-sub { max-width: 56ch; margin: -8px 0 clamp(28px,4vw,48px); }
+  .g-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+  .g-grid figure { margin: 0; position: relative; overflow: hidden; border-radius: 14px; border: 3px solid var(--ube); }
+  .g-grid .ph { width: 100%; aspect-ratio: 4/3; background-color: var(--paper); background-size: cover; background-position: center; transition: transform 0.3s;
+    background-image: linear-gradient(150deg, rgba(232,178,62,.4), rgba(229,86,143,.35)); }
+  .g-grid figure:hover .ph { transform: scale(1.04); }
+  .g-grid figcaption { position: absolute; left: 0; bottom: 0; background: var(--rosa); color: var(--paper-2); font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 6px 10px; font-weight: 700; }
+  @media (max-width: 760px) { .g-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .g-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBB.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBB.astro
@@ -1,0 +1,88 @@
+---
+/**
+ * filipino / HeaderBB — sticky paper nav with a Bricolage wordmark, Space Mono
+ * uppercase links and a pill CTA that reuses the hero's primary action. Collapses
+ * to an ink-bordered burger drawer on phones. Mirrors lp-101's sari-sari header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BB">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BB" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(251,244,230,0.92); backdrop-filter: blur(10px); border-bottom: 2px solid var(--ink); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 14px 0; }
+  .wm { font-family: var(--disp); font-weight: 800; font-size: 22px; letter-spacing: -0.02em; color: var(--ink); }
+  .wm:hover { color: var(--vermilion); }
+  .nav-links { display: flex; gap: 24px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-2); font-weight: 700; }
+  .nav-links a:hover { color: var(--vermilion); }
+  .nav-links .navc { border: 2px solid var(--ink); padding: 8px 16px; border-radius: 999px; color: var(--ink); }
+  .nav-links .navc:hover { background: var(--vermilion); border-color: var(--vermilion); color: var(--paper-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 2px solid var(--ink); border-radius: 8px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--ink); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--paper-2); border-top: 2px solid var(--rule); border-bottom: 2px solid var(--ink);
+      box-shadow: 0 12px 24px rgba(35,26,36,.14); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--ink-2); border-bottom: 1px dotted var(--rule); }
+    .nav-links a:not(.navc):hover { background: var(--paper); color: var(--vermilion); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--vermilion); border-color: var(--vermilion); color: var(--paper-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBC.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBC.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * filipino / HeaderBC — sticky coconut-cream nav with an Archivo wordmark, Space
+ * Mono uppercase links and a square CTA that reuses the hero's primary action.
+ * Collapses to a leaf-bordered burger drawer on phones. Mirrors lp-103's
+ * carinderia header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BC">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BC" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(250,243,226,0.93); backdrop-filter: blur(10px); border-bottom: 2px solid var(--leaf); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 14px 0; }
+  .wm { font-family: var(--disp); font-weight: 900; font-size: 20px; letter-spacing: -0.03em; color: var(--leaf); }
+  .wm:hover { color: var(--tomato); }
+  .nav-links { display: flex; gap: 24px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-2); font-weight: 700; }
+  .nav-links a:hover { color: var(--tomato); }
+  .nav-links .navc { border: 2px solid var(--leaf); padding: 8px 16px; border-radius: 2px; color: var(--leaf); }
+  .nav-links .navc:hover { background: var(--tomato); border-color: var(--tomato); color: var(--paper-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 2px solid var(--leaf); border-radius: 4px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--leaf); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--paper-2); border-top: 2px solid var(--rule); border-bottom: 2px solid var(--leaf);
+      box-shadow: 0 12px 24px rgba(32,41,31,.14); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--ink-2); border-bottom: 1px dotted var(--rule); }
+    .nav-links a:not(.navc):hover { background: var(--paper); color: var(--tomato); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--tomato); border-color: var(--tomato); color: var(--paper-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBD.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBD.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * filipino / HeaderBD — sticky dark-crust nav with a DM Serif wordmark, Space
+ * Mono uppercase links and a pill CTA that reuses the hero's primary action.
+ * Collapses to a cream-bordered burger drawer on phones. Mirrors lp-102's
+ * panaderia header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BD">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BD" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(42,28,18,0.92); backdrop-filter: blur(10px); border-bottom: 1.5px solid var(--rule-d); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 15px 0; }
+  .wm { font-family: var(--disp); font-weight: 400; font-size: 26px; letter-spacing: 0; color: var(--cream); }
+  .wm:hover { color: var(--pandesal); }
+  .nav-links { display: flex; gap: 26px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  .nav-links a:hover { color: var(--pandesal); }
+  .nav-links .navc { border: 1.5px solid rgba(244,231,207,0.4); padding: 8px 16px; border-radius: 3px; color: var(--cream); }
+  .nav-links .navc:hover { background: var(--brick); border-color: var(--brick); color: var(--cream); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 1.5px solid rgba(244,231,207,0.4); border-radius: 8px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--cream); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: #241811; border-top: 1.5px solid var(--rule-d); border-bottom: 1.5px solid var(--pandesal);
+      box-shadow: 0 12px 24px rgba(0,0,0,.4); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--mid-d); border-bottom: 1px dotted var(--rule-d); }
+    .nav-links a:not(.navc):hover { background: var(--crust); color: var(--pandesal); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--brick); border-color: var(--brick); color: var(--cream); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBE.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBE.astro
@@ -1,0 +1,88 @@
+---
+/**
+ * filipino / HeaderBE — sticky oat nav with a Zilla Slab wordmark, Space Mono
+ * uppercase links and a slab CTA that reuses the hero's primary action. Collapses
+ * to a bean-bordered burger drawer on phones. Mirrors lp-111's barako header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BE">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BE" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(239,228,208,0.93); backdrop-filter: blur(10px); border-bottom: 1.5px solid var(--bean); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 15px 0; }
+  .wm { font-family: var(--disp); font-weight: 700; font-size: 23px; letter-spacing: -0.01em; color: var(--bean); }
+  .wm:hover { color: var(--barako); }
+  .nav-links { display: flex; gap: 26px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--mid); font-weight: 700; }
+  .nav-links a:hover { color: var(--barako); }
+  .nav-links .navc { border: 1.5px solid var(--bean); padding: 9px 18px; border-radius: 3px; color: var(--bean); }
+  .nav-links .navc:hover { background: var(--barako); border-color: var(--barako); color: var(--oat-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 1.5px solid var(--bean); border-radius: 4px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--bean); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--oat-2); border-top: 1.5px solid var(--rule); border-bottom: 1.5px solid var(--bean);
+      box-shadow: 0 12px 24px rgba(36,24,18,.16); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--mid); border-bottom: 1px dotted var(--rule); }
+    .nav-links a:not(.navc):hover { background: var(--oat); color: var(--barako); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--barako); border-color: var(--barako); color: var(--oat-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBF.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBF.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * filipino / HeaderBF — sticky charcoal nav with an Archivo wordmark, Space Mono
+ * uppercase links and a squared CTA that reuses the hero's primary action.
+ * Collapses to a bone-bordered burger drawer on phones. Mirrors lp-117's grill
+ * header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BF">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BF" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(23,19,16,0.92); backdrop-filter: blur(10px); border-bottom: 1.5px solid var(--rule-d); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 15px 0; }
+  .wm { font-family: var(--disp); font-weight: 900; font-size: 21px; letter-spacing: -0.03em; text-transform: uppercase; color: var(--bone); }
+  .wm:hover { color: var(--skin); }
+  .nav-links { display: flex; gap: 26px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  .nav-links a:hover { color: var(--skin); }
+  .nav-links .navc { border: 1.5px solid rgba(246,239,227,0.4); padding: 8px 16px; border-radius: 2px; color: var(--bone); }
+  .nav-links .navc:hover { background: var(--glaze); border-color: var(--glaze); color: var(--bone-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 1.5px solid rgba(246,239,227,0.4); border-radius: 6px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--bone); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--char-2); border-top: 1.5px solid var(--rule-d); border-bottom: 1.5px solid rgba(246,239,227,0.4);
+      box-shadow: 0 12px 24px rgba(0,0,0,.5); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--mid-d); border-bottom: 1px dotted var(--rule-d); }
+    .nav-links a:not(.navc):hover { background: var(--char); color: var(--skin); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--glaze); border-color: var(--glaze); color: var(--bone-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBG.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBG.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * filipino / HeaderBG — sticky asphalt nav with an Archivo wordmark (hazard
+ * accent on the second word), Space Mono uppercase links and a sharp CTA that
+ * reuses the hero's primary action. Collapses to a steel-bordered burger drawer
+ * on phones. Mirrors lp-115's roadside vulcanizing header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BG">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BG" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(25,27,30,0.92); backdrop-filter: blur(10px); border-bottom: 1.5px solid var(--rule-d); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 15px 0; }
+  .wm { font-family: var(--disp); font-weight: 900; font-size: 21px; letter-spacing: -0.03em; text-transform: uppercase; color: var(--steel); }
+  .wm:hover { color: var(--hazard); }
+  .nav-links { display: flex; gap: 26px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  .nav-links a:hover { color: var(--hazard); }
+  .nav-links .navc { border: 1.5px solid rgba(236,239,242,0.4); padding: 8px 16px; border-radius: 2px; color: var(--steel); }
+  .nav-links .navc:hover { background: var(--alert); border-color: var(--alert); color: var(--steel-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 1.5px solid rgba(236,239,242,0.4); border-radius: 4px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--steel); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--asphalt-2); border-top: 1.5px solid var(--rule-d); border-bottom: 1.5px solid var(--rule-d);
+      box-shadow: 0 12px 24px rgba(0,0,0,.4); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--mid-d); border-bottom: 1px solid var(--rule-d); }
+    .nav-links a:not(.navc):hover { background: var(--asphalt); color: var(--hazard); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--alert); border-color: var(--alert); color: var(--steel-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/header/HeaderBH.astro
+++ b/astro-site-template/src/components/filipino/header/HeaderBH.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * filipino / HeaderBH — sticky milk-pink nav with an Unbounded wordmark, Space
+ * Mono uppercase links and a pill CTA that reuses the hero's primary action.
+ * Collapses to an ube-bordered burger drawer on phones. Mirrors lp-104's
+ * halo-halo header.
+ */
+interface Props { layout: any; content: any; }
+const { layout, content } = Astro.props;
+const brand = (content as any).footer?.brand || layout.businessName || 'Your Business';
+const navLinks: Array<{ href: string; label: string }> = (layout.navLinks && layout.navLinks.length)
+  ? layout.navLinks
+  : [];
+// Reuse the hero's primary CTA as the nav action so it stays in sync.
+const hero = (content as any).hero || {};
+const ctaText = hero.cta1?.text || '';
+const ctaHref = hero.cta1?.href || '#book';
+---
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#main" aria-label={`${brand} home`} data-field="footer.brand">{brand}</a>
+    {(navLinks.length > 0 || ctaText) && (
+      <Fragment>
+        <button class="nav-burger" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-primary-BH">
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="nav-primary-BH" aria-label="Primary">
+          {navLinks.map((link, i) => (
+            <a href={link.href} data-field={`navbar_links.${i}.label`} data-href-field={`navbar_links.${i}.href`}>{link.label}</a>
+          ))}
+          {ctaText && <a href={ctaHref} class="navc" data-field="hero.cta1.text" data-href-field="hero.cta1.href">{ctaText}</a>}
+        </nav>
+      </Fragment>
+    )}
+  </div>
+</header>
+<script is:inline>
+  (function () {
+    var hdr = document.querySelector('header.nav');
+    if (!hdr) return;
+    var btn = hdr.querySelector('.nav-burger');
+    if (!btn) return;
+    function setOpen(open) {
+      hdr.classList.toggle('open', open);
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    btn.addEventListener('click', function () { setOpen(!hdr.classList.contains('open')); });
+    hdr.querySelectorAll('.nav-links a').forEach(function (a) {
+      a.addEventListener('click', function () { setOpen(false); });
+    });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
+  })();
+</script>
+<style>
+  header.nav { position: sticky; top: 0; z-index: 50; background: rgba(251,241,245,0.93); backdrop-filter: blur(10px); border-bottom: 2px solid var(--ube); }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 14px 0; }
+  .wm { font-family: var(--disp); font-weight: 800; font-size: 20px; letter-spacing: -0.03em; color: var(--ube); }
+  .wm:hover { color: var(--rosa); }
+  .nav-links { display: flex; gap: 24px; align-items: center; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-2); font-weight: 700; }
+  .nav-links a:hover { color: var(--rosa); }
+  .nav-links .navc { border: 2px solid var(--ube); padding: 8px 16px; border-radius: 999px; color: var(--ube); }
+  .nav-links .navc:hover { background: var(--ube); border-color: var(--ube); color: var(--paper-2); }
+
+  .nav-burger {
+    display: none; flex-direction: column; justify-content: center; gap: 5px;
+    width: 46px; height: 44px; padding: 11px 10px; margin-left: 12px; flex-shrink: 0;
+    background: transparent; border: 2px solid var(--ube); border-radius: 8px; cursor: pointer;
+  }
+  .nav-burger span { display: block; width: 100%; height: 2px; background: var(--ube); transition: transform .25s ease, opacity .2s ease; }
+  header.nav.open .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  header.nav.open .nav-burger span:nth-child(2) { opacity: 0; }
+  header.nav.open .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  @media (prefers-reduced-motion: reduce) { .nav-burger span { transition: none; } }
+
+  @media (max-width: 880px) { .nav-links a:not(.navc) { display: none; } }
+  @media (max-width: 760px) {
+    .nav-burger { display: flex; }
+    .nav-links {
+      position: absolute; left: 0; right: 0; top: 100%;
+      display: none; flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--paper-2); border-top: 2px solid var(--rule); border-bottom: 2px solid var(--ube);
+      box-shadow: 0 12px 24px rgba(44,28,51,.14); padding: 6px 0 12px; max-height: 78vh; overflow-y: auto;
+    }
+    header.nav.open .nav-links { display: flex; }
+    .nav-links a:not(.navc) { display: flex; align-items: center; min-height: 44px; padding: 12px 22px; font-size: 13px; color: var(--ink-2); border-bottom: 1px dotted var(--rule); }
+    .nav-links a:not(.navc):hover { background: var(--paper); color: var(--rosa); }
+    .nav-links .navc { display: flex; align-items: center; justify-content: center; margin: 12px 22px 2px; min-height: 48px; background: var(--ube); border-color: var(--ube); color: var(--paper-2); }
+  }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBB.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBB.astro
@@ -1,0 +1,67 @@
+---
+/**
+ * filipino / HeroBB — lp-101's sari-sari hero: a Space Mono kicker, an oversized
+ * Bricolage headline, then a lower row pairing an art-directed store photo (left,
+ * with the "BUKAS · OPEN" rotated tag) against the lede + CTA pair (right). The
+ * photo slot keeps a warm gradient fallback until hero.image is set.
+ *
+ * Mirrors HeroAS's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Store photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 800; font-size: clamp(42px,7vw,100px); line-height: 0.94; letter-spacing: -0.025em; margin: 0 0 32px; max-width: 17ch; color: var(--ink); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em) { color: var(--vermilion); }
+  .hero-headline :global(.em2) { color: var(--turq); }
+  .hero-lower { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(30px,4vw,60px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 14px; border: 3px solid var(--ink); background-color: var(--paper-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(240,168,33,.5), rgba(26,156,142,.35)); }
+  .hero-photo::after { content: "BUKAS · OPEN · SUKI WELCOME"; position: absolute; left: -10px; top: -14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.1em; background: var(--marigold); color: var(--ink); padding: 8px 14px; border-radius: 999px; border: 2.5px solid var(--ink); transform: rotate(-3deg); }
+  .hero-right .lede { color: var(--ink-2); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBC.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBC.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * filipino / HeroBC — lp-103's carinderia hero: a Space Mono kicker, an oversized
+ * Archivo headline in leaf-green, then a lower row pairing an art-directed food
+ * photo (left, with the "TURO-TURO · LUTONG BAHAY · UNLI RICE" rotated tag)
+ * against the lede + CTA pair (right). The photo slot keeps a warm gradient
+ * fallback until hero.image is set.
+ *
+ * Mirrors HeroAS's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Food photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 900; font-size: clamp(40px,6.6vw,98px); line-height: 0.92; letter-spacing: -0.03em; margin: 0 0 32px; max-width: 18ch; color: var(--leaf); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em) { color: var(--tomato); }
+  .hero-headline :global(.em2) { color: var(--pandan); }
+  .hero-lower { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(30px,4vw,60px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 10px; border: 3px solid var(--leaf); background-color: var(--paper-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(224,169,43,.5), rgba(79,143,74,.35)); }
+  .hero-photo::after { content: "TURO-TURO · LUTONG BAHAY · UNLI RICE"; position: absolute; left: -8px; top: -14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.08em; background: var(--kalamansi); color: var(--ink); padding: 8px 14px; border-radius: 4px; border: 2.5px solid var(--leaf); transform: rotate(-2deg); }
+  .hero-right .lede { color: var(--ink-2); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBD.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBD.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * filipino / HeroBD — lp-102's panaderia hero: a Space Mono kicker, an oversized
+ * DM Serif headline (italic pandesal accents), then a lower row pairing an
+ * art-directed bakery photo (left, with the "MAINIT · FRESH FROM 5AM" tag)
+ * against the lede + CTA pair (right). The photo slot keeps a warm gradient
+ * fallback until hero.image is set.
+ *
+ * Mirrors HeroAS's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Bakery photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,66px) 0 clamp(60px,7vw,100px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 400; font-size: clamp(44px,7.2vw,108px); line-height: 0.98; letter-spacing: -0.01em; margin: 0 0 34px; max-width: 17ch; color: var(--cream); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(em) { font-style: italic; color: var(--pandesal); }
+  .hero-headline :global(.em) { font-style: italic; color: var(--pandesal); }
+  .hero-headline :global(.em2) { font-style: italic; color: var(--brick); }
+  .hero-lower { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(30px,4vw,64px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 4px; background-color: var(--crust); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(217,154,78,.5), rgba(176,71,47,.4)); }
+  .hero-photo::after { content: "MAINIT · FRESH FROM 5AM"; position: absolute; left: 14px; bottom: 14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.12em; background: var(--pandesal); color: var(--crust); padding: 7px 12px; border-radius: 3px; }
+  .hero-right .lede { color: var(--mid-d); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBE.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBE.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * filipino / HeroBE — lp-111's barako hero: a Space Mono kicker, an oversized
+ * Zilla Slab headline, then a lower row pairing an art-directed roastery photo
+ * (left, with the "HERITAGE LIBERICA · SINCE 2013" gold tag) against the lede +
+ * CTA pair (right). The photo slot keeps a warm roasted-earth gradient fallback
+ * until hero.image is set.
+ *
+ * Mirrors HeroAS's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Roastery photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,66px) 0 clamp(60px,7vw,100px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 700; font-size: clamp(42px,6.4vw,98px); line-height: 1.0; letter-spacing: -0.02em; margin: 0 0 34px; max-width: 17ch; color: var(--bean); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em), .hero-headline :global(em) { font-style: normal; color: var(--barako); }
+  .hero-headline :global(.em2) { font-style: normal; color: var(--gold); }
+  .hero-lower { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(30px,4vw,64px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 4px; background-color: var(--oat-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(181,71,31,.42), rgba(36,24,18,.55)); }
+  .hero-photo::after { content: "HERITAGE LIBERICA · SINCE 2013"; position: absolute; left: 14px; bottom: 14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.12em; background: var(--gold); color: var(--bean); padding: 7px 12px; border-radius: 3px; }
+  .hero-right .lede { color: var(--mid); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.74; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBF.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBF.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * filipino / HeroBF — lp-117's grill hero: a Space Mono kicker, an oversized
+ * Archivo headline, then a lower row pairing an art-directed rotisserie photo
+ * (left, with the "OVER LIVE COALS" corner tag) against the lede + CTA pair
+ * (right). The photo slot keeps a warm ember gradient fallback until hero.image
+ * is set.
+ *
+ * Mirrors HeroBB's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Grill photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 900; font-size: clamp(40px,6.4vw,98px); line-height: 0.92; letter-spacing: -0.03em; margin: 0 0 32px; max-width: 17ch; color: var(--bone); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em) { color: var(--skin); }
+  .hero-headline :global(.em2) { color: var(--glaze); }
+  .hero-headline :global(.out) { -webkit-text-stroke: 1.5px var(--glaze); color: transparent; }
+  .hero-lower { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(30px,4vw,64px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 3px; background-color: var(--char-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(217,144,47,.42), rgba(194,69,31,.5)); }
+  .hero-photo::after { content: "OVER LIVE COALS · OFF THE SPIT"; position: absolute; left: 14px; bottom: 14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.12em; background: var(--glaze); color: var(--bone-2); padding: 7px 12px; border-radius: 2px; }
+  .hero-right .lede { color: var(--mid-d); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBG.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBG.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * filipino / HeroBG — lp-115's roadside hero: a Space Mono kicker, an oversized
+ * Archivo headline, then a lower row pairing an art-directed shop photo (left,
+ * with the "OPEN 24 HOURS · SINCE 2001" hazard tag) against the lede + CTA pair
+ * (right). The photo slot keeps a dark industrial gradient fallback until
+ * hero.image is set.
+ *
+ * Mirrors HeroBB's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Shop photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 900; font-size: clamp(40px,6.4vw,98px); line-height: 0.92; letter-spacing: -0.03em; margin: 0 0 32px; max-width: 17ch; color: var(--steel); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em) { color: var(--hazard); }
+  .hero-headline :global(.em2) { color: var(--alert); }
+  .hero-lower { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(30px,4vw,64px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 3px; background-color: var(--asphalt-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(245,197,24,.18), rgba(226,59,46,.16)); }
+  .hero-photo::after { content: "OPEN 24 HOURS · SINCE 2001"; position: absolute; left: 14px; bottom: 14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.12em; background: var(--hazard); color: var(--asphalt); padding: 7px 12px; border-radius: 2px; }
+  .hero-right .lede { color: var(--mid-d); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/hero/HeroBH.astro
+++ b/astro-site-template/src/components/filipino/hero/HeroBH.astro
@@ -1,0 +1,67 @@
+---
+/**
+ * filipino / HeroBH — lp-104's halo-halo hero: a Space Mono kicker, an oversized
+ * Unbounded headline in ube, then a lower row pairing an art-directed glass photo
+ * (left, with the "HALO, HALO · MIX IT" rotated tag) against the lede + CTA pair
+ * (right). The photo slot keeps a cold gradient fallback until hero.image is set.
+ *
+ * Mirrors HeroAS's content contract exactly (hero.headlineLines / sub / cta1 /
+ * cta2 / image) so admin edits + derived defaults feed it unchanged.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const hero = content.hero || {};
+const heroImage = hero.image || (hero.photos && hero.photos[0]) || (content.photos && content.photos[0]) || '';
+const kicker = hero.kicker || hero.locality || '';
+const headlineLines: string[] = Array.isArray(hero.headlineLines) && hero.headlineLines.length > 0
+  ? hero.headlineLines
+  : (hero.headline ? [hero.headline] : []);
+const sub = hero.sub || '';
+const cta1Text = hero.cta1?.text || '';
+const cta1Href = hero.cta1?.href || '#book';
+const cta2Text = hero.cta2?.text || '';
+const cta2Href = hero.cta2?.href || (layout.contact?.phone ? `tel:${String(layout.contact.phone).replace(/[^0-9+]/g, '')}` : '#services');
+---
+<section class="hero" aria-label="Hero">
+  <div class="wrap">
+    {kicker && <div class="kick hero-kick" data-field="hero.kicker">{kicker}</div>}
+    {headlineLines.length > 0 && (
+      <h1 class="hero-headline">
+        {headlineLines.map((line: string, i: number) => (
+          <span class="ln" data-field={`hero.headlineLines.${i}`} set:html={line}></span>
+        ))}
+      </h1>
+    )}
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <div class="ph" role="img" aria-label="Halo-halo photo" data-image-field="hero.image" style={heroImage ? `background-image:url('${heroImage}');` : ''}></div>
+      </div>
+      <div class="hero-right">
+        {sub && <p class="lede" data-field="hero.sub">{sub}</p>}
+        {(cta1Text || cta2Text) && (
+          <div class="hero-ctas">
+            {cta1Text && <a class="btn btn-primary" href={cta1Href} data-field="hero.cta1.text" data-href-field="hero.cta1.href">{cta1Text}</a>}
+            {cta2Text && <a class="btn btn-ghost" href={cta2Href} data-field="hero.cta2.text" data-href-field="hero.cta2.href">{cta2Text}</a>}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .hero { padding: clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px); }
+  .hero-kick { margin-bottom: 22px; }
+  .hero-headline { font-family: var(--disp); font-weight: 800; font-size: clamp(34px,5.4vw,80px); line-height: 1.0; letter-spacing: -0.03em; margin: 0 0 32px; max-width: 17ch; color: var(--ube); }
+  .hero-headline .ln { display: block; }
+  .hero-headline :global(.em) { color: var(--rosa); }
+  .hero-headline :global(.em2) { color: var(--mango); }
+  .hero-lower { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: clamp(30px,4vw,60px); align-items: end; }
+  .hero-photo { position: relative; }
+  .hero-photo .ph { width: 100%; aspect-ratio: 16/10; border-radius: 18px; border: 3px solid var(--ube); background-color: var(--paper-2); background-size: cover; background-position: center;
+    background-image: linear-gradient(150deg, rgba(232,178,62,.5), rgba(229,86,143,.35)); }
+  .hero-photo::after { content: "HALO, HALO · MIX IT · MADE TO ORDER"; position: absolute; left: -8px; top: -14px; font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.08em; background: var(--leche); color: var(--ink); padding: 8px 14px; border-radius: 999px; border: 2.5px solid var(--ube); transform: rotate(-3deg); }
+  .hero-right .lede { color: var(--ink-2); font-size: clamp(15px,1.5vw,17.5px); line-height: 1.72; max-width: 44ch; }
+  .hero-ctas { margin-top: 26px; display: flex; gap: 13px; flex-wrap: wrap; }
+  @media (max-width: 820px) { .hero-lower { grid-template-columns: 1fr; } }
+  @media (max-width: 520px) { .hero-ctas .btn { flex: 1 1 100%; justify-content: center; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBB.astro
+++ b/astro-site-template/src/components/filipino/how/HowBB.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBB — lp-101's "how it goes" steps: a four-up row of vermilion-
+ * topped cells, each a mono STEP label, a Bricolage title and a muted line.
+ * Reads content.how.steps (canonical `body`, legacy `desc`). Auto-hides when
+ * empty. Mirrors HowAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 3px solid var(--vermilion); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; color: var(--turq); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 23px; margin: 8px 0 8px; line-height: 1.04; letter-spacing: -0.015em; color: var(--ink); }
+  .how-grid p { color: var(--ink-2); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBC.astro
+++ b/astro-site-template/src/components/filipino/how/HowBC.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBC — lp-103's "how it goes" steps: a four-up row of tomato-topped
+ * cells, each a mono STEP label, an Archivo title and a muted line. Reads
+ * content.how.steps (canonical `body`, legacy `desc`). Auto-hides when empty.
+ * Mirrors HowAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 3px solid var(--tomato); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; color: var(--pandan); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 23px; margin: 8px 0 8px; line-height: 1.02; letter-spacing: -0.02em; color: var(--leaf); }
+  .how-grid p { color: var(--ink-2); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBD.astro
+++ b/astro-site-template/src/components/filipino/how/HowBD.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBD — lp-102's "how it goes" steps on the dark crust band: a
+ * four-up row of rule-topped cells, each a mono STEP label, a DM Serif title and
+ * a muted line. Reads content.how.steps (canonical `body`, legacy `desc`).
+ * Auto-hides when empty. Mirrors HowAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 1.5px solid var(--rule-d); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; color: var(--pandesal); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 400; font-size: 25px; margin: 8px 0 8px; line-height: 1.08; color: var(--cream); }
+  .how-grid p { color: var(--mid-d); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBE.astro
+++ b/astro-site-template/src/components/filipino/how/HowBE.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBE — lp-111's "how it goes" steps: a four-up row of rule-topped
+ * cells, each a leaf-green mono STEP label, a Zilla Slab title and a muted line.
+ * Reads content.how.steps (canonical `body`, legacy `desc`). Auto-hides when
+ * empty. Mirrors HowAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 1.5px solid var(--rule); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--leaf); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 24px; margin: 8px 0 8px; line-height: 1.1; letter-spacing: -0.01em; color: var(--ink); }
+  .how-grid p { color: var(--mid); margin: 0; font-size: 13.5px; line-height: 1.66; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBF.astro
+++ b/astro-site-template/src/components/filipino/how/HowBF.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBF — lp-117's "how it goes" steps: a four-up row of glaze-topped
+ * cells, each a mono STEP label, an Archivo title and a muted line. Reads
+ * content.how.steps (canonical `body`, legacy `desc`). Auto-hides when empty.
+ * Mirrors HowBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 3px solid var(--glaze); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--skin); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 22px; margin: 8px 0 8px; line-height: 1.02; letter-spacing: -0.025em; color: var(--bone); }
+  .how-grid p { color: var(--mid-d); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBG.astro
+++ b/astro-site-template/src/components/filipino/how/HowBG.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBG — lp-115's "how it goes" steps on asphalt: a four-up row of
+ * alert-topped cells, each a mono STEP label, an Archivo title and a muted line.
+ * Reads content.how.steps (canonical `body`, legacy `desc`). Auto-hides when
+ * empty. Mirrors HowBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 3px solid var(--alert); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--hazard); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 22px; margin: 8px 0 8px; line-height: 1.02; letter-spacing: -0.02em; color: var(--steel); }
+  .how-grid p { color: var(--mid-d); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/how/HowBH.astro
+++ b/astro-site-template/src/components/filipino/how/HowBH.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * filipino / HowBH — lp-104's "how it goes" steps: a four-up row of rosa-topped
+ * cells, each a mono STEP label, an Unbounded title and a muted line.
+ * Reads content.how.steps (canonical `body`, legacy `desc`). Auto-hides when
+ * empty. Mirrors HowAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const how = content.how || {};
+const headline = how.headline || '';
+const tag = how.tag || '';
+type Step = { title: string; body?: string; desc?: string; description?: string };
+const steps: Step[] = Array.isArray(how.steps) ? how.steps : (Array.isArray(how.items) ? how.items : []);
+---
+{steps.length > 0 && (
+  <section class="how" id="how">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 04 / How it goes</span>{tag && <span data-field="how.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="how.headline" set:html={headline}></h2>}
+      <ol class="how-grid">
+        {steps.map((step, i) => (
+          <li class="reveal" data-delay={String(Math.min(i, 3))}>
+            <span class="step">Step {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`how.steps.${i}.title`}>{step.title}</h3>
+            {(step.body ?? step.desc ?? step.description) && (
+              <p data-field={`how.steps.${i}.body`}>{step.body ?? step.desc ?? step.description}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+)}
+<style>
+  .how-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: clamp(20px,3vw,42px); padding: 0; margin: clamp(10px,2vw,20px) 0 0; }
+  .how-grid > li { list-style: none; border-top: 3px solid var(--rosa); padding-top: 16px; }
+  .how-grid .step { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; color: var(--mango); text-transform: uppercase; font-weight: 700; }
+  .how-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 20px; margin: 8px 0 8px; line-height: 1.08; letter-spacing: -0.02em; color: var(--ube); }
+  .how-grid p { color: var(--ink-2); margin: 0; font-size: 13.5px; line-height: 1.64; }
+  @media (max-width: 760px) { .how-grid { grid-template-columns: 1fr 1fr; } }
+  @media (max-width: 460px) { .how-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBB.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBB.astro
@@ -1,0 +1,136 @@
+---
+/**
+ * filipino / LocationBB — lp-101's "the corner": a marigold NAP card (name /
+ * address / phone / email / hours) beside a Leaflet map. Map strategy mirrors
+ * LocationAS / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBBInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Aisle 10 / The corner</span><span>Find the shop</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBBInitMap) window.__filipinoBBInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBBInitMap) { window.__filipinoBBInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--marigold); color: var(--ink); padding: 34px; border-radius: 14px; border: 3px solid var(--ink); }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 700; font-size: 22px; line-height: 1.26; letter-spacing: -0.015em; }
+  .nap .addr { font-weight: 700; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 600; color: var(--ink); }
+  .nap a:hover { color: var(--vermilion); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 2px solid rgba(35,26,36,0.24); padding-top: 18px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--ink-2); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--ink-2); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--ink); border-bottom: 2px solid var(--vermilion); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 14px; border: 3px solid var(--ink); position: relative; background: var(--paper-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(35,26,36,.06) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(35,26,36,.06) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#f3ead2,#e8dcbf); }
+  .map-face .road { position: absolute; background: rgba(26,156,142,.5); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--vermilion); border: 3px solid var(--paper-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(226,72,46,.6); border-radius: 50%; animation: pingBB 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBB { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--paper-2); background: var(--vermilion); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBC.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBC.astro
@@ -1,0 +1,136 @@
+---
+/**
+ * filipino / LocationBC — lp-103's "the kusina": a kalamansi NAP card (name /
+ * address / phone / email / hours) beside a Leaflet map. Map strategy mirrors
+ * LocationAS / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBCInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Tray 10 / The kusina</span><span>Dapitan St, Sampaloc</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBCInitMap) window.__filipinoBCInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBCInitMap) { window.__filipinoBCInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--kalamansi); color: var(--ink); padding: 34px; border-radius: 10px; border: 3px solid var(--leaf); }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 800; font-size: 21px; line-height: 1.26; letter-spacing: -0.02em; }
+  .nap .addr { font-weight: 800; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 600; color: var(--leaf-2); }
+  .nap a:hover { color: var(--tomato); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 2px solid rgba(32,41,31,0.24); padding-top: 18px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--leaf-2); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--leaf-2); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--leaf-2); border-bottom: 2px solid var(--tomato); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 10px; border: 3px solid var(--leaf); position: relative; background: var(--paper-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(32,41,31,.06) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(32,41,31,.06) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#f3ecd6,#e8dfc2); }
+  .map-face .road { position: absolute; background: rgba(79,143,74,.5); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--tomato); border: 3px solid var(--paper-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(214,60,42,.6); border-radius: 50%; animation: pingBC 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBC { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--paper-2); background: var(--tomato); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBD.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBD.astro
@@ -1,0 +1,137 @@
+---
+/**
+ * filipino / LocationBD — lp-102's "the corner": a cream NAP card (name /
+ * address / phone / email / hours) beside a Leaflet map. Map strategy mirrors
+ * LocationAS / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBDInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Batch 10 / The corner</span><span>Find the bakery</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBDInitMap) window.__filipinoBDInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBDInitMap) { window.__filipinoBDInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc { padding-top: 0; }
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); margin-top: clamp(28px,4vw,48px); }
+  .nap { background: var(--cream); color: var(--crust); padding: 34px; border-radius: 4px; }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 400; font-size: 24px; line-height: 1.26; }
+  .nap .addr { font-weight: 400; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; text-transform: none; font-weight: 500; color: #4d3826; }
+  .nap a:hover { color: var(--brick); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 1px solid rgba(42,28,18,0.16); padding-top: 18px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--mid); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--mid); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--crust); border-bottom: 2px solid var(--brick); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 4px; border: 1.5px solid rgba(244,231,207,0.2); position: relative; background: var(--cream-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(42,28,18,.06) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(42,28,18,.06) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#f3ead2,#e8dcbf); }
+  .map-face .road { position: absolute; background: rgba(176,71,47,.45); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--brick); border: 3px solid var(--cream); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(176,71,47,.6); border-radius: 50%; animation: pingBD 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBD { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--cream); background: var(--brick); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBE.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBE.astro
@@ -1,0 +1,136 @@
+---
+/**
+ * filipino / LocationBE — lp-111's "the roastery": a bean NAP card (name /
+ * address / phone / email / hours) beside a Leaflet map. Map strategy mirrors
+ * LocationAS / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBEInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Roast 10 / The roastery</span><span>C.M. Recto Ave, Lipa</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBEInitMap) window.__filipinoBEInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBEInitMap) { window.__filipinoBEInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--bean); color: var(--oat); padding: 34px; border-radius: 4px; }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 700; font-size: 22px; line-height: 1.3; }
+  .nap .addr { font-weight: 700; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 500; color: var(--mid-d); }
+  .nap a:hover { color: var(--gold); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 1px solid var(--rule-d); padding-top: 18px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--mid-d); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--mid-d); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--oat); border-bottom: 2px solid var(--barako); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 4px; border: 1.5px solid var(--bean); position: relative; background: var(--oat-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(44,33,25,.06) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(44,33,25,.06) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#f3ead2,#e8dcbf); }
+  .map-face .road { position: absolute; background: rgba(95,122,68,.5); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--barako); border: 3px solid var(--oat-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(181,71,31,.6); border-radius: 50%; animation: pingBE 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBE { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--oat-2); background: var(--barako); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBF.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBF.astro
@@ -1,0 +1,136 @@
+---
+/**
+ * filipino / LocationBF — lp-117's "the kanto": a bone NAP card (name / address
+ * / phone / email / hours) beside a Leaflet map. Map strategy mirrors
+ * LocationBB / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBFInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed dark map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Spit 10 / The kanto</span><span>Find the grill</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBFInitMap) window.__filipinoBFInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBFInitMap) { window.__filipinoBFInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--bone); color: var(--ink); padding: 34px; border-radius: 3px; }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 800; font-size: 20px; line-height: 1.26; letter-spacing: -0.025em; }
+  .nap .addr { font-weight: 800; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 500; color: #463a2e; }
+  .nap a:hover { color: var(--glaze); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 1px solid rgba(35,28,22,0.16); padding-top: 18px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--mid); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--mid); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--ink); border-bottom: 2px solid var(--glaze); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 3px; border: 1.5px solid rgba(246,239,227,0.2); position: relative; background: var(--char-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(246,239,227,.05) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(246,239,227,.05) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#1c1712,#12100d); }
+  .map-face .road { position: absolute; background: rgba(217,144,47,.45); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--glaze); border: 3px solid var(--bone-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(194,69,31,.6); border-radius: 50%; animation: pingBF 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBF { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--bone-2); background: var(--glaze); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBG.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBG.astro
@@ -1,0 +1,138 @@
+---
+/**
+ * filipino / LocationBG — lp-115's "the shop": a steel NAP card (name / address /
+ * phone / email / hours) beside a Leaflet map. Map strategy mirrors LocationBB /
+ * the reference model:
+ *   1. build-time lat/lng → window.__filipinoBGInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed dark map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Bay 10 / The shop</span><span>Find us</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBGInitMap) window.__filipinoBGInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBGInitMap) { window.__filipinoBGInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc { padding-top: 0; }
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--steel); color: var(--ink); padding: 34px; border-radius: 3px; }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 800; font-size: 20px; line-height: 1.26; letter-spacing: -0.02em; }
+  .nap .addr { font-weight: 800; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 500; color: #3b4148; }
+  .nap a:hover { color: var(--alert); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 1px solid rgba(30,34,38,0.16); padding-top: 18px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--mid); }
+  .hours .row strong { color: var(--go); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--mid); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--ink); border-bottom: 2px solid var(--alert); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 3px; border: 1.5px solid rgba(236,239,242,0.2); position: relative; background: var(--asphalt-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(236,239,242,.05) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(236,239,242,.05) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#1e2226,#0f1113); }
+  .map-face .road { position: absolute; background: rgba(245,197,24,.35); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--alert); border: 3px solid var(--steel-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(226,59,46,.6); border-radius: 50%; animation: pingBG 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBG { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--steel-2); background: var(--alert); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/location/LocationBH.astro
+++ b/astro-site-template/src/components/filipino/location/LocationBH.astro
@@ -1,0 +1,136 @@
+---
+/**
+ * filipino / LocationBH — lp-104's "the haus": a leche NAP card (name / address
+ * / phone / email / hours) beside a Leaflet map. Map strategy mirrors LocationAS
+ * / the reference model:
+ *   1. build-time lat/lng → window.__filipinoBHInitMap(lat, lng, label)
+ *   2. else any address   → client-side Nominatim lookup, then Leaflet
+ *   3. else               → the designed map-face + pinging pin fallback
+ * The designed face lives inside #map until Leaflet mounts (the boot clears #map
+ * before drawing tiles). Reads content.location.* + layout.contact.
+ */
+interface Props { content: any; layout: any; }
+const { content, layout } = Astro.props;
+const loc = content.location || {};
+const headline = loc.headline || '';
+const sub = loc.sub || '';
+const brand = (content as any).footer?.brand || layout.businessName || '';
+const address = loc.address || layout.contact?.address || '';
+const addressLines = address ? address.split('\n') : [];
+const phone = loc.phone || layout.contact?.phone || '';
+const phoneDigits = phone.replace(/[^0-9+]/g, '');
+const email = loc.email || layout.contact?.email || '';
+const hours: Array<{ day: string; time: string }> = Array.isArray(loc.hours)
+  ? loc.hours
+  : (Array.isArray((content as any).footer?.hours) ? (content as any).footer.hours : []);
+const dirText = loc.directions?.text || '';
+const dirHref = loc.directions?.href || (address
+  ? `https://maps.google.com/?q=${encodeURIComponent(address.replace(/\n/g, ' '))}`
+  : '#');
+const lat = loc.lat != null ? Number(loc.lat) : (layout.contact?.lat != null ? Number(layout.contact.lat) : null);
+const lng = loc.lng != null ? Number(loc.lng) : (layout.contact?.lng != null ? Number(layout.contact.lng) : null);
+const label = layout.businessName || 'Our location';
+const mapAria = `Map showing ${label}`;
+const hasCoords = lat != null && lng != null && !isNaN(lat as number) && !isNaN(lng as number);
+const hasAddress = !!address;
+---
+<section class="loc" id="location">
+  <div class="wrap">
+    <div class="sw-head"><span>Layer 10 / The haus</span><span>Find the haus</span></div>
+    {headline && <h2 class="h2 reveal" data-field="location.headline" set:html={headline}></h2>}
+    {sub && <p class="loc-sub body reveal" data-field="location.sub">{sub}</p>}
+    <div class="loc-grid reveal">
+      <div class="nap">
+        <address>
+          {brand && <><strong data-field="footer.brand">{brand}</strong><br /></>}
+          {address && (
+            <span class="addr" data-field="location.address">
+              {addressLines.map((line: string, i: number) => (<>{i > 0 && <br />}{line}</>))}
+            </span>
+          )}
+          {(brand || address) && <br />}
+          {phone && <><a href={`tel:${phoneDigits}`} data-field="location.phone">{phone}</a><br /></>}
+          {email && <a href={`mailto:${email}`} data-field="location.email">{email}</a>}
+        </address>
+        {(hours.length > 0 || dirText) && (
+          <div class="hours">
+            {hours.map((r: any, i: number) => (
+              <div class="row"><span data-field={`location.hours.${i}.day`}>{r.day}</span><span data-field={`location.hours.${i}.time`}>{r.time}</span></div>
+            ))}
+            {dirText && <p class="gbp-note"><a class="dir" href={dirHref} target="_blank" rel="noopener noreferrer" data-field="location.directions.text" data-href-field="location.directions.href">{dirText}</a></p>}
+          </div>
+        )}
+      </div>
+      <div class="map-frame">
+        <div id="map" role="img" aria-label={mapAria}>
+          <div class="map-face" aria-hidden="true">
+            <div class="road" style="top:47%;left:0;right:0;height:6px;"></div>
+            <div class="road" style="top:0;bottom:0;left:44%;width:5px;"></div>
+            <div class="road" style="top:74%;left:0;right:0;height:3px;opacity:.6;"></div>
+          </div>
+          <div class="map-pin" aria-hidden="true"><div class="dot"></div>{label && <div class="mlbl">{label}</div>}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{hasCoords && (
+  <script is:inline define:vars={{ lat, lng, label }}>
+    (function init() {
+      if (window.__filipinoBHInitMap) window.__filipinoBHInitMap(lat, lng, label);
+      else setTimeout(init, 80);
+    })();
+  </script>
+)}
+{!hasCoords && hasAddress && (
+  <script is:inline define:vars={{ address, label }}>
+    (function geocodeThenInit() {
+      var attempt = 0;
+      function tryInit(lat, lng) {
+        if (window.__filipinoBHInitMap) { window.__filipinoBHInitMap(lat, lng, label); }
+        else if (attempt++ < 25) { setTimeout(function () { tryInit(lat, lng); }, 80); }
+      }
+      try {
+        var query = encodeURIComponent(String(address).replace(/\n/g, ', '));
+        var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + query;
+        fetch(url, { headers: { 'Accept-Language': 'en' } })
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (results) {
+            if (!Array.isArray(results) || results.length === 0) return;
+            var lat = parseFloat(results[0].lat);
+            var lng = parseFloat(results[0].lon);
+            if (isNaN(lat) || isNaN(lng)) return;
+            tryInit(lat, lng);
+          })
+          .catch(function () { /* keep the designed map-face fallback */ });
+      } catch (e) { /* never block render */ }
+    })();
+  </script>
+)}
+<style>
+  .loc-sub { max-width: 46ch; margin: -8px 0 clamp(24px,3.5vw,40px); }
+  .loc-grid { display: grid; grid-template-columns: 1fr 1.4fr; gap: clamp(24px,3.5vw,48px); }
+  .nap { background: var(--leche); color: var(--ink); padding: 34px; border-radius: 18px; border: 3px solid var(--ube); }
+  .nap address { font-style: normal; font-family: var(--disp); font-weight: 700; font-size: 19px; line-height: 1.3; letter-spacing: -0.02em; }
+  .nap .addr { font-weight: 700; }
+  .nap a { text-decoration: none; font-family: var(--sans); font-size: 15px; font-weight: 600; color: var(--ube-2); }
+  .nap a:hover { color: var(--rosa); }
+  .hours { font-family: var(--mono); font-size: 10.5px; margin-top: 24px; border-top: 2px solid rgba(44,28,51,0.24); padding-top: 18px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; }
+  .hours .row { display: flex; justify-content: space-between; padding: 4px 0; color: var(--ube-2); }
+  .hours .gbp-note { font-family: var(--sans); font-size: 12.5px; color: var(--ube-2); margin: 14px 0 0; line-height: 1.62; letter-spacing: 0; text-transform: none; font-weight: 400; }
+  .hours .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; font-weight: 700; color: var(--ube-2); border-bottom: 2px solid var(--rosa); }
+  .map-frame { min-height: 380px; overflow: hidden; border-radius: 18px; border: 3px solid var(--ube); position: relative; background: var(--paper-2); }
+  #map { position: absolute; inset: 0; z-index: 0; min-height: 380px; }
+  .map-face { position: absolute; inset: 0; background:
+    repeating-linear-gradient(0deg,rgba(44,28,51,.06) 0 1px,transparent 1px 34px),
+    repeating-linear-gradient(90deg,rgba(44,28,51,.06) 0 1px,transparent 1px 34px),
+    linear-gradient(160deg,#f3e7ef,#e8d7e6); }
+  .map-face .road { position: absolute; background: rgba(91,42,134,.4); }
+  .map-pin { position: absolute; top: 46%; left: 50%; transform: translate(-50%,-100%); z-index: 3; text-align: center; }
+  .map-pin .dot { width: 16px; height: 16px; background: var(--ube); border: 3px solid var(--paper-2); border-radius: 50%; margin: 0 auto; position: relative; }
+  .map-pin .dot::after { content: ""; position: absolute; inset: -10px; border: 2px solid rgba(91,42,134,.6); border-radius: 50%; animation: pingBH 2.6s ease-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .map-pin .dot::after { animation: none; } }
+  @keyframes pingBH { 0% { transform: scale(.6); opacity: .9; } 100% { transform: scale(2.8); opacity: 0; } }
+  .map-pin .mlbl { margin-top: 10px; font-family: var(--mono); font-size: 11px; color: var(--paper-2); background: var(--ube); padding: 5px 9px; }
+  @media (max-width: 820px) { .loc-grid { grid-template-columns: 1fr; } .map-frame { min-height: 320px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBB.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBB.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * filipino / ServicesBB — lp-101's "what we carry" ledger: a bordered stack of
+ * rows, each a mono index (No. NN), a Bricolage title and a muted description,
+ * that shift on hover. Reads content.services.items ({title, desc}); auto-hides
+ * when empty. Mirrors ServicesAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 02 / What we carry</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .svc-rows { border-top: 2px solid var(--ink); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid var(--rule); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(240,168,33,0.16); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--turq); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 700; font-size: clamp(24px,2.6vw,34px); margin: 0; line-height: 1.0; letter-spacing: -0.015em; color: var(--ink); }
+  .svc-row p { color: var(--ink-2); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBC.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBC.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * filipino / ServicesBC — lp-103's "what's cooking" ledger: a leaf-bordered stack
+ * of rows, each a mono index (No. NN), an Archivo title and a muted description,
+ * that shift on hover. Reads content.services.items ({title, desc}); auto-hides
+ * when empty. Mirrors ServicesAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 02 / What's cooking</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .svc-rows { border-top: 2px solid var(--leaf); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid var(--rule); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(214,60,42,0.1); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--pandan); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 800; font-size: clamp(24px,2.6vw,34px); margin: 0; line-height: 1.0; letter-spacing: -0.02em; color: var(--leaf); }
+  .svc-row p { color: var(--ink-2); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBD.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBD.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / ServicesBD — lp-102's "what we bake" ledger on the dark crust band:
+ * a bordered stack of rows, each a mono index (No. NN), a DM Serif title and a
+ * muted description, that shift on hover. Reads content.services.items
+ * ({title, desc}); auto-hides when empty. Mirrors ServicesAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 02 / What we bake</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .services { background: var(--crust); }
+  .svc-rows { border-top: 1.5px solid var(--rule-d); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid rgba(244,231,207,0.12); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(176,71,47,0.12); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; color: var(--pandesal); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 400; font-size: clamp(25px,2.7vw,36px); margin: 0; line-height: 1.04; color: var(--cream); }
+  .svc-row p { color: var(--mid-d); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBE.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBE.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * filipino / ServicesBE — lp-111's "the coffee" ledger: a bean-topped stack of
+ * rows, each a leaf-green mono index (No. NN), a Zilla Slab title and a muted
+ * description, that shift on hover into a barako wash. Reads content.services.items
+ * ({title, desc}); auto-hides when empty. Mirrors ServicesAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 02 / The coffee</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .svc-rows { border-top: 1.5px solid var(--bean); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid var(--rule); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(181,71,31,0.1); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.09em; color: var(--leaf); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 700; font-size: clamp(24px,2.6vw,34px); margin: 0; line-height: 1.06; letter-spacing: -0.01em; color: var(--ink); }
+  .svc-row p { color: var(--mid); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBF.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBF.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * filipino / ServicesBF — lp-117's "off the grill" ledger: a bordered stack of
+ * rows, each a mono index (No. NN), an Archivo title and a muted description,
+ * that shift on hover over a glaze wash. Reads content.services.items ({title,
+ * desc}); auto-hides when empty. Mirrors ServicesBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 02 / Off the grill</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .svc-rows { border-top: 1.5px solid var(--rule-d); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid rgba(246,239,227,0.12); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(194,69,31,0.12); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; color: var(--skin); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 800; font-size: clamp(24px,2.6vw,34px); margin: 0; line-height: 1.0; letter-spacing: -0.025em; color: var(--bone); }
+  .svc-row p { color: var(--mid-d); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBG.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBG.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / ServicesBG — lp-115's "what we fix" ledger on asphalt: a bordered
+ * stack of rows, each a mono index (No. NN), an Archivo title and a muted
+ * description, that shift + flash alert-red on hover. Reads content.services.items
+ * ({title, desc}); auto-hides when empty. Mirrors ServicesBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 02 / What we fix</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .services { background: var(--asphalt); }
+  .svc-rows { border-top: 1.5px solid var(--rule-d); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid rgba(236,239,242,0.12); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(226,59,46,0.12); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; color: var(--hazard); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 800; font-size: clamp(24px,2.6vw,34px); margin: 0; line-height: 1.0; letter-spacing: -0.02em; color: var(--steel); }
+  .svc-row p { color: var(--mid-d); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/services/ServicesBH.astro
+++ b/astro-site-template/src/components/filipino/services/ServicesBH.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * filipino / ServicesBH — lp-104's "what's in the glass" ledger: a bordered stack
+ * of rows, each a mono index (No. NN), an Unbounded title and a muted description,
+ * that shift on hover. Reads content.services.items ({title, desc}); auto-hides
+ * when empty. Mirrors ServicesAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const services = content.services || {};
+const tag = services.tag || '';
+const headline = services.headline || '';
+const sub = services.sub || '';
+type Item = { title: string; desc?: string; price?: string; duration?: string; tag?: string };
+const items: Item[] = Array.isArray(services.items) ? services.items : (Array.isArray(services) ? services : []);
+---
+{items.length > 0 && (
+  <section class="services" id="services">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 02 / The glass</span>{tag && <span data-field="services.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="services.headline" set:html={headline}></h2>}
+      <div class="svc-rows">
+        {items.map((item, i) => (
+          <div class="svc-row reveal" data-delay={String(i % 3)}>
+            <span class="no">No. {String(i + 1).padStart(2, '0')}</span>
+            <h3 data-field={`services.items.${i}.title`}>{item.title}</h3>
+            {item.desc && <p data-field={`services.items.${i}.desc`}>{item.desc}</p>}
+          </div>
+        ))}
+      </div>
+      {sub && <p class="svc-note body reveal" data-field="services.sub">{sub}</p>}
+    </div>
+  </section>
+)}
+<style>
+  .svc-rows { border-top: 2px solid var(--ube); }
+  .svc-row { display: grid; grid-template-columns: 110px 1fr 1.5fr; gap: clamp(18px,3vw,46px); padding: 28px 0; border-bottom: 1px solid var(--rule); align-items: baseline; transition: 0.15s; }
+  .svc-row:hover { background: rgba(229,86,143,0.1); padding-left: 12px; }
+  .svc-row .no { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--mango); text-transform: uppercase; font-weight: 700; }
+  .svc-row h3 { font-family: var(--disp); font-weight: 700; font-size: clamp(21px,2.3vw,30px); margin: 0; line-height: 1.06; letter-spacing: -0.02em; color: var(--ube); }
+  .svc-row p { color: var(--ink-2); margin: 0; font-size: 15px; line-height: 1.66; }
+  .svc-note { margin-top: 22px; max-width: 60ch; }
+  @media (max-width: 760px) { .svc-row { grid-template-columns: 1fr; gap: 8px; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBB.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBB.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBB — lp-101's "from the street" band on ink: the first
+ * quote runs large in Bricolage with a marigold attribution, the rest sit below
+ * in a two-up sub-grid. Reads content.testimonials.items ({quote, who/name,
+ * role/context}). Auto-hides when empty. Mirrors TestimonialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 05 / From the street</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--ink); color: var(--paper); }
+  .testimonials .sw-head { color: rgba(251,244,230,0.55); border-color: rgba(251,244,230,0.22); }
+  .t-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(28px,3.7vw,52px); line-height: 1.06; max-width: 26ch; margin: 0 0 24px; letter-spacing: -0.02em; color: var(--paper); }
+  .t-quote :global(em) { font-style: normal; color: var(--marigold); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--marigold); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 2px solid rgba(251,244,230,0.22); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: rgba(251,244,230,0.82); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(251,244,230,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBC.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBC.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBC — lp-103's "from the tables" band on ink: the first
+ * quote runs large in Archivo with a kalamansi attribution, the rest sit below
+ * in a two-up sub-grid. Reads content.testimonials.items ({quote, who/name,
+ * role/context}). Auto-hides when empty. Mirrors TestimonialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 05 / From the tables</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--ink); color: var(--paper); }
+  .testimonials .sw-head { color: rgba(250,243,226,0.55); border-color: rgba(250,243,226,0.22); }
+  .t-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(28px,3.7vw,52px); line-height: 1.02; max-width: 26ch; margin: 0 0 24px; letter-spacing: -0.025em; color: var(--paper); }
+  .t-quote :global(em) { font-style: normal; color: var(--kalamansi); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--kalamansi); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 2px solid rgba(250,243,226,0.22); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: rgba(250,243,226,0.82); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(250,243,226,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBD.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBD.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBD — lp-102's "from the queue" band on deep crust: the
+ * first quote runs large in DM Serif with a pandesal attribution, the rest sit
+ * below in a two-up sub-grid. Reads content.testimonials.items ({quote, who/name,
+ * role/context}). Auto-hides when empty. Mirrors TestimonialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 05 / From the queue</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: #241811; color: var(--cream); }
+  .testimonials .sw-head { color: var(--mid-d); border-color: var(--rule-d); }
+  .t-quote { font-family: var(--disp); font-weight: 400; font-size: clamp(30px,4vw,56px); line-height: 1.1; max-width: 26ch; margin: 0 0 24px; color: var(--cream); }
+  .t-quote :global(em) { font-style: italic; color: var(--pandesal); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 1.5px solid var(--rule-d); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: var(--mid-d); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBE.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBE.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBE — lp-111's "from the cup" band on bean-darkest: the
+ * first quote runs large in Zilla Slab with a gold attribution, the rest sit
+ * below in a two-up sub-grid. Reads content.testimonials.items ({quote, who/name,
+ * role/context}). Auto-hides when empty. Mirrors TestimonialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 05 / From the cup</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--bean-2); color: var(--oat); }
+  .testimonials .sw-head { color: var(--mid-d); border-color: var(--rule-d); }
+  .t-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(28px,3.7vw,54px); line-height: 1.1; max-width: 26ch; margin: 0 0 24px; letter-spacing: -0.01em; color: var(--oat); }
+  .t-quote :global(em) { font-style: normal; color: var(--gold); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--gold); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 1.5px solid var(--rule-d); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.74; margin: 0 0 12px; color: var(--mid-d); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBF.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBF.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBF — lp-117's "from the kanto" band on the darkest
+ * charcoal: the first quote runs large in Archivo with a skin attribution, the
+ * rest sit below in a two-up sub-grid. Reads content.testimonials.items
+ * ({quote, who/name, role/context}). Auto-hides when empty. Mirrors
+ * TestimonialsBB's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 05 / From the kanto</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--char-2); color: var(--bone); }
+  .t-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(28px,3.7vw,54px); line-height: 1.04; max-width: 25ch; margin: 0 0 24px; letter-spacing: -0.03em; color: var(--bone); }
+  .t-quote :global(em) { font-style: normal; color: var(--skin); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 1.5px solid var(--rule-d); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: var(--mid-d); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBG.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBG.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBG — lp-115's "from the roadside" band on the darkest
+ * asphalt: the first quote runs large in Archivo with a hazard attribution, the
+ * rest sit below in a two-up sub-grid. Reads content.testimonials.items ({quote,
+ * who/name, role/context}). Auto-hides when empty. Mirrors TestimonialsBB.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 05 / From the roadside</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--asphalt-2); color: var(--steel); }
+  .testimonials .sw-head { color: var(--mid-d); border-color: var(--rule-d); }
+  .t-quote { font-family: var(--disp); font-weight: 800; font-size: clamp(28px,3.7vw,54px); line-height: 1.04; max-width: 25ch; margin: 0 0 24px; letter-spacing: -0.025em; color: var(--steel); }
+  .t-quote :global(em) { font-style: normal; color: var(--hazard); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 1.5px solid var(--rule-d); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: var(--mid-d); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mid-d); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/testimonials/TestimonialsBH.astro
+++ b/astro-site-template/src/components/filipino/testimonials/TestimonialsBH.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * filipino / TestimonialsBH — lp-104's "from the spoon" band on deep ube: the
+ * first quote runs large in Unbounded with a leche attribution, the rest sit
+ * below in a two-up sub-grid. Reads content.testimonials.items ({quote, who/name,
+ * role/context}). Auto-hides when empty. Mirrors TestimonialsAS's contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const test = content.testimonials || {};
+const tag = test.tag || '';
+type Item = { quote: string; who?: string; role?: string; author?: string; name?: string; context?: string };
+const items: Item[] = Array.isArray(test.items) ? test.items : (Array.isArray(test) ? test : []);
+const named = (it: Item) => ({ who: it.who ?? it.author ?? it.name, role: it.role ?? it.context });
+const lead = items[0];
+const leadNamed = lead ? named(lead) : { who: undefined, role: undefined };
+const rest = items.slice(1);
+---
+{items.length > 0 && (
+  <section class="testimonials" id="reviews">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 05 / From the spoon</span>{tag && <span data-field="testimonials.tag">{tag}</span>}</div>
+      <blockquote class="t-quote reveal" data-field="testimonials.items.0.quote">“{lead.quote}”</blockquote>
+      {(leadNamed.who || leadNamed.role) && (
+        <div class="t-attr reveal">
+          {leadNamed.who && <span data-field="testimonials.items.0.who">{leadNamed.who}</span>}
+          {leadNamed.role && <span data-field="testimonials.items.0.role"> — {leadNamed.role}</span>}
+        </div>
+      )}
+      {rest.length > 0 && (
+        <div class="t-sub reveal">
+          {rest.map((item, j) => {
+            const n = named(item);
+            const idx = j + 1;
+            return (
+              <figure>
+                <blockquote data-field={`testimonials.items.${idx}.quote`}>“{item.quote}”</blockquote>
+                {(n.who || n.role) && (
+                  <figcaption>
+                    {n.who && <span data-field={`testimonials.items.${idx}.who`}>{n.who}</span>}
+                    {n.role && <span data-field={`testimonials.items.${idx}.role`}> — {n.role}</span>}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </section>
+)}
+<style>
+  .testimonials { background: var(--ube-2); color: var(--paper); }
+  .testimonials .sw-head { color: rgba(251,241,245,0.55); border-color: rgba(251,241,245,0.22); }
+  .t-quote { font-family: var(--disp); font-weight: 700; font-size: clamp(24px,3.2vw,44px); line-height: 1.14; max-width: 26ch; margin: 0 0 24px; letter-spacing: -0.025em; color: var(--paper); }
+  .t-quote :global(em) { font-style: normal; color: var(--leche); }
+  .t-attr { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--leche); margin-bottom: clamp(38px,5vw,60px); font-weight: 700; }
+  .t-sub { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(28px,5vw,76px); border-top: 2px solid rgba(251,241,245,0.22); padding-top: 34px; }
+  .t-sub figure { margin: 0; }
+  .t-sub blockquote { font-size: 15.5px; line-height: 1.72; margin: 0 0 12px; color: rgba(251,241,245,0.82); }
+  .t-sub figcaption { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(251,241,245,0.6); font-weight: 700; }
+  @media (max-width: 760px) { .t-sub { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBB.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBB.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBB — lp-101's turquoise credibility strip under the hero: a
+ * single mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 1998" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--turq); color: var(--paper-2); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,250,240,0.92); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: #fff; }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBC.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBC.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBC — lp-103's leaf-green credibility strip under the hero: a
+ * single mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 2003" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--leaf); color: var(--paper-2); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,250,239,0.9); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: #fff; }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBD.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBD.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBD — lp-102's pandesal credibility strip under the hero: a
+ * single mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 1975" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--pandesal); color: var(--crust); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(42,28,18,0.82); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: var(--crust); }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBE.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBE.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBE — lp-111's bean credibility strip under the hero: a single
+ * mono row of short trust statements split across the dark band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 2013" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--bean); color: var(--oat-2); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(247,239,223,0.86); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: var(--gold); }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBF.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBF.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBF — lp-117's gold credibility strip under the hero: a single
+ * mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "Since 2008" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--skin); color: var(--char); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(23,19,16,0.82); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: var(--char); }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBG.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBG.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBG — lp-115's hazard-yellow credibility strip under the hero: a
+ * single mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 2001" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--hazard); color: var(--asphalt); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(25,27,30,0.82); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: var(--asphalt); }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/trust/TrustBH.astro
+++ b/astro-site-template/src/components/filipino/trust/TrustBH.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * filipino / TrustBH — lp-104's ube credibility strip under the hero: a single
+ * mono row of short trust statements split across the band. Reads
+ * content.trust.cells ({num, label}); renders num inline before the label when
+ * present so a "★★★★★" / "Since 2016" cell still reads. Auto-hides when empty.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const trust = content.trust || {};
+const cells: Array<{ num?: string; label?: string }> = Array.isArray(trust.cells) ? trust.cells : (Array.isArray(trust) ? trust : []);
+---
+{cells.length > 0 && (
+  <section class="trust">
+    <div class="wrap row">
+      {cells.map((cell, i) => (
+        <span class="cell">
+          {cell.num && <em class="n" data-field={`trust.cells.${i}.num`} set:html={cell.num}></em>}
+          {cell.label && <span class="t" data-field={`trust.cells.${i}.label`}>{cell.label}</span>}
+        </span>
+      ))}
+    </div>
+  </section>
+)}
+<style>
+  .trust { background: var(--ube); color: var(--paper-2); padding: 0; }
+  .trust .row { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; padding: 15px 0; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255,248,251,0.9); font-weight: 700; }
+  .trust .cell { display: inline-flex; gap: 8px; align-items: baseline; }
+  .trust .cell .n { font-style: normal; color: #fff; }
+  @media (max-width: 640px) { .trust .row { justify-content: flex-start; gap: 14px 22px; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBB.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBB.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBB — lp-101's "why the window works" band on grape: a three-up
+ * grid of reasons, each a marigold mono index, a Bricolage title and a light body
+ * line. Reads content.why.items (canonical `body`, legacy `desc`). Auto-hides
+ * when empty. Mirrors WhyAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Aisle 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--grape); color: var(--paper-2); }
+  .why .sw-head { color: rgba(255,250,240,0.7); border-color: rgba(255,250,240,0.24); }
+  .why .h2 { color: var(--paper-2); }
+  .why .h2 :global(em) { color: var(--marigold); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--marigold); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 27px; margin: 0 0 10px; line-height: 1.02; letter-spacing: -0.015em; color: var(--paper-2); }
+  .why-grid p { color: rgba(255,250,240,0.86); margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBC.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBC.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBC — lp-103's "the difference" band on leaf-green: a three-up
+ * grid of reasons, each a kalamansi mono index, an Archivo title and a light body
+ * line. Reads content.why.items (canonical `body`, legacy `desc`). Auto-hides
+ * when empty. Mirrors WhyAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Tray 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--leaf); color: var(--paper-2); }
+  .why .sw-head { color: rgba(255,250,239,0.7); border-color: rgba(255,250,239,0.24); }
+  .why .h2 { color: var(--paper-2); }
+  .why .h2 :global(em) { color: var(--kalamansi); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--kalamansi); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 27px; margin: 0 0 10px; line-height: 1.0; letter-spacing: -0.02em; color: var(--paper-2); }
+  .why-grid p { color: rgba(255,250,239,0.86); margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBD.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBD.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBD — lp-102's "why it still tastes right" band on cream: a
+ * three-up grid of reasons, each a brick mono index, a DM Serif title and a dark
+ * body line. Reads content.why.items (canonical `body`, legacy `desc`). Auto-hides
+ * when empty. Mirrors WhyAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Batch 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--cream); color: var(--crust); }
+  .why .sw-head { color: var(--mid); border-color: rgba(42,28,18,0.16); }
+  .why .h2 { color: var(--crust); }
+  .why .h2 :global(em) { color: var(--brick); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--brick); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 400; font-size: 29px; margin: 0 0 10px; line-height: 1.06; color: var(--crust); }
+  .why-grid p { color: #4d3826; margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBE.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBE.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBE — lp-111's "the difference" band on bean-dark: a three-up
+ * grid of reasons, each a gold mono index, a Zilla Slab title and a light body
+ * line. Reads content.why.items (canonical `body`, legacy `desc`). Auto-hides
+ * when empty. Mirrors WhyAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Roast 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--bean); color: var(--oat); }
+  .why .sw-head { color: var(--mid-d); border-color: var(--rule-d); }
+  .why .h2 { color: var(--oat); }
+  .why .h2 :global(em) { color: var(--gold); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; color: var(--gold); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 28px; margin: 0 0 10px; line-height: 1.1; letter-spacing: -0.01em; color: var(--oat); }
+  .why-grid p { color: var(--mid-d); margin: 0; font-size: 14.5px; line-height: 1.72; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBF.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBF.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBF — lp-117's "why the skin crackles" band on the light bone
+ * ground: a three-up grid of reasons, each a glaze mono index, an Archivo title
+ * and a dark body line. Reads content.why.items (canonical `body`, legacy
+ * `desc`). Auto-hides when empty. Mirrors WhyBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Spit 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--bone); color: var(--ink); }
+  .why .sw-head { color: var(--mid); border-color: rgba(35,28,22,0.16); }
+  .why .h2 { color: var(--ink); }
+  .why .h2 :global(em) { color: var(--glaze); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; color: var(--glaze); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 27px; margin: 0 0 10px; line-height: 1.0; letter-spacing: -0.025em; color: var(--ink); }
+  .why-grid p { color: #463a2e; margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBG.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBG.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBG — lp-115's "why you save our number" band on a steel daylight
+ * bay: a three-up grid of reasons, each an alert-red mono index, an Archivo title
+ * and a dark body line. Reads content.why.items (canonical `body`, legacy `desc`).
+ * Auto-hides when empty. Mirrors WhyBB's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Bay 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--steel); color: var(--ink); }
+  .why .sw-head { color: var(--mid); border-color: rgba(30,34,38,0.16); }
+  .why .h2 { color: var(--ink); }
+  .why .h2 :global(em) { color: var(--alert); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; color: var(--alert); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 800; font-size: 27px; margin: 0 0 10px; line-height: 1.0; letter-spacing: -0.02em; color: var(--ink); }
+  .why-grid p { color: #3b4148; margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/components/filipino/why/WhyBH.astro
+++ b/astro-site-template/src/components/filipino/why/WhyBH.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * filipino / WhyBH — lp-104's "why ours is different" band on ube: a three-up
+ * grid of reasons, each a leche mono index, an Unbounded title and a light body
+ * line. Reads content.why.items (canonical `body`, legacy `desc`). Auto-hides
+ * when empty. Mirrors WhyAS's content contract.
+ */
+interface Props { content: any; }
+const { content } = Astro.props;
+const why = content.why || {};
+const headline = why.headline || '';
+const tag = why.tag || '';
+const items: Array<{ title: string; body?: string; desc?: string; description?: string }> =
+  Array.isArray(why.items) ? why.items : [];
+---
+{items.length > 0 && (
+  <section class="why">
+    <div class="wrap">
+      <div class="sw-head"><span>Layer 03 / The difference</span>{tag && <span data-field="why.tag">{tag}</span>}</div>
+      {headline && <h2 class="h2 reveal" data-field="why.headline" set:html={headline}></h2>}
+      <div class="why-grid">
+        {items.map((item, i) => (
+          <div class="reveal" data-delay={String(i % 3)}>
+            <span class="no">{String(i + 1).padStart(2, '0')} / {String(items.length).padStart(2, '0')}</span>
+            <h3 data-field={`why.items.${i}.title`}>{item.title}</h3>
+            {(item.body ?? item.desc ?? item.description) && (
+              <p data-field={`why.items.${i}.body`}>{item.body ?? item.desc ?? item.description}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+<style>
+  .why { background: var(--ube); color: var(--paper-2); }
+  .why .sw-head { color: rgba(255,248,251,0.7); border-color: rgba(255,248,251,0.24); }
+  .why .h2 { color: var(--paper-2); }
+  .why .h2 :global(em) { color: var(--leche); }
+  .why-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: clamp(26px,4vw,60px); margin-top: clamp(10px,2vw,20px); }
+  .why-grid .no { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; color: var(--leche); display: block; margin-bottom: 14px; text-transform: uppercase; font-weight: 700; }
+  .why-grid h3 { font-family: var(--disp); font-weight: 700; font-size: 23px; margin: 0 0 10px; line-height: 1.08; letter-spacing: -0.02em; color: var(--paper-2); }
+  .why-grid p { color: rgba(255,248,251,0.86); margin: 0; font-size: 14.5px; line-height: 1.7; }
+  @media (max-width: 760px) { .why-grid { grid-template-columns: 1fr; } }
+</style>

--- a/astro-site-template/src/pages/index.astro
+++ b/astro-site-template/src/pages/index.astro
@@ -112,6 +112,7 @@ import PageAX from '../components/layouts/PageAX.astro';
 import PageAY from '../components/layouts/PageAY.astro';
 import PageAZ from '../components/layouts/PageAZ.astro';
 import PageBA from '../components/layouts/PageBA.astro';
+import PageBB from '../components/filipino/PageBB.astro';
 import siteData from '../data/site-data.json';
 
 // Live-editor support: template / colour / font / hidden-sections can be driven
@@ -162,10 +163,12 @@ const servicesMatch = /^services:(AS)$/.exec(heroStyle);
 const servicesLetter = servicesMatch ? servicesMatch[1] : null;
 const layoutsMatch = /^layouts:(A[V-Z]|BA)$/.exec(heroStyle);
 const layoutsLetter = layoutsMatch ? layoutsMatch[1] : null;
+const filipinoMatch = /^filipino:(BB)$/.exec(heroStyle);
+const filipinoLetter = filipinoMatch ? filipinoMatch[1] : null;
 const anyLetter = genericLetter || barbershopLetter || salonspaLetter
   || autoshopLetter || restaurantLetter || shirtstoreLetter
   || retailLetter || medicalLetter || fitnessLetter || educationLetter || tradesLetter || foodcraftLetter
-  || servicesLetter || layoutsLetter;
+  || servicesLetter || layoutsLetter || filipinoLetter;
 ---
 
 {genericLetter === 'A' && <PageA siteData={data} />}
@@ -221,6 +224,7 @@ const anyLetter = genericLetter || barbershopLetter || salonspaLetter
 {layoutsLetter === 'BA' && <PageBA siteData={data} />}
 {educationLetter === 'AT' && <PageAT siteData={data} />}
 {tradesLetter === 'AU' && <PageAU siteData={data} />}
+{filipinoLetter === 'BB' && <PageBB siteData={data} />}
 {!anyLetter && (
   <BaseLayout
     businessName={layout.businessName ?? ''}

--- a/astro-site-template/src/pages/index.astro
+++ b/astro-site-template/src/pages/index.astro
@@ -113,6 +113,12 @@ import PageAY from '../components/layouts/PageAY.astro';
 import PageAZ from '../components/layouts/PageAZ.astro';
 import PageBA from '../components/layouts/PageBA.astro';
 import PageBB from '../components/filipino/PageBB.astro';
+import PageBC from '../components/filipino/PageBC.astro';
+import PageBD from '../components/filipino/PageBD.astro';
+import PageBE from '../components/filipino/PageBE.astro';
+import PageBF from '../components/filipino/PageBF.astro';
+import PageBG from '../components/filipino/PageBG.astro';
+import PageBH from '../components/filipino/PageBH.astro';
 import siteData from '../data/site-data.json';
 
 // Live-editor support: template / colour / font / hidden-sections can be driven
@@ -163,7 +169,7 @@ const servicesMatch = /^services:(AS)$/.exec(heroStyle);
 const servicesLetter = servicesMatch ? servicesMatch[1] : null;
 const layoutsMatch = /^layouts:(A[V-Z]|BA)$/.exec(heroStyle);
 const layoutsLetter = layoutsMatch ? layoutsMatch[1] : null;
-const filipinoMatch = /^filipino:(BB)$/.exec(heroStyle);
+const filipinoMatch = /^filipino:(B[B-H])$/.exec(heroStyle);
 const filipinoLetter = filipinoMatch ? filipinoMatch[1] : null;
 const anyLetter = genericLetter || barbershopLetter || salonspaLetter
   || autoshopLetter || restaurantLetter || shirtstoreLetter
@@ -225,6 +231,12 @@ const anyLetter = genericLetter || barbershopLetter || salonspaLetter
 {educationLetter === 'AT' && <PageAT siteData={data} />}
 {tradesLetter === 'AU' && <PageAU siteData={data} />}
 {filipinoLetter === 'BB' && <PageBB siteData={data} />}
+{filipinoLetter === 'BC' && <PageBC siteData={data} />}
+{filipinoLetter === 'BD' && <PageBD siteData={data} />}
+{filipinoLetter === 'BE' && <PageBE siteData={data} />}
+{filipinoLetter === 'BF' && <PageBF siteData={data} />}
+{filipinoLetter === 'BG' && <PageBG siteData={data} />}
+{filipinoLetter === 'BH' && <PageBH siteData={data} />}
 {!anyLetter && (
   <BaseLayout
     businessName={layout.businessName ?? ''}

--- a/components/editor/editorConstants.ts
+++ b/components/editor/editorConstants.ts
@@ -101,5 +101,6 @@ export const CURATED: Record<TemplateFamily, string[]> = {
     trades:     ["blue", "dark", "black", "orange", "professional"],
     foodcraft:  ["pink", "gold", "orange", "maroon"],
     services:   ["blue", "green", "professional", "whitegold"],
+    filipino:   ["orange", "maroon", "gold", "purple", "green", "brown"],
     layouts:    ["blue", "green", "purple", "orange", "brown", "maroon", "professional", "dark"],
 };

--- a/components/editor/templateCatalog.ts
+++ b/components/editor/templateCatalog.ts
@@ -14,7 +14,7 @@
 export type TemplateFamily =
     | "generic" | "barbershop" | "salonspa" | "autoshop" | "restaurant"
     | "shirtstore" | "retail" | "medical" | "fitness" | "education"
-    | "trades" | "foodcraft" | "services" | "layouts";
+    | "trades" | "foodcraft" | "services" | "filipino" | "layouts";
 
 export interface TemplateDef {
     letter: string;
@@ -110,6 +110,10 @@ const SERVICES_TEMPLATES: TemplateDef[] = [
     { letter: "AS", code: "services:AS", label: "Labaná Laundry & Press", tagline: "Crisp + clean · laundry & services", preview: "/template-previews/as.html" },
 ];
 
+const FILIPINO_TEMPLATES: TemplateDef[] = [
+    { letter: "BB", code: "filipino:BB", label: "Tindahan · Suki Storefront", tagline: "Barangay warmth · sari-sari & corner stores", preview: "/template-previews/bb.html" },
+];
+
 /** Families in rail-display order, each with a human label. */
 export const TEMPLATE_FAMILIES: Array<{ family: TemplateFamily; label: string; templates: TemplateDef[] }> = [
     { family: "generic",    label: "Generic",     templates: GENERIC_TEMPLATES },
@@ -125,6 +129,7 @@ export const TEMPLATE_FAMILIES: Array<{ family: TemplateFamily; label: string; t
     { family: "trades",     label: "Trades",      templates: TRADES_TEMPLATES },
     { family: "foodcraft",  label: "Foodcraft",   templates: FOODCRAFT_TEMPLATES },
     { family: "services",   label: "Services",    templates: SERVICES_TEMPLATES },
+    { family: "filipino",   label: "Filipino",    templates: FILIPINO_TEMPLATES },
 ];
 
 export const ALL_TEMPLATES: TemplateDef[] = TEMPLATE_FAMILIES.flatMap((f) => f.templates);

--- a/components/editor/templateCatalog.ts
+++ b/components/editor/templateCatalog.ts
@@ -111,7 +111,13 @@ const SERVICES_TEMPLATES: TemplateDef[] = [
 ];
 
 const FILIPINO_TEMPLATES: TemplateDef[] = [
-    { letter: "BB", code: "filipino:BB", label: "Tindahan · Suki Storefront", tagline: "Barangay warmth · sari-sari & corner stores", preview: "/template-previews/bb.html" },
+    { letter: "BB", code: "filipino:BB", label: "Tindahan · Suki Storefront",  tagline: "Barangay warmth · sari-sari & corner stores", preview: "/template-previews/bb.html" },
+    { letter: "BC", code: "filipino:BC", label: "Lutong Bahay · Carinderia",   tagline: "Turo-turo warmth · carinderias & eateries",  preview: "/template-previews/bc.html" },
+    { letter: "BD", code: "filipino:BD", label: "Tahanan Panaderia",           tagline: "Dark-crust bakeshop · panaderia & bakeries", preview: "/template-previews/bd.html" },
+    { letter: "BE", code: "filipino:BE", label: "Barako Kapehan",              tagline: "Slab-roast warmth · coffee & kapehan",      preview: "/template-previews/be.html" },
+    { letter: "BF", code: "filipino:BF", label: "Lechon Manok · Spit",         tagline: "Charcoal grill · roast chicken & BBQ",      preview: "/template-previews/bf.html" },
+    { letter: "BG", code: "filipino:BG", label: "Vulca Bay",                   tagline: "Hazard-yellow grit · vulcanizing & repair", preview: "/template-previews/bg.html" },
+    { letter: "BH", code: "filipino:BH", label: "Halo Haus",                   tagline: "Ube pastel · halo-halo & desserts",         preview: "/template-previews/bh.html" },
 ];
 
 /** Families in rail-display order, each with a human label. */

--- a/public/template-previews/bb.html
+++ b/public/template-previews/bb.html
@@ -1,0 +1,526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Tindahan ni Aling Rosa — sari-sari store, e-load, padala & the friendliest utang in the barangay, Quezon City</title>
+<meta name="description" content="Tindahan ni Aling Rosa is a sari-sari store in Barangay Bagong Silang, Quezon City — everything by tingi, e-load and bills payment, padala and pick-up point, cold drinks and the whole street's suki since 1998. Open early, closes late." />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,700;12..96,800&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Tindahan ni Aling Rosa", phone: "+63 917 555 0142", phoneDisplay: "0917 555 0142", email: "alingrosa.store@gmail.com", foundedYear: 1998 },
+  hero: {
+    kicker: "Sari-sari store · e-load · padala · Bagong Silang, Quezon City",
+    headline: "The whole street's front door. Open before you wake, closed after you sleep.",
+    lede: "The corner store that keeps a barangay running — everything sold by tingi so a five-peso coin still buys something, e-load and bills payment, padala pick-up, ice-cold softdrinks, and a utang ledger for the suki we've known for twenty-five years. If it's not on the shelf, ask; Aling Rosa probably has it out back.",
+    primaryCta: { label: "Message the store", href: "#book" },
+    secondaryCta: { label: "What we carry", href: "#services" },
+    image: "https://images.unsplash.com/photo-1596461404969-9ae70f2830c1?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "A bright shelf packed with colourful sachets and goods."
+  },
+  trust: { years: "Serving the barangay since 1998" },
+  about: {
+    heading: "A peso still buys something here. That's not nothing — that's the whole idea.",
+    paragraphs: [
+      "Tindahan ni Aling Rosa opened in 1998 as a window cut into the front of the house, and it never really closed again. It's a sari-sari store in the truest sense — sari-sari means 'variety,' and behind that little grille is shampoo in sachets, coffee in singles, one cigarette or a whole pack, a scoop of rice, a piece of pandesal, a cold Coke in a plastic bag with a straw, and a hundred small things you didn't know you needed until you're standing there.",
+      "The whole point is tingi — selling by the piece, by the sachet, by the small amount — because that's how the neighbourhood actually shops. Not everyone has a supermarket budget on a Tuesday; everyone has five or ten pesos and a need. We break the bulk so the bulk price reaches the people who need it most, and we've been doing it long enough that we know your order before you finish saying it.",
+      "Over the years the window grew a second life: e-load for every network, bills payment, padala and parcel pick-up, and the famous listahan — the utang notebook where the suki we trust run a tab till payday. Aling Rosa is still at the window most days. The store is a shop, yes, but it's also the barangay's message board, lost-and-found, and place to stand and talk while your load comes through."
+    ],
+    portrait: "https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "Colourful goods and cold drinks stacked at the counter."
+  },
+  services: [
+    { name: "Everything by tingi", description: "Sold the way the barangay shops: single sachets of shampoo, coffee and seasoning, cigarettes by the stick, rice and sugar by the scoop, one egg or a dozen. We break the bulk so a small coin still buys what you need." },
+    { name: "E-load & bills payment", description: "Prepaid load for every network, promos and data, plus electric, water and other bills paid over the counter. No need to travel to the mall — the whole street tops up here." },
+    { name: "Padala & pick-up point", description: "A pick-up and drop-off point for parcels and padala, plus a hand with sending money where we can — the barangay's little logistics hub, open when the couriers aren't." },
+    { name: "Cold drinks & merienda", description: "Ice-cold softdrinks, juice and water, plus pandesal, biscuits, chichirya and quick merienda — a cold drink in a bag with a straw is practically the house special." },
+    { name: "Household & everyday", description: "Detergent, soap, candles, batteries, load cards, school supplies and the small emergencies of daily life — the things you run out of at the worst possible moment." },
+    { name: "Utang for the suki", description: "The listahan: a tab in the notebook for the regulars we've known for years, settled on payday. Built on trust, kept fair, and one of the quiet reasons the store still stands." }
+  ],
+  why: [
+    { title: "We sell it your size.", body: "Tingi is the whole philosophy — buy one sachet, one stick, one scoop, one piece. We break bulk so the everyday price reaches people who buy for today, not for the month." },
+    { title: "Open when you need it.", body: "Before the jeeps start and after the last one's gone. Sundays, holidays, the middle of a brownout — the window's open when the supermarkets are shut and you're out of load." },
+    { title: "We know your order.", body: "Twenty-five years at the same window means we know the suki, the kids' snacks, whose lola takes which coffee. It's a shop that runs on names, not numbers." }
+  ],
+  how: [
+    { step: "01", title: "Come to the window", body: "No aisles, no queues, no self-checkout — just the window and whoever's minding it. Tell us what you need, even if it's five pesos' worth. Especially if it's five pesos' worth." },
+    { step: "02", title: "Ask if you can't see it", body: "The shelf is the front page; the stockroom is the rest of the book. If it's not on display, ask — Aling Rosa probably has it, or can have it tomorrow." },
+    { step: "03", title: "Load, pay, or send", body: "Topping up, paying a bill, picking up a padala? Same window, same friendly face. Give the number, we'll sort it, and you can wait in the shade while it goes through." },
+    { step: "04", title: "Suki? Use the listahan", body: "Trusted regulars run a tab in the notebook and settle on payday. Ask about becoming suki — it's earned over time, but once you're in, you're family." }
+  ],
+  testimonials: [
+    { quote: "Aling Rosa's window has fed my family for twenty years — literally, on the days between paydays when the listahan kept us going. She's fair, she's kind, she never once made anyone feel small for buying tingi. This store is the heart of our street. Wala nang iba.", name: "Nanay Cely", context: "suki since 1999" },
+    { quote: "I forget how much I rely on this place until I travel and there's no sari-sari on the corner. Load at midnight, a cold drink after a shift, one egg when the recipe's short — it's all just there. Fast, friendly, and cheaper than you'd think.", name: "Jomar R.", context: "neighbour, two doors down" },
+    { quote: "My kids' whole childhood is this window — the yosi errands for their lolo, the chichirya after school, the ice candy in summer. Now they send me here for the same things. Some businesses just belong to a place. This is one of them.", name: "Tita Baby", context: "regular, Bagong Silang" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1596461404969-9ae70f2830c1?w=1600&q=85&auto=format&fit=crop", alt: "A shelf packed with colourful sachets and goods." },
+    { src: "https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1600&q=85&auto=format&fit=crop", alt: "Cold drinks and treats stacked at the counter." },
+    { src: "https://images.unsplash.com/photo-1516981879613-9f5da904015f?w=1600&q=85&auto=format&fit=crop", alt: "Colourful packaged goods lined up." },
+    { src: "https://images.unsplash.com/photo-1526394931762-90052e97b376?w=1600&q=85&auto=format&fit=crop", alt: "Rows of stacked goods in the store." },
+    { src: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop", alt: "A cold drink on the counter." },
+    { src: "https://images.unsplash.com/photo-1610890716171-6b1bb98ffd09?w=1600&q=85&auto=format&fit=crop", alt: "Neighbours gathered by the store window." }
+  ],
+  faq: [
+    { q: "What does 'tingi' actually mean, and why sell that way?", a: "Tingi is the Filipino practice of selling and buying in small, single quantities rather than whole packs — one sachet of shampoo instead of a bottle, a single stick of cigarette instead of a pack, a scoop of rice instead of a sack, one egg instead of a tray. It exists because it fits how a lot of the barangay genuinely lives and spends: money comes in small and often, needs are for today rather than the month, and a five- or ten-peso coin should still be able to buy something useful. Selling tingi means we buy in bulk and break it down, passing the everyday accessibility on to the customer. It's more work for us — repackaging, tracking tiny margins — but it's the entire reason a sari-sari store matters to a neighbourhood. It's how the corner store makes sure nobody has to go without the small things just because they can't buy big." },
+    { q: "Can I get e-load and pay my bills here?", a: "Yes — the window does e-load for every major network (prepaid credit, data promos, the lot), and we accept over-the-counter payment for common bills like electricity, water and select others, so you don't have to travel to a mall or payment centre for the small stuff. Just give us the number to load or the bill to pay, and we'll process it while you wait in the shade. It's one of the quiet ways the store has become the barangay's little service hub over the years: the same window that sells you a cold drink also keeps your phone connected and your bills settled. Ask us which bills and networks we currently handle, since the list changes as providers come and go, and we'll always tell you straight if something's better done elsewhere." },
+    { q: "How does the utang (listahan) work?", a: "The listahan is the utang notebook — the tab that trusted regular customers, the suki, can run and settle on payday. It's one of the oldest and most human parts of how a sari-sari store works, and it runs entirely on trust built up over time. We don't extend it to everyone straight away, and we keep it fair and modest on both sides: it's meant to bridge the gap between paydays for people we know, not to let debts pile up in a way that hurts anyone. If you've been buying here a while and want to ask about it, talk to Aling Rosa directly — it's a relationship, not a form. And if you ever can't settle on time, come and say so; a quiet word keeps the trust intact far better than avoiding the window." },
+    { q: "What are your opening hours?", a: "Early and late — genuinely. The window tends to open before the first jeeps run and stays open until well after the last one's gone home, seven days a week, because the whole value of a sari-sari store is being there when the bigger shops aren't: Sunday mornings, holidays, the middle of a brownout, that moment at night when you've run out of load or milk or matches. Exact hours flex with the day and the season, and they're kept live on our Google Business Profile, but as a rule if the street is awake, the window is open. If you're coming from further out for something specific, message us first and we'll tell you if we're open and whether we have it in." },
+    { q: "What if what I need isn't on the shelf?", a: "Ask anyway — the shelf is only the front page. A sari-sari store's display is what fits in the window, but there's usually more in the stockroom out back, and Aling Rosa has a memory like a ledger for what's where. If we genuinely don't have it, there's a good chance we can get it in with the next delivery, especially if it's something the street asks for regularly; a lot of what we stock got added exactly because a suki asked. So don't assume — a quick question at the window is the whole point of a shop run by people who know the neighbourhood, rather than a warehouse run by a barcode. Tell us what you're after and we'll tell you honestly whether we have it, can get it, or where you'd be better off going." },
+    { q: "Do you do padala and parcel pick-up?", a: "Yes — the store doubles as a drop-off and pick-up point for parcels and padala, which makes life much easier when the couriers only come during working hours and half the street is out at work then. Your delivery can be left with us and collected when you're home; senders in the neighbourhood can drop things for pick-up too. We'll also lend a hand with sending money where we're able and point you the right way when it's something we can't do ourselves. It's part of how the corner store has quietly become the barangay's logistics hub — the one place that's reliably open, reliably staffed by someone who knows everyone, and reliably willing to hold your box behind the counter until you get back. Ask us what courier and padala services we're currently working with." }
+  ],
+  area: { places: ["Bagong Silang", "Novaliches", "Fairview", "Commonwealth", "Quezon City", "Walk-up neighbourhood"] },
+  credentials: [
+    { label: "Since 1998", detail: "A window in the front of the house, never closed" },
+    { label: "Sold by tingi", detail: "Sachets, sticks, scoops — a peso still buys" },
+    { label: "Load & bills", detail: "E-load every network, bills over the counter" },
+    { label: "The listahan", detail: "Utang for the suki, kept fair, settled on payday" }
+  ],
+  location: { name: "Tindahan ni Aling Rosa", addressStreet: "24 Sampaguita St, Bagong Silang", addressLocality: "Quezon City", addressRegion: "Metro Manila", addressPostcode: "1116", addressCountry: "Philippines" },
+  cta: { heading: "The corner store that keeps the street running.", body: "Everything by tingi, e-load and bills payment, padala pick-up, cold drinks and the friendliest utang in the barangay — open before you wake and closed after you sleep. Message us or just come to the window.", primary: { label: "Message the store", href: "#book" }, secondary: { label: "0917 555 0142", href: "tel:+639175550142" } },
+  messaging: { whatsapp: "https://wa.me/639175550142", messenger: "https://m.me/alingrosastore" }
+};
+</script>
+
+<style>
+  :root {
+    --paper:#fbf4e6; --paper-2:#fffaf0; --ink:#231a24; --ink-2:#4a3d4a;
+    --vermilion:#e2482e; --turq:#1a9c8e; --marigold:#f0a821; --grape:#7a3b8f;
+    --mid:#8a7d84; --rule:rgba(35,26,36,0.14);
+    --disp:"Bricolage Grotesque",system-ui,sans-serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--paper);color:var(--ink);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--vermilion);}
+  .wrap{width:min(1280px,93vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--vermilion);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:800;font-size:clamp(38px,5.4vw,78px);line-height:0.98;margin:0 0 0.3em;letter-spacing:-0.015em;}
+  .h2 em{font-style:normal;color:var(--vermilion);}
+  .body{color:var(--ink-2);line-height:1.7;}
+  section{padding:clamp(72px,9vw,124px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:15px 30px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:999px;}
+  .btn-primary{background:var(--vermilion);color:var(--paper-2);} .btn-primary:hover{background:var(--grape);}
+  .btn-ghost{border:2px solid var(--ink);color:var(--ink);} .btn-ghost:hover{background:var(--ink);color:var(--paper-2);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.14em;text-transform:uppercase;color:var(--mid);border-bottom:2px solid var(--rule);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,58px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(251,244,230,0.92);backdrop-filter:blur(10px);border-bottom:2px solid var(--ink);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0;}
+  .wm{font-family:var(--disp);font-weight:800;font-size:22px;text-decoration:none;letter-spacing:-0.02em;}
+  .wm span{color:var(--vermilion);}
+  .nav-links{display:flex;gap:24px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase;color:var(--ink-2);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:800;font-size:clamp(42px,7vw,100px);line-height:0.94;letter-spacing:-0.025em;margin:0 0 32px;max-width:17ch;}
+  .hero-headline .em{color:var(--vermilion);}
+  .hero-headline .em2{color:var(--turq);}
+  .hero-lower{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(30px,4vw,60px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:14px;border:3px solid var(--ink);}
+  .hero-photo::after{content:"BUKAS · OPEN · SUKI WELCOME";position:absolute;left:-10px;top:-14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.1em;background:var(--marigold);color:var(--ink);padding:8px 14px;border-radius:999px;border:2.5px solid var(--ink);transform:rotate(-3deg);}
+  .hero-right .lede{color:var(--ink-2);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--turq);color:var(--paper-2);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:rgba(255,250,240,0.92);font-weight:700;}
+
+  .about{background:var(--paper-2);color:var(--ink);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:14px;border:3px solid var(--ink);}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.76;margin:0 0 1em;color:var(--ink-2);}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:2px solid var(--ink);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid var(--rule);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(240,168,33,0.16);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;color:var(--turq);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:700;font-size:clamp(24px,2.6vw,34px);margin:0;line-height:1.0;letter-spacing:-0.015em;}
+  .svc-row p{color:var(--ink-2);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--grape);color:var(--paper-2);}
+  .why .sw-head{color:rgba(255,250,240,0.7);border-color:rgba(255,250,240,0.24);}
+  .why .h2{color:var(--paper-2);} .why .h2 em{color:var(--marigold);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--marigold);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:700;font-size:27px;margin:0 0 10px;line-height:1.02;letter-spacing:-0.015em;}
+  .why-grid p{color:rgba(255,250,240,0.86);margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:3px solid var(--vermilion);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.12em;color:var(--turq);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:700;font-size:23px;margin:8px 0 8px;line-height:1.04;letter-spacing:-0.015em;}
+  .how-grid p{color:var(--ink-2);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--ink);color:var(--paper);}
+  .t-quote{font-family:var(--disp);font-weight:700;font-size:clamp(28px,3.7vw,52px);line-height:1.06;max-width:26ch;margin:0 0 24px;letter-spacing:-0.02em;}
+  .t-quote em{font-style:normal;color:var(--marigold);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--marigold);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:2px solid rgba(251,244,230,0.22);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:rgba(251,244,230,0.82);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(251,244,230,0.6);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:12px;border:3px solid var(--ink);}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--vermilion);color:var(--paper-2);font-family:var(--mono);font-size:9px;letter-spacing:0.08em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule);padding:22px 0;}
+  .faq-list details:first-child{border-top:2px solid var(--ink);}
+  .faq-list summary{font-family:var(--disp);font-weight:700;font-size:22px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.14;letter-spacing:-0.015em;}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--vermilion);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--ink-2);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.06em;text-transform:uppercase;padding:10px 20px;border:2px solid var(--ink);border-radius:999px;font-weight:700;color:var(--ink-2);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:3px solid var(--turq);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--vermilion);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:700;font-size:19px;line-height:1.14;letter-spacing:-0.015em;}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--marigold);color:var(--ink);padding:34px;border-radius:14px;border:3px solid var(--ink);}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:700;font-size:22px;line-height:1.26;letter-spacing:-0.015em;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:600;color:var(--ink);}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:2px solid rgba(35,26,36,0.24);padding-top:18px;letter-spacing:0.06em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--ink-2);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--ink-2);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:14px;border:3px solid var(--ink);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.15) contrast(1.02);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--vermilion);color:var(--paper-2);padding:clamp(80px,10vw,144px) 0;text-align:center;}
+  .cta-band .kick{color:var(--paper-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:800;font-size:clamp(42px,6.5vw,106px);line-height:0.96;margin:14px auto 18px;max-width:16ch;letter-spacing:-0.025em;}
+  .cta-band h2 em{font-style:normal;color:var(--marigold);}
+  .cta-band p{color:rgba(255,250,240,0.92);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--paper-2);color:var(--vermilion);} .cta-band .btn-primary:hover{background:var(--grape);color:var(--paper-2);}
+  .cta-band .btn-ghost{border-color:var(--paper-2);color:var(--paper-2);} .cta-band .btn-ghost:hover{background:var(--paper-2);color:var(--vermilion);}
+
+  footer{background:var(--ink);color:var(--paper);border-top:3px solid var(--vermilion);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--marigold);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:rgba(251,244,230,0.72);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid rgba(251,244,230,0.16);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.08em;text-transform:uppercase;color:rgba(251,244,230,0.6);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--turq);color:var(--paper-2);padding:13px 20px;border-radius:999px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;box-shadow:0 8px 24px rgba(26,156,142,0.4);border:2.5px solid var(--ink);}
+  .msg-fab a:hover{background:var(--vermilion);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"ConvenienceStore","name":"Tindahan ni Aling Rosa","description":"Sari-sari store in Barangay Bagong Silang, Quezon City — everything by tingi, e-load and bills payment, padala pick-up, cold drinks and the friendliest utang in the barangay since 1998.","url":"https://alingrosastore.ph/","telephone":"+639175550142","email":"alingrosa.store@gmail.com","address":{"@type":"PostalAddress","streetAddress":"24 Sampaguita St, Bagong Silang","addressLocality":"Quezon City","addressRegion":"Metro Manila","postalCode":"1116","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":14.7350,"longitude":121.0430},"areaServed":["Bagong Silang","Novaliches","Fairview","Commonwealth"],"image":["https://images.unsplash.com/photo-1596461404969-9ae70f2830c1?w=1600"],"foundingDate":"1998"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What does 'tingi' mean and why sell that way?","acceptedAnswer":{"@type":"Answer","text":"Tingi is selling in small single quantities — one sachet, one stick, one scoop, one egg — rather than whole packs. It fits how much of the barangay lives: money comes in small and often, and a five- or ten-peso coin should still buy something useful. We buy in bulk and break it down so the everyday price reaches people who buy for today, not the month. It's more work for us but it's the whole reason a sari-sari store matters."}},
+{"@type":"Question","name":"Can I get e-load and pay bills here?","acceptedAnswer":{"@type":"Answer","text":"Yes — e-load for every major network plus over-the-counter payment for common bills like electricity and water, so you don't have to travel to a mall. Give us the number or bill and we'll process it while you wait. Ask which networks and bills we currently handle, as the list changes."}},
+{"@type":"Question","name":"How does the utang (listahan) work?","acceptedAnswer":{"@type":"Answer","text":"The listahan is the utang notebook — a tab trusted regulars (suki) can run and settle on payday. It runs on trust built over time, kept fair and modest, meant to bridge paydays rather than let debt pile up. Talk to Aling Rosa directly to ask about it — it's a relationship, not a form — and if you ever can't settle on time, come and say so."}},
+{"@type":"Question","name":"What are your opening hours?","acceptedAnswer":{"@type":"Answer","text":"Early and late, seven days a week — the window opens before the first jeeps run and closes after the last one's gone. The value of a sari-sari store is being open when bigger shops aren't: Sundays, holidays, brownouts, late at night. Hours flex with the day and are kept live on our Google Business Profile; if the street's awake, the window's open."}},
+{"@type":"Question","name":"What if what I need isn't on the shelf?","acceptedAnswer":{"@type":"Answer","text":"Ask anyway — the shelf is only the front page. There's usually more in the stockroom, and if we don't have it we can often get it with the next delivery, especially if the street asks for it regularly. A quick question at the window is the whole point of a shop run by people who know the neighbourhood. We'll tell you honestly whether we have it, can get it, or where you'd be better off going."}},
+{"@type":"Question","name":"Do you do padala and parcel pick-up?","acceptedAnswer":{"@type":"Answer","text":"Yes — the store doubles as a drop-off and pick-up point for parcels and padala, handy when couriers only come during working hours. Deliveries can be left with us and collected when you're home, and we'll help with sending money where we can. Ask which courier and padala services we're currently working with."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Tindahan ni <span>Aling Rosa</span></a>
+    <nav class="nav-links">
+      <a href="#about">The store</a><a href="#services">What we carry</a><a href="#location">Find us</a><a href="#book">Message</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Sari-sari store · e-load · padala · Bagong Silang, Quezon City</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      The whole street's <span class="em">front door.</span> Open before you wake, closed after you <span class="em2">sleep.</span>
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1596461404969-9ae70f2830c1?w=2000&q=85&auto=format&fit=crop"
+             alt="A bright shelf packed with colourful sachets and goods." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">The corner store that keeps a barangay running — everything sold by tingi so a five-peso coin still buys something, e-load and bills payment, padala pick-up, ice-cold softdrinks, and a utang ledger for the suki we've known for twenty-five years. If it's not on the shelf, ask; Aling Rosa probably has it out back.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Message the store</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">What we carry</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Serving the barangay since 1998</span>
+    <span>Everything by tingi</span>
+    <span>E-load · bills · padala</span>
+    <span>Suki utang, kept fair</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 01 / THE STORE</span><span>A WINDOW IN THE HOUSE</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">A peso still buys something here. That's not nothing — that's the whole <em>idea.</em></h2>
+        <p>Tindahan ni Aling Rosa opened in 1998 as a window cut into the front of the house, and it never really closed again. It's a sari-sari store in the truest sense — sari-sari means "variety," and behind that little grille is shampoo in sachets, coffee in singles, one cigarette or a whole pack, a scoop of rice, a piece of pandesal, a cold Coke in a plastic bag with a straw, and a hundred small things you didn't know you needed until you're standing there.</p>
+        <p>The whole point is tingi — selling by the piece, by the sachet, by the small amount — because that's how the neighbourhood actually shops. Not everyone has a supermarket budget on a Tuesday; everyone has five or ten pesos and a need. We break the bulk so the bulk price reaches the people who need it most, and we've been doing it long enough that we know your order before you finish saying it.</p>
+        <p>Over the years the window grew a second life: e-load for every network, bills payment, padala and parcel pick-up, and the famous listahan — the utang notebook where the suki we trust run a tab till payday. Aling Rosa is still at the window most days. The store is a shop, yes, but it's also the barangay's message board, lost-and-found, and place to stand and talk while your load comes through.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1200&q=85&auto=format&fit=crop"
+           alt="Colourful goods and cold drinks stacked at the counter." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" data-component="SERVICES" data-variant="v78" data-screen-label="Services">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 02 / WHAT WE CARRY</span><span>TINGI · LOAD · PADALA · MERIENDA</span></div>
+    <h2 class="h2">What we carry.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Everything by tingi</h3><p>Sold the way the barangay shops: single sachets of shampoo, coffee and seasoning, cigarettes by the stick, rice and sugar by the scoop, one egg or a dozen. We break bulk so a small coin still buys what you need.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>E-load &amp; bills payment</h3><p>Prepaid load for every network, promos and data, plus electric, water and other bills paid over the counter. No need to travel to the mall — the whole street tops up here.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>Padala &amp; pick-up point</h3><p>A pick-up and drop-off point for parcels and padala, plus a hand with sending money where we can — the barangay's little logistics hub, open when the couriers aren't.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Cold drinks &amp; merienda</h3><p>Ice-cold softdrinks, juice and water, plus pandesal, biscuits, chichirya and quick merienda — a cold drink in a bag with a straw is practically the house special.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Household &amp; everyday</h3><p>Detergent, soap, candles, batteries, load cards, school supplies and the small emergencies of daily life — the things you run out of at the worst possible moment.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Utang for the suki</h3><p>The listahan: a tab in the notebook for the regulars we've known for years, settled on payday. Built on trust, kept fair, and one of the quiet reasons the store still stands.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 03 / THE DIFFERENCE</span><span>WHY THE WINDOW WORKS</span></div>
+    <h2 class="h2">Why the window works.</h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>We sell it your size.</h3><p>Tingi is the whole philosophy — buy one sachet, one stick, one scoop, one piece. We break bulk so the everyday price reaches people who buy for today, not for the month.</p></div>
+      <div><span class="no">02 / 03</span><h3>Open when you need it.</h3><p>Before the jeeps start and after the last one's gone. Sundays, holidays, the middle of a brownout — the window's open when the supermarkets are shut and you're out of load.</p></div>
+      <div><span class="no">03 / 03</span><h3>We know your order.</h3><p>Twenty-five years at the same window means we know the suki, the kids' snacks, whose lola takes which coffee. It's a shop that runs on names, not numbers.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 04 / HOW IT GOES</span><span>WINDOW → ASK → LOAD → LISTAHAN</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Come to the window</h3><p>No aisles, no queues, no self-checkout — just the window and whoever's minding it. Tell us what you need, even if it's five pesos' worth. Especially if it's five pesos' worth.</p></li>
+      <li><span class="step">STEP 02</span><h3>Ask if you can't see it</h3><p>The shelf is the front page; the stockroom is the rest of the book. If it's not on display, ask — Aling Rosa probably has it, or can have it tomorrow.</p></li>
+      <li><span class="step">STEP 03</span><h3>Load, pay, or send</h3><p>Topping up, paying a bill, picking up a padala? Same window, same friendly face. Give the number, we'll sort it, and wait in the shade while it goes through.</p></li>
+      <li><span class="step">STEP 04</span><h3>Suki? Use the listahan</h3><p>Trusted regulars run a tab in the notebook and settle on payday. Ask about becoming suki — it's earned over time, but once you're in, you're family.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 05 / FROM THE STREET</span><span>WALA NANG IBA</span></div>
+    <blockquote class="t-quote">“She never once made anyone feel small for buying tingi. This store is the heart of our street. <em>Wala nang iba.</em>”</blockquote>
+    <div class="t-attr">Nanay Cely — suki since 1999</div>
+    <div class="t-sub">
+      <figure><blockquote>“I forget how much I rely on this place until I travel and there's no sari-sari on the corner. Load at midnight, a cold drink after a shift, one egg when the recipe's short — it's all just there. Fast, friendly, and cheaper than you'd think.”</blockquote><figcaption>Jomar R. — neighbour, two doors down</figcaption></figure>
+      <figure><blockquote>“My kids' whole childhood is this window — the errands for their lolo, the chichirya after school, the ice candy in summer. Now they send me here for the same things. Some businesses just belong to a place. This is one of them.”</blockquote><figcaption>Tita Baby — regular, Bagong Silang</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 06 / AT THE WINDOW</span><span>SARI-SARI, LITERALLY</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1596461404969-9ae70f2830c1?w=1600&q=85&auto=format&fit=crop" alt="A shelf packed with colourful sachets and goods." /><figcaption>THE SHELF</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1600&q=85&auto=format&fit=crop" alt="Cold drinks and treats stacked at the counter." /><figcaption>THE COUNTER</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1516981879613-9f5da904015f?w=1600&q=85&auto=format&fit=crop" alt="Colourful packaged goods lined up." /><figcaption>THE STOCK</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1526394931762-90052e97b376?w=1600&q=85&auto=format&fit=crop" alt="Rows of stacked goods in the store." /><figcaption>THE RACKS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop" alt="A cold drink on the counter." /><figcaption>THE COLD ONE</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1610890716171-6b1bb98ffd09?w=1600&q=85&auto=format&fit=crop" alt="Neighbours gathered by the store window." /><figcaption>THE TAMBAYAN</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 07 / GOOD TO KNOW</span><span>TINGI, LOAD &amp; LISTAHAN</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+639175550142" style="color:var(--vermilion);font-weight:700;">0917 555 0142</a>. Or just come to the window; it's easier than typing.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What does 'tingi' actually mean, and why sell that way?</summary><p>Tingi is the Filipino practice of selling and buying in small, single quantities rather than whole packs — one sachet of shampoo instead of a bottle, a single stick instead of a pack, a scoop of rice instead of a sack, one egg instead of a tray. It exists because it fits how a lot of the barangay genuinely lives and spends: money comes in small and often, needs are for today rather than the month, and a five- or ten-peso coin should still be able to buy something useful. Selling tingi means we buy in bulk and break it down, passing the everyday accessibility on to the customer. It's more work for us — repackaging, tracking tiny margins — but it's the entire reason a sari-sari store matters to a neighbourhood.</p></details>
+        <details><summary>Can I get e-load and pay my bills here?</summary><p>Yes — the window does e-load for every major network (prepaid credit, data promos, the lot), and we accept over-the-counter payment for common bills like electricity, water and select others, so you don't have to travel to a mall or payment centre for the small stuff. Just give us the number to load or the bill to pay, and we'll process it while you wait in the shade. It's one of the quiet ways the store has become the barangay's little service hub over the years: the same window that sells you a cold drink also keeps your phone connected and your bills settled. Ask us which bills and networks we currently handle, since the list changes as providers come and go.</p></details>
+        <details><summary>How does the utang (listahan) work?</summary><p>The listahan is the utang notebook — the tab that trusted regular customers, the suki, can run and settle on payday. It's one of the oldest and most human parts of how a sari-sari store works, and it runs entirely on trust built up over time. We don't extend it to everyone straight away, and we keep it fair and modest on both sides: it's meant to bridge the gap between paydays for people we know, not to let debts pile up in a way that hurts anyone. If you've been buying here a while and want to ask about it, talk to Aling Rosa directly — it's a relationship, not a form. And if you ever can't settle on time, come and say so; a quiet word keeps the trust intact far better than avoiding the window.</p></details>
+        <details><summary>What are your opening hours?</summary><p>Early and late — genuinely. The window tends to open before the first jeeps run and stays open until well after the last one's gone home, seven days a week, because the whole value of a sari-sari store is being there when the bigger shops aren't: Sunday mornings, holidays, the middle of a brownout, that moment at night when you've run out of load or milk or matches. Exact hours flex with the day and the season, and they're kept live on our Google Business Profile, but as a rule if the street is awake, the window is open. If you're coming from further out for something specific, message us first.</p></details>
+        <details><summary>What if what I need isn't on the shelf?</summary><p>Ask anyway — the shelf is only the front page. A sari-sari store's display is what fits in the window, but there's usually more in the stockroom out back, and Aling Rosa has a memory like a ledger for what's where. If we genuinely don't have it, there's a good chance we can get it in with the next delivery, especially if it's something the street asks for regularly; a lot of what we stock got added exactly because a suki asked. So don't assume — a quick question at the window is the whole point of a shop run by people who know the neighbourhood, rather than a warehouse run by a barcode.</p></details>
+        <details><summary>Do you do padala and parcel pick-up?</summary><p>Yes — the store doubles as a drop-off and pick-up point for parcels and padala, which makes life much easier when the couriers only come during working hours and half the street is out at work then. Your delivery can be left with us and collected when you're home; senders in the neighbourhood can drop things for pick-up too. We'll also lend a hand with sending money where we're able and point you the right way when it's something we can't do ourselves. It's part of how the corner store has quietly become the barangay's logistics hub. Ask us what courier and padala services we're currently working with.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 08 / THE NEIGHBOURHOOD</span><span>BAGONG SILANG &amp; NEARBY</span></div>
+    <ul class="area-list">
+      <li>Bagong Silang</li><li>Novaliches</li><li>Fairview</li><li>Commonwealth</li><li>Quezon City</li><li>Walk-up neighbourhood</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 09 / THE ESSENTIALS</span><span>HOW THE WINDOW RUNS</span></div>
+    <div class="creds">
+      <div><div class="label">Since 1998</div><div class="detail">A window in the front of the house</div></div>
+      <div><div class="label">Sold by tingi</div><div class="detail">Sachets, sticks, scoops — a peso still buys</div></div>
+      <div><div class="label">Load &amp; bills</div><div class="detail">E-load every network, bills over the counter</div></div>
+      <div><div class="label">The listahan</div><div class="detail">Utang for the suki, kept fair, paid on payday</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>AISLE 10 / THE CORNER</span><span>SAMPAGUITA ST, BAGONG SILANG</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Tindahan ni Aling Rosa</strong><br />
+          24 Sampaguita St, Bagong Silang<br />
+          Quezon City 1116<br /><br />
+          <a href="tel:+639175550142" data-bind="business.phoneDisplay">0917 555 0142</a><br />
+          <a href="mailto:alingrosa.store@gmail.com" data-bind="business.email">alingrosa.store@gmail.com</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>MON – SUN</span><span>5AM – 11PM</span></div>
+          <div class="row"><span>LOAD &amp; PADALA</span><span>ALL DAY</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. The window is on the corner of Sampaguita St — look for the marigold shutter and the cold-drinks cooler out front.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Tindahan ni Aling Rosa, Quezon City" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=121.0280%2C14.7250%2C121.0580%2C14.7450&layer=mapnik&marker=14.7350%2C121.0430"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">AISLE 11 / COME BY</div>
+    <h2 data-bind="cta.heading">The corner store that keeps the street <em>running.</em></h2>
+    <p data-bind="cta.body">Everything by tingi, e-load and bills payment, padala pick-up, cold drinks and the friendliest utang in the barangay — open before you wake and closed after you sleep. Message us or just come to the window.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Message the store</a>
+      <a class="btn btn-ghost" href="tel:+639175550142" data-bind="cta.secondary.label">0917 555 0142</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/639175550142" data-bind="messaging.whatsapp" aria-label="Message the store">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:22px;">Tindahan ni <span style="color:var(--marigold);">Aling Rosa</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;color:rgba(251,244,230,0.72);">A sari-sari store in Bagong Silang, Quezon City — everything by tingi, e-load, padala and the friendliest utang in the barangay since 1998.</p>
+      </div>
+      <div>
+        <h4>The store</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:rgba(251,244,230,0.72);">
+          24 Sampaguita St, Bagong Silang<br />Quezon City 1116<br />
+          <a href="tel:+639175550142">0917 555 0142</a><br />
+          <a href="mailto:alingrosa.store@gmail.com">alingrosa.store@gmail.com</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">What we carry</a><a href="#about">The store</a><a href="#location">Find us</a><a href="#book">Message</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> TINDAHAN NI ALING ROSA</span>
+      <span>BUKAS · OPEN · SUKI WELCOME</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/bc.html
+++ b/public/template-previews/bc.html
@@ -1,0 +1,525 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Lutong Bahay ni Aling Puring — turo-turo carinderia, home-cooked ulam & unli rice in Sampaloc, Manila</title>
+<meta name="description" content="Lutong Bahay ni Aling Puring is a turo-turo carinderia in Sampaloc, Manila — point at the ulam, eat home-cooked adobo, kare-kare, sinigang and the fresh dish of the day with unli rice, dine-in or take-out, plus baon and simple catering. Cooking since 2003." />
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Lutong Bahay ni Aling Puring", phone: "+63 917 555 0288", phoneDisplay: "0917 555 0288", email: "alingpuring.kusina@gmail.com", foundedYear: 2003 },
+  hero: {
+    kicker: "Turo-turo carinderia · lutong bahay · unli rice · Sampaloc, Manila",
+    headline: "Point at what you want. It's already cooked, and it tastes like home.",
+    lede: "A turo-turo carinderia in Sampaloc, where the ulam is laid out fresh every morning and you eat like you're at your Nanay's table — adobo, kare-kare, sinigang, ginisang gulay and the dish of the day, ladled hot over unli rice. Dine-in on the long tables, take-out in a bag, or order baon and simple catering. Sulit, mabilis, and home-cooked, every day.",
+    primaryCta: { label: "See today's ulam", href: "#book" },
+    secondaryCta: { label: "How turo-turo works", href: "#services" },
+    image: "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "A hot bowl of home-cooked ulam over rice."
+  },
+  trust: { years: "Feeding Sampaloc since 2003" },
+  about: {
+    heading: "No menu. Just what Nanay cooked this morning, still steaming in the tray.",
+    paragraphs: [
+      "Lutong Bahay ni Aling Puring is a carinderia — a turo-turo, from the word for 'point-point,' because that's exactly how you order: you look at the trays of ulam behind the glass, you point at what you want, and it lands on your plate over rice in about thirty seconds. There's no menu to read, no waiting on a kitchen, no fuss. What you see is what Aling Puring cooked this morning, and when a tray runs out, it's out.",
+      "We opened in 2003 with three dishes and a rice cooker, feeding students, jeepney drivers, construction workers and office staff on their lunch break — anyone who wants a proper, hot, home-cooked meal, fast and sulit. The food is lutong bahay in the truest sense: the adobo, sinigang, kare-kare, menudo, ginisang gulay and pritong isda you'd eat at home, cooked in big batches from scratch every day, seasoned by taste, not by packet.",
+      "The whole point of a carinderia is that a filling meal shouldn't cost the earth or take an hour. Unli rice keeps everyone full; the long communal tables keep it friendly; and the regulars have their orders down to a nod. We also pack baon for people on the go and cater simple trays for offices and gatherings. Come hungry, point at what looks good, and eat like you're home."
+    ],
+    portrait: "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "A home-cooked dish plated and ready to serve."
+  },
+  services: [
+    { name: "Point-at-it ulam", description: "The turo-turo heart of it: trays of fresh ulam behind the glass — point at one, two or three viands and eat in seconds. Adobo, menudo, ginisang gulay, pritong isda and more, all cooked this morning." },
+    { name: "The dish of the day", description: "A rotating special cooked in bigger batches — kare-kare, sinigang na baboy, bulalo, caldereta or whatever's good and in season. Ask what today's is; it's usually the first tray to empty." },
+    { name: "Unli rice & combos", description: "Rice keeps coming until you're full, and our silog and rice-meal combos make a fast, filling lunch for one price — the everyday sulit meal Sampaloc runs on. Add an egg, add soup, add another scoop." },
+    { name: "Take-out & baon", description: "Everything packs to go — a rice meal in a bag for the jeepney, or baon boxed up for work and school the night before. Same home-cooked food, wrapped for the road, ready in minutes." },
+    { name: "Merienda & soup", description: "Between the lunch and dinner rush: lugaw, arroz caldo, pancit, and whatever snack Nanay felt like making — the warm merienda that bridges the long afternoon on a student's budget." },
+    { name: "Simple catering & trays", description: "Bilao and trays of uland rice for offices, meetings, birthdays and small gatherings — home-cooked party food without the party price, delivered around Sampaloc. Order a day ahead." }
+  ],
+  why: [
+    { title: "Cooked fresh, every morning.", body: "Nothing sits from yesterday. Every tray is cooked from scratch in the morning, seasoned by taste, and when it's gone it's gone. What you point at is genuinely today's food." },
+    { title: "Sulit, and fast.", body: "A hot, filling, home-cooked meal with unli rice for the price of a snack elsewhere, on your plate in under a minute. This is what a carinderia is for — feeding real people on real budgets." },
+    { title: "It tastes like home.", body: "Lutong bahay, not restaurant food — the adobo and sinigang you grew up on, cooked the way a Filipino kitchen actually cooks. Students far from home come here to be fed like family." }
+  ],
+  how: [
+    { step: "01", title: "Look at the trays", body: "Come to the glass and see what's cooked today — the ulam is right there, no menu needed. Ask what the dish of the day is; ask what's freshest. We'll happily tell you." },
+    { step: "02", title: "Point at what you want", body: "Turo-turo: point at one, two or three viands. We ladle them over rice on the spot. Tell us if you want more sauce, more rice, an egg on top — it's your plate." },
+    { step: "03", title: "Dine in or take out", body: "Grab a spot at the long tables and eat with unli rice, or say 'take-out' and we'll bag it hot for the road in under a minute. Either way, you're eating fast." },
+    { step: "04", title: "Order baon or a tray", body: "Want lunch sorted for tomorrow, or feeding a group? Order baon or a catering tray a day ahead, message us the count, and pick it up or have it delivered around Sampaloc." }
+  ],
+  testimonials: [
+    { quote: "I studied in Sampaloc for four years and Aling Puring's carinderia basically raised me. Cheap, hot, unli rice, and it tasted like my mom's cooking when I missed home the most. The kare-kare on Wednesdays got me through college. Forever grateful, ma'am.", name: "Kevin O.", context: "student, 2015–2019" },
+    { quote: "As a jeepney driver I don't have time or money to waste on lunch. Here I point, I eat, I'm full, I'm back on the road in fifteen minutes, and it costs less than anywhere. Sarap, mabilis, sulit. The whole route eats here.", name: "Mang Celso", context: "jeepney driver, daily" },
+    { quote: "We order trays from Aling Puring for every office birthday now. Real home-cooked food, generous portions, delivered on time, and everyone always asks who catered. Way better than fast food and honestly cheaper. Our go-to, no question.", name: "Divine R.", context: "office catering, España" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=1600&q=85&auto=format&fit=crop", alt: "A hot bowl of ulam over rice." },
+    { src: "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1600&q=85&auto=format&fit=crop", alt: "A home-cooked dish plated." },
+    { src: "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop", alt: "A plate of viand ready to eat." },
+    { src: "https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1600&q=85&auto=format&fit=crop", alt: "Steam rising from a pot on the stove." },
+    { src: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop", alt: "A cold drink beside a meal." },
+    { src: "https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop", alt: "The long tables of the carinderia." }
+  ],
+  faq: [
+    { q: "How does turo-turo actually work?", a: "Turo-turo means 'point-point,' and it's the simplest way to eat there is. You come up to the display where the day's cooked dishes — the ulam — are laid out in trays behind glass, you look at what's there, and you literally point at what you want. We ladle it straight onto a plate of rice and you're eating within about thirty seconds; there's no menu to read, no order ticket, and no waiting for a kitchen to cook because the food is already made. You can pick one viand or build a bigger plate with two or three, add extra rice or an egg, and ask for more sauce — it's entirely up to you and what looks good that day. Prices are per viand and clearly the point of the format: you see exactly what you're getting and roughly what it costs before it hits your plate. If you've never done it, just come to the glass and point; we'll guide you." },
+    { q: "Is the food really cooked fresh each day?", a: "Yes — everything is cooked from scratch in the morning, in big batches, and served through the day until it runs out, which is the whole discipline of a good carinderia. We don't carry dishes over from yesterday or stretch a tray with yesterday's leftovers; when a viand is gone, that tray is empty and that's that, which is exactly why the popular dishes disappear first and why regulars come early for the ones they love. Cooking fresh daily in volume is hard work — Aling Puring and the kitchen are at it before dawn — but it's the reason the food tastes like home rather than like a steam-table that's been sitting since who-knows-when. If you want a specific dish, it's worth asking what's cooked that day or coming at the start of the lunch rush, and if there's something you'd love us to make, tell us; a lot of our regular rotation started as a request." },
+    { q: "What does unli rice mean, and is it really unlimited?", a: "Unli is short for unlimited — unli rice means your rice keeps coming as long as you're still eating, at no extra charge, which together with a viand or two makes a genuinely filling meal for very little money. It's a staple of the carinderia and eatery world here because rice is the heart of a Filipino meal and nobody should leave hungry over a second scoop. In practice, order your ulam, and if you finish your rice before your viand, just ask for more and we'll top you up. It's meant honestly and used honestly — it's there so a hungry student, driver or worker gets full, not as a challenge — and it's a big part of why a carinderia meal is so sulit. Pair it with our soup of the day and you've eaten properly for the price of a snack elsewhere." },
+    { q: "Can I take the food out or order baon?", a: "Absolutely — take-out is half of what we do, and it's fast. Just tell us 'take-out' when you point at your ulam and we'll bag it hot with rice in under a minute, ready for the jeepney, the office desk or home. For baon — packed meals to bring to work or school — you can order the night before or in the morning and we'll box it up fresh for you to grab on the way; a lot of our regulars have a standing baon order so lunch is sorted without thinking about it. Everything on the tray travels well, and we pack rice and ulam separately when it helps keep things right. If you're grabbing baon for the family or the whole office, message us a rough count ahead of time so we can have it ready and you're not waiting; otherwise, just come by and point." },
+    { q: "Do you do catering or party trays?", a: "Yes — simple, home-cooked catering is something we're glad to do and it's become a real part of the business, especially for offices, meetings, birthdays, baptisms and small neighbourhood gatherings around Sampaloc. Think bilao and trays of the same lutong bahay we serve daily — pancit, adobo, menudo, kare-kare, rice and the rest — in party quantities, at carinderia prices rather than fancy-caterer prices, which is why our office regulars keep coming back for it. We ask for a day's notice so we can shop and cook properly for the numbers, more if it's a big order or a busy weekend, and we can deliver around the area or have it ready for pick-up. Tell us the headcount, the date and roughly what dishes you'd like (or let us suggest a spread), and we'll sort a menu and a fair price. It's genuine home-cooked party food without the party price." },
+    { q: "Is a carinderia clean and safe to eat at?", a: "Yes — and it's a fair thing to ask, because a carinderia lives or dies on its regulars trusting the food, and we've kept ours coming back since 2003. Cooking fresh in volume every day and selling out actually helps here: food doesn't sit around, the trays turn over fast, and there's nothing lingering from previous days. We keep the cooking area, the display and the tables clean, handle and store the food properly, and we're happy for you to see the kitchen — there's nothing to hide in a carinderia, where everything is cooked in plain sight. The long-running popularity of the place, packed with students, workers and families day after day, is its own answer: people who eat here every day of their lives wouldn't if it made them sick. Come and see for yourself; the busy tables tell you more than any sign could." }
+  ],
+  area: { places: ["Sampaloc", "España", "Dapitan", "University Belt", "Manila", "Baon & catering delivery"] },
+  credentials: [
+    { label: "Since 2003", detail: "Home-cooked turo-turo in Sampaloc" },
+    { label: "Cooked fresh", detail: "Every tray from scratch each morning" },
+    { label: "Unli rice", detail: "Sulit, filling meals on a real budget" },
+    { label: "Baon & trays", detail: "Take-out and simple catering around Manila" }
+  ],
+  location: { name: "Lutong Bahay ni Aling Puring", addressStreet: "38 Dapitan St, Sampaloc", addressLocality: "Manila", addressRegion: "Metro Manila", addressPostcode: "1008", addressCountry: "Philippines" },
+  cta: { heading: "Come hungry. Point at what looks good.", body: "Fresh home-cooked ulam over unli rice, dine-in on the long tables or bagged for the road, plus baon and simple catering — turo-turo in Sampaloc since 2003. See today's trays or message us to order.", primary: { label: "See today's ulam", href: "#book" }, secondary: { label: "0917 555 0288", href: "tel:+639175550288" } },
+  messaging: { whatsapp: "https://wa.me/639175550288", messenger: "https://m.me/alingpuringkusina" }
+};
+</script>
+
+<style>
+  :root {
+    --leaf:#1f4d2e; --leaf-2:#173d24; --coco:#faf3e2; --coco-2:#fffaef; --ink:#20291f; --ink-2:#43503f;
+    --tomato:#d63c2a; --kalamansi:#e0a92b; --pandan:#4f8f4a;
+    --mid:#7f8a79; --rule:rgba(32,41,31,0.14);
+    --disp:"Archivo",system-ui,sans-serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--coco);color:var(--ink);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--tomato);}
+  .wrap{width:min(1280px,93vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--tomato);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:900;font-size:clamp(38px,5.4vw,80px);line-height:0.96;margin:0 0 0.3em;letter-spacing:-0.02em;}
+  .h2 em{font-style:normal;color:var(--tomato);}
+  .body{color:var(--ink-2);line-height:1.7;}
+  section{padding:clamp(74px,9vw,126px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:16px 32px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:2px;}
+  .btn-primary{background:var(--tomato);color:var(--coco-2);} .btn-primary:hover{background:var(--leaf);}
+  .btn-ghost{border:2px solid var(--leaf);color:var(--leaf);} .btn-ghost:hover{background:var(--leaf);color:var(--coco-2);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.14em;text-transform:uppercase;color:var(--mid);border-bottom:2px solid var(--rule);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,58px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(250,243,226,0.93);backdrop-filter:blur(10px);border-bottom:2px solid var(--leaf);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0;}
+  .wm{font-family:var(--disp);font-weight:900;font-size:20px;text-decoration:none;letter-spacing:-0.03em;color:var(--leaf);}
+  .wm span{color:var(--tomato);}
+  .nav-links{display:flex;gap:24px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase;color:var(--ink-2);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:900;font-size:clamp(40px,6.6vw,98px);line-height:0.92;letter-spacing:-0.03em;margin:0 0 32px;max-width:18ch;color:var(--leaf);}
+  .hero-headline .em{color:var(--tomato);}
+  .hero-lower{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(30px,4vw,60px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:10px;border:3px solid var(--leaf);}
+  .hero-photo::after{content:"TURO-TURO · LUTONG BAHAY · UNLI RICE";position:absolute;left:-8px;top:-14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.08em;background:var(--kalamansi);color:var(--ink);padding:8px 14px;border-radius:4px;border:2.5px solid var(--leaf);transform:rotate(-2deg);}
+  .hero-right .lede{color:var(--ink-2);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--leaf);color:var(--coco-2);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:rgba(255,250,239,0.9);font-weight:700;}
+
+  .about{background:var(--coco-2);color:var(--ink);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:10px;border:3px solid var(--leaf);}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.76;margin:0 0 1em;color:var(--ink-2);}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:2px solid var(--leaf);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid var(--rule);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(214,60,42,0.1);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;color:var(--pandan);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:800;font-size:clamp(24px,2.6vw,34px);margin:0;line-height:1.0;letter-spacing:-0.02em;color:var(--leaf);}
+  .svc-row p{color:var(--ink-2);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--leaf);color:var(--coco-2);}
+  .why .sw-head{color:rgba(255,250,239,0.7);border-color:rgba(255,250,239,0.24);}
+  .why .h2{color:var(--coco-2);} .why .h2 em{color:var(--kalamansi);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--kalamansi);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:800;font-size:27px;margin:0 0 10px;line-height:1.0;letter-spacing:-0.02em;}
+  .why-grid p{color:rgba(255,250,239,0.86);margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:3px solid var(--tomato);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.12em;color:var(--pandan);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:800;font-size:23px;margin:8px 0 8px;line-height:1.02;letter-spacing:-0.02em;color:var(--leaf);}
+  .how-grid p{color:var(--ink-2);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--ink);color:var(--coco);}
+  .t-quote{font-family:var(--disp);font-weight:800;font-size:clamp(28px,3.7vw,52px);line-height:1.02;max-width:26ch;margin:0 0 24px;letter-spacing:-0.025em;}
+  .t-quote em{font-style:normal;color:var(--kalamansi);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--kalamansi);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:2px solid rgba(250,243,226,0.22);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:rgba(250,243,226,0.82);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(250,243,226,0.6);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:8px;border:3px solid var(--leaf);}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--tomato);color:var(--coco-2);font-family:var(--mono);font-size:9px;letter-spacing:0.08em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule);padding:22px 0;}
+  .faq-list details:first-child{border-top:2px solid var(--leaf);}
+  .faq-list summary{font-family:var(--disp);font-weight:800;font-size:22px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.12;letter-spacing:-0.02em;color:var(--leaf);}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--tomato);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--ink-2);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.06em;text-transform:uppercase;padding:10px 20px;border:2px solid var(--leaf);border-radius:2px;font-weight:700;color:var(--ink-2);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:3px solid var(--pandan);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--tomato);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:800;font-size:19px;line-height:1.12;letter-spacing:-0.02em;color:var(--leaf);}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--kalamansi);color:var(--ink);padding:34px;border-radius:10px;border:3px solid var(--leaf);}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:800;font-size:21px;line-height:1.26;letter-spacing:-0.02em;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:600;color:var(--leaf-2);}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:2px solid rgba(32,41,31,0.24);padding-top:18px;letter-spacing:0.06em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--leaf-2);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--leaf-2);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:10px;border:3px solid var(--leaf);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.15) contrast(1.02);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--tomato);color:var(--coco-2);padding:clamp(80px,10vw,144px) 0;text-align:center;}
+  .cta-band .kick{color:var(--coco-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:900;font-size:clamp(42px,6.5vw,106px);line-height:0.94;margin:14px auto 18px;max-width:15ch;letter-spacing:-0.03em;}
+  .cta-band h2 em{font-style:normal;color:var(--kalamansi);}
+  .cta-band p{color:rgba(255,250,239,0.92);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--coco-2);color:var(--tomato);} .cta-band .btn-primary:hover{background:var(--leaf);color:var(--coco-2);}
+  .cta-band .btn-ghost{border-color:var(--coco-2);color:var(--coco-2);} .cta-band .btn-ghost:hover{background:var(--coco-2);color:var(--tomato);}
+
+  footer{background:var(--leaf-2);color:var(--coco);border-top:3px solid var(--kalamansi);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--kalamansi);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:rgba(250,243,226,0.72);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid rgba(250,243,226,0.16);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.08em;text-transform:uppercase;color:rgba(250,243,226,0.6);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--leaf);color:var(--coco-2);padding:13px 20px;border-radius:999px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;box-shadow:0 8px 24px rgba(31,77,46,0.4);border:2.5px solid var(--kalamansi);}
+  .msg-fab a:hover{background:var(--tomato);border-color:var(--coco-2);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Restaurant","name":"Lutong Bahay ni Aling Puring","description":"Turo-turo carinderia in Sampaloc, Manila — home-cooked ulam over unli rice, adobo, kare-kare, sinigang and the dish of the day, dine-in or take-out, plus baon and simple catering. Cooking since 2003.","servesCuisine":"Filipino","url":"https://alingpuringkusina.ph/","telephone":"+639175550288","email":"alingpuring.kusina@gmail.com","address":{"@type":"PostalAddress","streetAddress":"38 Dapitan St, Sampaloc","addressLocality":"Manila","addressRegion":"Metro Manila","postalCode":"1008","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":14.6100,"longitude":120.9930},"areaServed":["Sampaloc","España","University Belt","Manila"],"image":["https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=1600"],"foundingDate":"2003"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"How does turo-turo actually work?","acceptedAnswer":{"@type":"Answer","text":"Turo-turo means 'point-point.' You come to the display where the day's cooked dishes are laid out in trays, look at what's there, and point at what you want. We ladle it onto rice and you're eating within about thirty seconds — no menu, no order ticket, no waiting for a kitchen. Pick one viand or build a plate with two or three, add rice or an egg. Prices are per viand so you see what you're getting before it hits the plate."}},
+{"@type":"Question","name":"Is the food really cooked fresh each day?","acceptedAnswer":{"@type":"Answer","text":"Yes — everything is cooked from scratch in the morning in big batches and served until it runs out. We don't carry dishes over from yesterday; when a viand is gone, that tray is empty, which is why popular dishes disappear first and regulars come early. Cooking fresh daily in volume is hard work but it's why the food tastes like home. Ask what's cooked that day, and tell us if there's something you'd love us to make."}},
+{"@type":"Question","name":"What does unli rice mean?","acceptedAnswer":{"@type":"Answer","text":"Unli is unlimited — your rice keeps coming as long as you're eating, at no extra charge, which with a viand or two makes a filling meal for very little. It's a carinderia staple because rice is the heart of a Filipino meal and nobody should leave hungry over a second scoop. Order your ulam and just ask for more rice when you need it. It's meant and used honestly, and a big part of why a carinderia meal is so sulit."}},
+{"@type":"Question","name":"Can I take the food out or order baon?","acceptedAnswer":{"@type":"Answer","text":"Yes — take-out is half of what we do. Say 'take-out' when you point and we'll bag it hot with rice in under a minute. For baon, order the night before or in the morning and we'll box it fresh to grab on the way; many regulars have a standing baon order. Everything travels well and we pack rice and ulam separately when it helps. For a family or office, message a rough count ahead so it's ready."}},
+{"@type":"Question","name":"Do you do catering or party trays?","acceptedAnswer":{"@type":"Answer","text":"Yes — simple home-cooked catering for offices, meetings, birthdays, baptisms and gatherings around Sampaloc: bilao and trays of the same lutong bahay we serve daily — pancit, adobo, menudo, kare-kare, rice — in party quantities at carinderia prices. We ask for a day's notice (more for big orders or busy weekends) and can deliver or set it for pick-up. Tell us the headcount, date and dishes, or let us suggest a spread, and we'll sort a fair price."}},
+{"@type":"Question","name":"Is a carinderia clean and safe to eat at?","acceptedAnswer":{"@type":"Answer","text":"Yes — a carinderia lives or dies on its regulars trusting the food, and we've kept ours since 2003. Cooking fresh in volume and selling out helps: nothing sits around and the trays turn over fast. We keep the cooking area, display and tables clean, handle and store food properly, and you're welcome to see the kitchen — everything is cooked in plain sight. The busy tables, packed with students, workers and families day after day, are their own answer."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Lutong Bahay ni <span>Aling Puring</span></a>
+    <nav class="nav-links">
+      <a href="#about">The carinderia</a><a href="#services">What's cooking</a><a href="#location">Find us</a><a href="#book">Order</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Turo-turo carinderia · lutong bahay · unli rice · Sampaloc, Manila</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      Point at what you want. It's already cooked, and it tastes like <span class="em">home.</span>
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=2000&q=85&auto=format&fit=crop"
+             alt="A hot bowl of home-cooked ulam over rice." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A turo-turo carinderia in Sampaloc, where the ulam is laid out fresh every morning and you eat like you're at your Nanay's table — adobo, kare-kare, sinigang, ginisang gulay and the dish of the day, ladled hot over unli rice. Dine-in on the long tables, take-out in a bag, or order baon and simple catering. Sulit, mabilis, and home-cooked, every day.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">See today's ulam</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">How turo-turo works</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Feeding Sampaloc since 2003</span>
+    <span>Cooked fresh every morning</span>
+    <span>Unli rice, always</span>
+    <span>Dine-in · take-out · baon</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 01 / THE CARINDERIA</span><span>NO MENU, JUST WHAT NANAY COOKED</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">No menu. Just what Nanay cooked this morning, still steaming in the <em>tray.</em></h2>
+        <p>Lutong Bahay ni Aling Puring is a carinderia — a turo-turo, from the word for "point-point," because that's exactly how you order: you look at the trays of ulam behind the glass, you point at what you want, and it lands on your plate over rice in about thirty seconds. There's no menu to read, no waiting on a kitchen, no fuss. What you see is what Aling Puring cooked this morning, and when a tray runs out, it's out.</p>
+        <p>We opened in 2003 with three dishes and a rice cooker, feeding students, jeepney drivers, construction workers and office staff on their lunch break — anyone who wants a proper, hot, home-cooked meal, fast and sulit. The food is lutong bahay in the truest sense: the adobo, sinigang, kare-kare, menudo, ginisang gulay and pritong isda you'd eat at home, cooked in big batches from scratch every day, seasoned by taste, not by packet.</p>
+        <p>The whole point of a carinderia is that a filling meal shouldn't cost the earth or take an hour. Unli rice keeps everyone full; the long communal tables keep it friendly; and the regulars have their orders down to a nod. We also pack baon for people on the go and cater simple trays for offices and gatherings. Come hungry, point at what looks good, and eat like you're home.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1200&q=85&auto=format&fit=crop"
+           alt="A home-cooked dish plated and ready to serve." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" data-component="SERVICES" data-variant="v78" data-screen-label="Services">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 02 / WHAT'S COOKING</span><span>ULAM · RICE · BAON · CATERING</span></div>
+    <h2 class="h2">What's cooking.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Point-at-it ulam</h3><p>The turo-turo heart of it: trays of fresh ulam behind the glass — point at one, two or three viands and eat in seconds. Adobo, menudo, ginisang gulay, pritong isda and more, all cooked this morning.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>The dish of the day</h3><p>A rotating special cooked in bigger batches — kare-kare, sinigang na baboy, bulalo, caldereta or whatever's good and in season. Ask what today's is; it's usually the first tray to empty.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>Unli rice &amp; combos</h3><p>Rice keeps coming until you're full, and our silog and rice-meal combos make a fast, filling lunch for one price — the everyday sulit meal Sampaloc runs on. Add an egg, add soup, add a scoop.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Take-out &amp; baon</h3><p>Everything packs to go — a rice meal in a bag for the jeepney, or baon boxed up for work and school the night before. Same home-cooked food, wrapped for the road, ready in minutes.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Merienda &amp; soup</h3><p>Between the lunch and dinner rush: lugaw, arroz caldo, pancit, and whatever snack Nanay felt like making — the warm merienda that bridges the long afternoon on a student's budget.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Simple catering &amp; trays</h3><p>Bilao and trays of ulam and rice for offices, meetings, birthdays and small gatherings — home-cooked party food without the party price, delivered around Sampaloc. Order a day ahead.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 03 / THE DIFFERENCE</span><span>WHY THE TABLES ARE FULL</span></div>
+    <h2 class="h2">Why the tables are <em>full.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Cooked fresh, every morning.</h3><p>Nothing sits from yesterday. Every tray is cooked from scratch in the morning, seasoned by taste, and when it's gone it's gone. What you point at is genuinely today's food.</p></div>
+      <div><span class="no">02 / 03</span><h3>Sulit, and fast.</h3><p>A hot, filling, home-cooked meal with unli rice for the price of a snack elsewhere, on your plate in under a minute. This is what a carinderia is for — feeding real people on real budgets.</p></div>
+      <div><span class="no">03 / 03</span><h3>It tastes like home.</h3><p>Lutong bahay, not restaurant food — the adobo and sinigang you grew up on, cooked the way a Filipino kitchen actually cooks. Students far from home come here to be fed like family.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 04 / HOW IT GOES</span><span>LOOK · POINT · EAT · TAKE HOME</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Look at the trays</h3><p>Come to the glass and see what's cooked today — the ulam is right there, no menu needed. Ask what the dish of the day is; ask what's freshest. We'll happily tell you.</p></li>
+      <li><span class="step">STEP 02</span><h3>Point at what you want</h3><p>Turo-turo: point at one, two or three viands. We ladle them over rice on the spot. Tell us if you want more sauce, more rice, an egg on top — it's your plate.</p></li>
+      <li><span class="step">STEP 03</span><h3>Dine in or take out</h3><p>Grab a spot at the long tables and eat with unli rice, or say 'take-out' and we'll bag it hot for the road in under a minute. Either way, you're eating fast.</p></li>
+      <li><span class="step">STEP 04</span><h3>Order baon or a tray</h3><p>Want lunch sorted for tomorrow, or feeding a group? Order baon or a catering tray a day ahead, message us the count, and pick it up or have it delivered around Sampaloc.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 05 / FROM THE TABLES</span><span>SARAP · MABILIS · SULIT</span></div>
+    <blockquote class="t-quote">“Aling Puring's carinderia basically raised me. The kare-kare on Wednesdays got me through college. <em>Forever grateful, ma'am.</em>”</blockquote>
+    <div class="t-attr">Kevin O. — student, 2015–2019</div>
+    <div class="t-sub">
+      <figure><blockquote>“As a jeepney driver I don't have time or money to waste on lunch. Here I point, I eat, I'm full, I'm back on the road in fifteen minutes, and it costs less than anywhere. Sarap, mabilis, sulit. The whole route eats here.”</blockquote><figcaption>Mang Celso — jeepney driver, daily</figcaption></figure>
+      <figure><blockquote>“We order trays from Aling Puring for every office birthday now. Real home-cooked food, generous portions, delivered on time, and everyone always asks who catered. Way better than fast food and honestly cheaper. Our go-to, no question.”</blockquote><figcaption>Divine R. — office catering, España</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--coco-2);">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 06 / ON THE PLATE</span><span>LUTONG BAHAY, EVERY DAY</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=1600&q=85&auto=format&fit=crop" alt="A hot bowl of ulam over rice." /><figcaption>THE ULAM</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1600&q=85&auto=format&fit=crop" alt="A home-cooked dish plated." /><figcaption>THE VIAND</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop" alt="A plate of viand ready to eat." /><figcaption>THE PLATE</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1600&q=85&auto=format&fit=crop" alt="Steam rising from a pot on the stove." /><figcaption>THE POT</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop" alt="A cold drink beside a meal." /><figcaption>THE DRINK</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop" alt="The long tables of the carinderia." /><figcaption>THE TABLES</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 07 / GOOD TO KNOW</span><span>TURO-TURO, RICE &amp; TRAYS</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+639175550288" style="color:var(--tomato);font-weight:700;">0917 555 0288</a>. Or just come to the glass and point; that's the whole system.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>How does turo-turo actually work?</summary><p>Turo-turo means "point-point," and it's the simplest way to eat there is. You come up to the display where the day's cooked dishes — the ulam — are laid out in trays behind glass, you look at what's there, and you literally point at what you want. We ladle it straight onto a plate of rice and you're eating within about thirty seconds; there's no menu to read, no order ticket, and no waiting for a kitchen because the food is already made. You can pick one viand or build a bigger plate with two or three, add extra rice or an egg, and ask for more sauce — it's entirely up to you and what looks good that day. Prices are per viand, so you see exactly what you're getting before it hits your plate.</p></details>
+        <details><summary>Is the food really cooked fresh each day?</summary><p>Yes — everything is cooked from scratch in the morning, in big batches, and served through the day until it runs out, which is the whole discipline of a good carinderia. We don't carry dishes over from yesterday or stretch a tray with leftovers; when a viand is gone, that tray is empty, which is exactly why the popular dishes disappear first and why regulars come early for the ones they love. Cooking fresh daily in volume is hard work — the kitchen is at it before dawn — but it's the reason the food tastes like home rather than like a steam-table that's been sitting for hours. If you want a specific dish, ask what's cooked that day, and if there's something you'd love us to make, tell us; a lot of our rotation started as a request.</p></details>
+        <details><summary>What does unli rice mean, and is it really unlimited?</summary><p>Unli is short for unlimited — unli rice means your rice keeps coming as long as you're still eating, at no extra charge, which together with a viand or two makes a genuinely filling meal for very little money. It's a staple of the carinderia world because rice is the heart of a Filipino meal and nobody should leave hungry over a second scoop. In practice, order your ulam, and if you finish your rice before your viand, just ask for more and we'll top you up. It's meant honestly and used honestly — it's there so a hungry student, driver or worker gets full — and it's a big part of why a carinderia meal is so sulit.</p></details>
+        <details><summary>Can I take the food out or order baon?</summary><p>Absolutely — take-out is half of what we do, and it's fast. Just tell us "take-out" when you point at your ulam and we'll bag it hot with rice in under a minute, ready for the jeepney, the office desk or home. For baon — packed meals to bring to work or school — you can order the night before or in the morning and we'll box it up fresh for you to grab on the way; a lot of our regulars have a standing baon order so lunch is sorted without thinking about it. Everything on the tray travels well, and we pack rice and ulam separately when it helps. For a family or the whole office, message us a rough count ahead of time so it's ready.</p></details>
+        <details><summary>Do you do catering or party trays?</summary><p>Yes — simple, home-cooked catering is something we're glad to do, especially for offices, meetings, birthdays, baptisms and small neighbourhood gatherings around Sampaloc. Think bilao and trays of the same lutong bahay we serve daily — pancit, adobo, menudo, kare-kare, rice and the rest — in party quantities, at carinderia prices rather than fancy-caterer prices. We ask for a day's notice so we can shop and cook properly for the numbers, more if it's a big order or a busy weekend, and we can deliver around the area or have it ready for pick-up. Tell us the headcount, the date and roughly what dishes you'd like, or let us suggest a spread, and we'll sort a menu and a fair price.</p></details>
+        <details><summary>Is a carinderia clean and safe to eat at?</summary><p>Yes — and it's a fair thing to ask, because a carinderia lives or dies on its regulars trusting the food, and we've kept ours coming back since 2003. Cooking fresh in volume every day and selling out actually helps: food doesn't sit around, the trays turn over fast, and there's nothing lingering from previous days. We keep the cooking area, the display and the tables clean, handle and store the food properly, and we're happy for you to see the kitchen — there's nothing to hide in a carinderia, where everything is cooked in plain sight. The busy tables, packed with students, workers and families day after day, are their own answer.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 08 / WE FEED</span><span>SAMPALOC &amp; THE U-BELT</span></div>
+    <ul class="area-list">
+      <li>Sampaloc</li><li>España</li><li>Dapitan</li><li>University Belt</li><li>Manila</li><li>Baon &amp; catering delivery</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 09 / THE ESSENTIALS</span><span>HOW WE COOK</span></div>
+    <div class="creds">
+      <div><div class="label">Since 2003</div><div class="detail">Home-cooked turo-turo in Sampaloc</div></div>
+      <div><div class="label">Cooked fresh</div><div class="detail">Every tray from scratch each morning</div></div>
+      <div><div class="label">Unli rice</div><div class="detail">Sulit, filling meals on a real budget</div></div>
+      <div><div class="label">Baon &amp; trays</div><div class="detail">Take-out &amp; simple catering around Manila</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>TRAY 10 / THE KUSINA</span><span>DAPITAN ST, SAMPALOC</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Lutong Bahay ni Aling Puring</strong><br />
+          38 Dapitan St, Sampaloc<br />
+          Manila 1008<br /><br />
+          <a href="tel:+639175550288" data-bind="business.phoneDisplay">0917 555 0288</a><br />
+          <a href="mailto:alingpuring.kusina@gmail.com" data-bind="business.email">alingpuring.kusina@gmail.com</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>MON – SAT</span><span>7AM – 8PM</span></div>
+          <div class="row"><span>LUNCH RUSH</span><span>11AM – 1PM</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. We're on Dapitan near the U-Belt schools — come for the lunch rush, or early for the dish of the day before it runs out.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Lutong Bahay ni Aling Puring, Sampaloc" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=120.9780%2C14.6000%2C121.0080%2C14.6200&layer=mapnik&marker=14.6100%2C120.9930"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">TRAY 11 / COME EAT</div>
+    <h2 data-bind="cta.heading">Come hungry. Point at what looks <em>good.</em></h2>
+    <p data-bind="cta.body">Fresh home-cooked ulam over unli rice, dine-in on the long tables or bagged for the road, plus baon and simple catering — turo-turo in Sampaloc since 2003. See today's trays or message us to order.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">See today's ulam</a>
+      <a class="btn btn-ghost" href="tel:+639175550288" data-bind="cta.secondary.label">0917 555 0288</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/639175550288" data-bind="messaging.whatsapp" aria-label="Message the carinderia">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:20px;color:var(--coco);">Lutong Bahay ni <span style="color:var(--kalamansi);">Aling Puring</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;color:rgba(250,243,226,0.72);">A turo-turo carinderia in Sampaloc, Manila — home-cooked ulam over unli rice, dine-in, take-out and baon, since 2003.</p>
+      </div>
+      <div>
+        <h4>The carinderia</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:rgba(250,243,226,0.72);">
+          38 Dapitan St, Sampaloc<br />Manila 1008<br />
+          <a href="tel:+639175550288">0917 555 0288</a><br />
+          <a href="mailto:alingpuring.kusina@gmail.com">alingpuring.kusina@gmail.com</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">What's cooking</a><a href="#about">The carinderia</a><a href="#location">Find us</a><a href="#book">Order</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> LUTONG BAHAY NI ALING PURING</span>
+      <span>SARAP · MABILIS · SULIT · SAMPALOC</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/bd.html
+++ b/public/template-previews/bd.html
@@ -1,0 +1,526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Panaderia de San Roque — hot pandesal from five, ensaymada & merienda breads in Malolos, Bulacan</title>
+<meta name="description" content="Panaderia de San Roque is a neighbourhood bakery in Malolos, Bulacan — hot pandesal from five in the morning, ensaymada, monay, Spanish bread and pan de coco baked all day, and wholesale to the sari-sari stores. Baking since 1975." />
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Panaderia de San Roque", phone: "+63 44 555 0176", phoneDisplay: "(044) 555 0176", email: "hello@sanroquebakery.ph", foundedYear: 1975 },
+  hero: {
+    kicker: "Neighbourhood panaderia · hot pandesal from 5AM · Malolos, Bulacan",
+    headline: "The smell reaches the street before the sun does.",
+    lede: "A neighbourhood bakery in Malolos, Bulacan, baking the breads a Filipino morning is built on — hot pandesal from five, ensaymada rich with butter and cheese, monay, Spanish bread, pan de coco and the merienda loaves that never went out of style. Baked through the day, sold warm, and delivered to the sari-sari stores before the jeeps start.",
+    primaryCta: { label: "Order or enquire", href: "#book" },
+    secondaryCta: { label: "What we bake", href: "#services" },
+    image: "https://images.unsplash.com/photo-1509440159596-0249088772ff?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "Fresh bread rolls cooling on wooden racks."
+  },
+  trust: { years: "Baking for Malolos since 1975" },
+  about: {
+    heading: "Three generations, one oven, and a queue that still forms at five.",
+    paragraphs: [
+      "Panaderia de San Roque has stood on the same corner since 1975, and for three generations the day has started the same way: the first batch of pandesal out of the oven before dawn, the shutter half up, and a small queue of tricycle drivers, students and titas already waiting with their bags. Pandesal is the bread of the Filipino morning — soft, faintly sweet, dusted with breadcrumb — and ours is still shaped and baked here, not delivered frozen in a truck.",
+      "Alongside the pandesal we bake the whole repertoire of the neighbourhood panaderia: ensaymada coiled and brushed with butter, sugar and cheese; monay and Spanish bread; pan de coco and pan de sal de coco; hopia and the merienda loaves that keep a household going between meals. The recipes came down from the founder to his children to theirs, adjusted for the flour and the weather but never for the worse.",
+      "We bake through the day so there's warm bread at merienda, not just at breakfast, and we supply the sari-sari stores and canteens around Malolos wholesale, our delivery boy weaving out before the streets fill. A panaderia isn't a bakery that happens to be Filipino — it's a fixture of the barangay, and after fifty years, we're proud to still be the one this corner wakes up to."
+    ],
+    portrait: "https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "A baker shaping dough by hand at the bench."
+  },
+  services: [
+    { name: "Hot pandesal, all day", description: "The soft, faintly sweet breadcrumb-dusted roll the Filipino morning runs on — first batch from five, then baked in waves through the day so there's a hot one at merienda too. Sold by the piece or the bag." },
+    { name: "Ensaymada & mamon", description: "Ensaymada coiled and brushed with butter, sugar and grated cheese, and light mamon sponge — the rich end of the counter, for coffee, gifts and every fiesta table. Boxed to order." },
+    { name: "Everyday breads", description: "Monay, Spanish bread rolled with sweet filling, pan de coco, pan de sal de coco and the classic merienda loaves — the honest daily bread that fills a household between meals." },
+    { name: "Wholesale to sari-sari", description: "We supply the neighbourhood stores, canteens and carinderias around Malolos wholesale, delivered fresh before the streets fill, on standing daily orders — the quiet backbone of the business." },
+    { name: "Cakes & fiesta orders", description: "Ensaymada trays, bread platters and simple celebration cakes to order for birthdays, fiestas, baptisms and pasalubong — the breads a Bulacan celebration expects, made ahead so you don't queue." },
+    { name: "Kape & merienda counter", description: "A hot cup to go with a warm pandesal at the little counter out front — the two-peso pleasure of coffee and bread standing up, the way merienda was always meant to be taken." }
+  ],
+  why: [
+    { title: "Shaped and baked here.", body: "Every pandesal is mixed, proofed and shaped in this bakery and baked in our own oven — not trucked in frozen and finished. You're tasting the same dough this corner has for fifty years." },
+    { title: "Baked in waves, all day.", body: "We don't bake once and let it sit. Fresh batches come out through the morning and again for merienda, so the bread you buy is warm, not this morning's leftover under a lamp." },
+    { title: "Recipes handed down.", body: "The founder's recipes passed to his children and theirs — tuned to the flour and the weather over the decades, but never cheapened. Three generations, one taste." }
+  ],
+  how: [
+    { step: "01", title: "Come early, or come at merienda", body: "The first pandesal is out by five; there's a warm batch again mid-afternoon. Walk in, buy by the piece or the bag — no order needed for the daily breads." },
+    { step: "02", title: "Order ahead for a crowd", body: "Ensaymada trays, bread platters, cakes and big pandesal orders for fiestas and offices — message or call a day ahead and we'll have it boxed and ready." },
+    { step: "03", title: "Set up a wholesale run", body: "Running a store or canteen? We deliver standing daily orders fresh before opening. Tell us the quantities and route and we'll build it into the morning round." },
+    { step: "04", title: "Take it warm", body: "Best eaten within the hour, warm, with coffee — that's the whole point. For later, keep it wrapped; a quick warm in the morning brings it back to life." }
+  ],
+  testimonials: [
+    { quote: "I've bought pandesal here since I was small enough to be sent on the errand myself, and now I send my own kids. The five o'clock batch is worth the early alarm — soft, warm, gone before we get home. Fifty years and it hasn't slipped once. This is Malolos in bread form.", name: "Aling Choleng", context: "customer since childhood" },
+    { quote: "Their ensaymada is the one we bring to every family gathering, no debate. Buttery, cheesy, boxed beautifully, and always ready when they say. We've tried the fancy city bakeries — nothing beats San Roque. Nothing.", name: "The Bautista family", context: "fiesta & pasalubong orders" },
+    { quote: "My store has taken their wholesale pandesal every single morning for eleven years and they have never once been late. Fresh, reliable, fairly priced — half my regulars come in for it specifically. A bakery you can build a business on.", name: "Mang Tonyo", context: "sari-sari store owner" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1509440159596-0249088772ff?w=1600&q=85&auto=format&fit=crop", alt: "Bread rolls cooling on wooden racks." },
+    { src: "https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1600&q=85&auto=format&fit=crop", alt: "Dough being shaped at the bench." },
+    { src: "https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1600&q=85&auto=format&fit=crop", alt: "Bread baking in the oven." },
+    { src: "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop", alt: "Freshly baked bread on a plate." },
+    { src: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop", alt: "A cup of coffee beside warm bread." },
+    { src: "https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop", alt: "The counter and shutter of the panaderia." }
+  ],
+  faq: [
+    { q: "What time is the first pandesal out?", a: "Around five in the morning, seven days a week — the first batch of pandesal is the whole reason a panaderia opens before the sun, and there's usually a small queue of early risers, tricycle drivers and titas waiting with their bags when the shutter goes half up. We bake pandesal in waves after that too, so there's a warm batch again around merienda time in the mid-afternoon, which is when a lot of families do their second run of the day. If you want pandesal genuinely hot from the oven, come for the five o'clock batch or ask us what time the next tray is due — we're always happy to tell you, and it's worth timing your visit. The daily breads never need an order; just walk up and buy by the piece or the bag." },
+    { q: "What's the difference between pandesal, monay and the sweet breads?", a: "Pandesal is the soft, lightly sweet, breadcrumb-dusted morning roll — the everyday staple, eaten warm, split and filled or dunked in coffee. Monay is denser and rounder, a heartier plain bread that keeps well and fills you up. Then there's the sweet and rich end of the counter: ensaymada, coiled and brushed with butter, sugar and grated cheese; mamon, a light sponge; Spanish bread, rolled around a sweet buttery filling; pan de coco, filled with sweet grated coconut; and hopia and the other merienda favourites. Roughly, pandesal and monay are your daily bread, and the rest are for merienda, coffee, gifts and celebrations. If you're not sure what to try, tell us who it's for and how you'll eat it and we'll point you to the right thing — half the joy of a panaderia is being guided by someone who bakes it." },
+    { q: "Can I order ahead for a fiesta or office?", a: "Yes, and we'd encourage it for anything beyond a bag or two, especially around fiestas, Christmas and school events when the counter is busy. We take orders for ensaymada trays, mixed bread platters, big pandesal quantities and simple celebration cakes, boxed and ready for the time you need them, so you're not queuing behind the daily crowd. A day's notice is usually plenty for breads; a little more for cakes and large trays, and as much as you can give during peak season. Message or call us with the quantities, the date and the time, and whether you'll collect or need it set aside, and we'll confirm and have it waiting. Ordering ahead also means you get it at its freshest, baked to your pick-up time rather than sitting on the shelf." },
+    { q: "Do you supply sari-sari stores and canteens wholesale?", a: "Yes — wholesale delivery to the neighbourhood stores, canteens, carinderias and offices around Malolos is a core part of what we do, and for many of them we're a standing daily order delivered fresh before they open. It's the quiet backbone of the bakery: our delivery run goes out early, before the streets fill, so the pandesal is on your shelf warm and ready for the morning rush. If you run a store or a canteen and want to take our bread, talk to us about quantities, timing and your route — we'll work out a standing order that fits your morning and a fair wholesale price, and we pride ourselves on never being late, because your customers are counting on that bread being there. Reliability is the whole product when it comes to wholesale, and after fifty years it's what we're known for." },
+    { q: "How should I keep pandesal and bread fresh?", a: "Honestly, the best answer is to eat it warm and soon — pandesal and most of our breads are at their glorious best within an hour or two of baking, which is exactly why we bake in waves through the day rather than once in the morning. For bread you're keeping until later or the next day, wrap it well to keep it soft and store it at room temperature rather than the fridge, which actually dries bread out faster. A quick warm-up in a low oven, toaster or even a hot pan brings day-old pandesal back to life beautifully, soft inside with a little crisp on the outside — many people prefer it that way, split and filled. Richer breads like ensaymada keep a little longer thanks to the butter, and freeze well if you want to keep a batch; just thaw and warm before serving. When in doubt, buy less more often — that's what the panaderia is for." },
+    { q: "Are you really still using the original recipes?", a: "Yes, in the way that matters — the recipes came down from our founder to his children and then to us, and the character of the bread is unchanged, even if the details have been quietly tuned over fifty years. Flour changes, the weather changes, the humidity in Bulacan does its own thing to a dough, and any baker worth their salt adjusts to keep the result the same rather than letting it drift; that's not changing the recipe, it's honouring it. What we've never done is cheapen it — swap in worse fat, cut the proofing time, or truck in frozen dough to finish on site — because the whole reason people have come to this corner for three generations is that the pandesal tastes like the pandesal they remember. Taste it against your childhood memory; that's the only test we care about passing." }
+  ],
+  area: { places: ["Malolos", "Guiguinto", "Plaridel", "Calumpit", "Bulacan", "Wholesale delivery"] },
+  credentials: [
+    { label: "Since 1975", detail: "Three generations on the same corner" },
+    { label: "From 5AM", detail: "Hot pandesal, then baked in waves all day" },
+    { label: "Shaped here", detail: "Mixed, proofed & baked in our own oven" },
+    { label: "Wholesale", detail: "Fresh daily to Malolos stores & canteens" }
+  ],
+  location: { name: "Panaderia de San Roque", addressStreet: "9 Paseo del Congreso", addressLocality: "Malolos", addressRegion: "Bulacan", addressPostcode: "3000", addressCountry: "Philippines" },
+  cta: { heading: "Come for the five o'clock batch.", body: "Hot pandesal from five, ensaymada and mamon, the everyday breads a Filipino morning is built on, and reliable wholesale to the neighbourhood stores — baked on the same Malolos corner since 1975. Order ahead or just follow your nose.", primary: { label: "Order or enquire", href: "#book" }, secondary: { label: "(044) 555 0176", href: "tel:+63445550176" } },
+  messaging: { whatsapp: "https://wa.me/63445550176", messenger: "https://m.me/sanroquebakery" }
+};
+</script>
+
+<style>
+  :root {
+    --crust:#2a1c12; --crust-2:#35251829; --cream:#f4e7cf; --cream-2:#fbf2df; --pandesal:#d99a4e; --brick:#b0472f; --sage:#7d8b5a;
+    --mid:#8a7355; --mid-d:#c9b48f; --rule-d:rgba(244,231,207,0.16);
+    --disp:"DM Serif Display",Georgia,serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--crust);color:var(--cream);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--pandesal);}
+  .wrap{width:min(1240px,92vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--pandesal);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:400;font-size:clamp(40px,5.6vw,82px);line-height:1.0;margin:0 0 0.3em;letter-spacing:-0.005em;}
+  .h2 em{font-style:italic;color:var(--pandesal);}
+  .body{color:var(--mid-d);line-height:1.7;}
+  section{padding:clamp(76px,9vw,130px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:16px 32px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:3px;}
+  .btn-primary{background:var(--brick);color:var(--cream);} .btn-primary:hover{background:var(--pandesal);color:var(--crust);}
+  .btn-ghost{border:1.5px solid rgba(244,231,207,0.4);color:var(--cream);} .btn-ghost:hover{background:var(--cream);color:var(--crust);border-color:var(--cream);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.14em;text-transform:uppercase;color:var(--mid-d);border-bottom:1.5px solid var(--rule-d);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,60px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(42,28,18,0.92);backdrop-filter:blur(10px);border-bottom:1.5px solid var(--rule-d);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:15px 0;}
+  .wm{font-family:var(--disp);font-weight:400;font-size:26px;text-decoration:none;letter-spacing:0;}
+  .wm span{color:var(--pandesal);font-style:italic;}
+  .nav-links{display:flex;gap:26px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,66px) 0 clamp(60px,7vw,100px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:400;font-size:clamp(44px,7.2vw,108px);line-height:0.98;letter-spacing:-0.01em;margin:0 0 34px;max-width:17ch;}
+  .hero-headline em{font-style:italic;color:var(--pandesal);}
+  .hero-lower{display:grid;grid-template-columns:1.15fr 0.85fr;gap:clamp(30px,4vw,64px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:4px;}
+  .hero-photo::after{content:"MAINIT · FRESH FROM 5AM";position:absolute;left:14px;bottom:14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.12em;background:var(--pandesal);color:var(--crust);padding:7px 12px;border-radius:3px;}
+  .hero-right .lede{color:var(--mid-d);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--pandesal);color:var(--crust);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:rgba(42,28,18,0.82);font-weight:700;}
+
+  .about{background:var(--cream);color:var(--crust);}
+  .about .h2{color:var(--crust);} .about .h2 em{color:var(--brick);}
+  .about .sw-head{color:var(--mid);border-color:rgba(42,28,18,0.16);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:4px;}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.78;margin:0 0 1em;color:#4d3826;}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:1.5px solid var(--rule-d);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid rgba(244,231,207,0.12);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(176,71,47,0.12);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;color:var(--pandesal);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:400;font-size:clamp(25px,2.7vw,36px);margin:0;line-height:1.04;}
+  .svc-row p{color:var(--mid-d);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--cream);color:var(--crust);}
+  .why .h2{color:var(--crust);} .why .h2 em{color:var(--brick);}
+  .why .sw-head{color:var(--mid);border-color:rgba(42,28,18,0.16);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--brick);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:400;font-size:29px;margin:0 0 10px;line-height:1.06;}
+  .why-grid p{color:#4d3826;margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:1.5px solid var(--rule-d);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.12em;color:var(--pandesal);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:400;font-size:25px;margin:8px 0 8px;line-height:1.08;}
+  .how-grid p{color:var(--mid-d);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:#241811;}
+  .t-quote{font-family:var(--disp);font-weight:400;font-size:clamp(30px,4vw,56px);line-height:1.1;max-width:26ch;margin:0 0 24px;}
+  .t-quote em{font-style:italic;color:var(--pandesal);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:1.5px solid var(--rule-d);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:var(--mid-d);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:4px;}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--brick);color:var(--cream);font-family:var(--mono);font-size:9px;letter-spacing:0.08em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule-d);padding:22px 0;}
+  .faq-list details:first-child{border-top:1.5px solid var(--rule-d);}
+  .faq-list summary{font-family:var(--disp);font-weight:400;font-size:24px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.14;}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--pandesal);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--mid-d);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.06em;text-transform:uppercase;padding:10px 20px;border:1.5px solid rgba(244,231,207,0.3);border-radius:3px;font-weight:700;color:var(--mid-d);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:1.5px solid var(--rule-d);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--pandesal);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:400;font-size:20px;line-height:1.16;}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--cream);color:var(--crust);padding:34px;border-radius:4px;}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:400;font-size:24px;line-height:1.26;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:500;color:#4d3826;}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:1px solid rgba(42,28,18,0.16);padding-top:18px;letter-spacing:0.06em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--mid);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--mid);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:4px;border:1.5px solid rgba(244,231,207,0.2);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.3) invert(0.9) hue-rotate(150deg) brightness(0.92) sepia(0.2);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--brick);color:var(--cream);padding:clamp(84px,10vw,150px) 0;text-align:center;}
+  .cta-band .kick{color:var(--cream);}
+  .cta-band h2{font-family:var(--disp);font-weight:400;font-size:clamp(44px,6.5vw,110px);line-height:1.0;margin:14px auto 18px;max-width:15ch;}
+  .cta-band h2 em{font-style:italic;color:var(--pandesal);}
+  .cta-band p{color:rgba(244,231,207,0.9);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--cream);color:var(--brick);} .cta-band .btn-primary:hover{background:var(--pandesal);color:var(--crust);}
+  .cta-band .btn-ghost{border-color:rgba(244,231,207,0.6);color:var(--cream);} .cta-band .btn-ghost:hover{background:var(--cream);color:var(--brick);}
+
+  footer{background:var(--crust);border-top:1.5px solid var(--rule-d);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--pandesal);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:var(--mid-d);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid var(--rule-d);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.08em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--brick);color:var(--cream);padding:13px 20px;border-radius:3px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;box-shadow:0 8px 24px rgba(176,71,47,0.4);}
+  .msg-fab a:hover{background:var(--cream);color:var(--crust);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Bakery","name":"Panaderia de San Roque","description":"Neighbourhood bakery in Malolos, Bulacan — hot pandesal from 5AM, ensaymada, monay, Spanish bread and pan de coco baked all day, plus wholesale to the sari-sari stores. Baking since 1975.","url":"https://sanroquebakery.ph/","telephone":"+63445550176","email":"hello@sanroquebakery.ph","address":{"@type":"PostalAddress","streetAddress":"9 Paseo del Congreso","addressLocality":"Malolos","addressRegion":"Bulacan","postalCode":"3000","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":14.8433,"longitude":120.8114},"areaServed":["Malolos","Guiguinto","Plaridel","Calumpit"],"image":["https://images.unsplash.com/photo-1509440159596-0249088772ff?w=1600"],"foundingDate":"1975"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What time is the first pandesal out?","acceptedAnswer":{"@type":"Answer","text":"Around five in the morning, seven days a week, with a small queue usually waiting. We bake in waves after that, so there's a warm batch again around merienda in the mid-afternoon. For pandesal genuinely hot from the oven, come for the five o'clock batch or ask what time the next tray is due. Daily breads never need an order — just buy by the piece or the bag."}},
+{"@type":"Question","name":"What's the difference between pandesal, monay and the sweet breads?","acceptedAnswer":{"@type":"Answer","text":"Pandesal is the soft, lightly sweet breadcrumb-dusted morning roll; monay is denser and heartier. The rich end is ensaymada (butter, sugar, cheese), mamon (light sponge), Spanish bread (sweet buttery filling), pan de coco (sweet coconut) and hopia. Roughly, pandesal and monay are daily bread; the rest are for merienda, coffee, gifts and celebrations. Tell us who it's for and we'll point you to the right thing."}},
+{"@type":"Question","name":"Can I order ahead for a fiesta or office?","acceptedAnswer":{"@type":"Answer","text":"Yes — we take orders for ensaymada trays, mixed bread platters, big pandesal quantities and simple celebration cakes, boxed for your pick-up time so you skip the daily queue. A day's notice is usually plenty for breads, a little more for cakes and large trays, and as much as you can give in peak season. Message or call with quantities, date and time. Ordering ahead means it's baked to your pick-up time, at its freshest."}},
+{"@type":"Question","name":"Do you supply sari-sari stores and canteens wholesale?","acceptedAnswer":{"@type":"Answer","text":"Yes — wholesale to stores, canteens, carinderias and offices around Malolos is core to what we do, often as a standing daily order delivered fresh before opening. Our run goes out early so the pandesal is on your shelf warm for the morning rush. Talk to us about quantities, timing and route and we'll build a standing order and fair price. We pride ourselves on never being late — reliability is the whole product in wholesale."}},
+{"@type":"Question","name":"How should I keep pandesal and bread fresh?","acceptedAnswer":{"@type":"Answer","text":"Best eaten warm and soon — which is why we bake in waves. For later, wrap it well and keep at room temperature, not the fridge (which dries bread out). Reheat day-old pandesal in a low oven, toaster or hot pan to bring it back, soft inside with a little crisp. Richer breads like ensaymada keep longer and freeze well; thaw and warm before serving. When in doubt, buy less more often."}},
+{"@type":"Question","name":"Are you really still using the original recipes?","acceptedAnswer":{"@type":"Answer","text":"Yes in the way that matters — the recipes came down from our founder through three generations and the character is unchanged, even if details are tuned for the flour and the Bulacan weather to keep the result the same. What we never do is cheapen it with worse fat, cut proofing, or frozen dough finished on site, because people come to this corner because the pandesal tastes like the pandesal they remember. Taste it against your childhood memory — that's the only test we care about."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Panaderia de <span>San Roque</span></a>
+    <nav class="nav-links">
+      <a href="#about">The bakery</a><a href="#services">What we bake</a><a href="#location">Find us</a><a href="#book">Order</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Neighbourhood panaderia · hot pandesal from 5AM · Malolos, Bulacan</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      The smell reaches the street <em>before the sun</em> does.
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1509440159596-0249088772ff?w=2000&q=85&auto=format&fit=crop"
+             alt="Fresh bread rolls cooling on wooden racks." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A neighbourhood bakery in Malolos, Bulacan, baking the breads a Filipino morning is built on — hot pandesal from five, ensaymada rich with butter and cheese, monay, Spanish bread, pan de coco and the merienda loaves that never went out of style. Baked through the day, sold warm, and delivered to the sari-sari stores before the jeeps start.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Order or enquire</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">What we bake</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Baking for Malolos since 1975</span>
+    <span>Hot pandesal from 5AM</span>
+    <span>Shaped &amp; baked here, all day</span>
+    <span>Wholesale to the barangay</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 01 / THE BAKERY</span><span>THREE GENERATIONS, ONE OVEN</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">Three generations, one oven, and a queue that still forms at <em>five.</em></h2>
+        <p>Panaderia de San Roque has stood on the same corner since 1975, and for three generations the day has started the same way: the first batch of pandesal out of the oven before dawn, the shutter half up, and a small queue of tricycle drivers, students and titas already waiting with their bags. Pandesal is the bread of the Filipino morning — soft, faintly sweet, dusted with breadcrumb — and ours is still shaped and baked here, not delivered frozen in a truck.</p>
+        <p>Alongside the pandesal we bake the whole repertoire of the neighbourhood panaderia: ensaymada coiled and brushed with butter, sugar and cheese; monay and Spanish bread; pan de coco and pan de sal de coco; hopia and the merienda loaves that keep a household going between meals. The recipes came down from the founder to his children to theirs, adjusted for the flour and the weather but never for the worse.</p>
+        <p>We bake through the day so there's warm bread at merienda, not just at breakfast, and we supply the sari-sari stores and canteens around Malolos wholesale, our delivery boy weaving out before the streets fill. A panaderia isn't a bakery that happens to be Filipino — it's a fixture of the barangay, and after fifty years, we're proud to still be the one this corner wakes up to.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1200&q=85&auto=format&fit=crop"
+           alt="A baker shaping dough by hand at the bench." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" class="testimonials" data-component="SERVICES" data-variant="v78" data-screen-label="Services" style="background:var(--crust);">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 02 / WHAT WE BAKE</span><span>PANDESAL · ENSAYMADA · MERIENDA</span></div>
+    <h2 class="h2">What we bake.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Hot pandesal, all day</h3><p>The soft, faintly sweet breadcrumb-dusted roll the Filipino morning runs on — first batch from five, then baked in waves so there's a hot one at merienda too. By the piece or the bag.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>Ensaymada &amp; mamon</h3><p>Ensaymada coiled and brushed with butter, sugar and grated cheese, and light mamon sponge — the rich end of the counter, for coffee, gifts and every fiesta table. Boxed to order.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>Everyday breads</h3><p>Monay, Spanish bread rolled with sweet filling, pan de coco, pan de sal de coco and the classic merienda loaves — the honest daily bread that fills a household between meals.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Wholesale to sari-sari</h3><p>We supply the neighbourhood stores, canteens and carinderias around Malolos wholesale, delivered fresh before the streets fill, on standing daily orders — the quiet backbone of the business.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Cakes &amp; fiesta orders</h3><p>Ensaymada trays, bread platters and simple celebration cakes for birthdays, fiestas, baptisms and pasalubong — the breads a Bulacan celebration expects, made ahead so you don't queue.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Kape &amp; merienda counter</h3><p>A hot cup to go with a warm pandesal at the little counter out front — the two-peso pleasure of coffee and bread standing up, the way merienda was always meant to be taken.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 03 / THE DIFFERENCE</span><span>WHY IT STILL TASTES RIGHT</span></div>
+    <h2 class="h2">Why it still tastes <em>right.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Shaped and baked here.</h3><p>Every pandesal is mixed, proofed and shaped in this bakery and baked in our own oven — not trucked in frozen and finished. The same dough this corner has known for fifty years.</p></div>
+      <div><span class="no">02 / 03</span><h3>Baked in waves, all day.</h3><p>We don't bake once and let it sit. Fresh batches come out through the morning and again for merienda, so the bread you buy is warm, not this morning's leftover under a lamp.</p></div>
+      <div><span class="no">03 / 03</span><h3>Recipes handed down.</h3><p>The founder's recipes passed to his children and theirs — tuned to the flour and the weather over the decades, but never cheapened. Three generations, one taste.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 04 / HOW IT GOES</span><span>WALK IN · ORDER · WHOLESALE · WARM</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Come early, or at merienda</h3><p>The first pandesal is out by five; there's a warm batch again mid-afternoon. Walk in, buy by the piece or the bag — no order needed for the daily breads.</p></li>
+      <li><span class="step">STEP 02</span><h3>Order ahead for a crowd</h3><p>Ensaymada trays, bread platters, cakes and big pandesal orders for fiestas and offices — message or call a day ahead and we'll have it boxed and ready.</p></li>
+      <li><span class="step">STEP 03</span><h3>Set up a wholesale run</h3><p>Running a store or canteen? We deliver standing daily orders fresh before opening. Tell us the quantities and route and we'll build it into the morning round.</p></li>
+      <li><span class="step">STEP 04</span><h3>Take it warm</h3><p>Best eaten within the hour, warm, with coffee — that's the whole point. For later, keep it wrapped; a quick warm in the morning brings it back to life.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 05 / FROM THE QUEUE</span><span>MALOLOS IN BREAD FORM</span></div>
+    <blockquote class="t-quote">“The five o'clock batch is worth the early alarm. Fifty years and it hasn't slipped once. This is <em>Malolos in bread form.</em>”</blockquote>
+    <div class="t-attr">Aling Choleng — customer since childhood</div>
+    <div class="t-sub">
+      <figure><blockquote>“Their ensaymada is the one we bring to every family gathering, no debate. Buttery, cheesy, boxed beautifully, and always ready when they say. We've tried the fancy city bakeries — nothing beats San Roque. Nothing.”</blockquote><figcaption>The Bautista family — fiesta &amp; pasalubong orders</figcaption></figure>
+      <figure><blockquote>“My store has taken their wholesale pandesal every single morning for eleven years and they have never once been late. Fresh, reliable, fairly priced — half my regulars come in for it specifically. A bakery you can build a business on.”</blockquote><figcaption>Mang Tonyo — sari-sari store owner</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--cream);">
+  <div class="wrap">
+    <div class="sw-head" style="color:var(--mid);border-color:rgba(42,28,18,0.16);"><span>BATCH 06 / FROM THE OVEN</span><span>FLOUR, BUTTER &amp; HEAT</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1509440159596-0249088772ff?w=1600&q=85&auto=format&fit=crop" alt="Bread rolls cooling on wooden racks." /><figcaption>THE PANDESAL</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1600&q=85&auto=format&fit=crop" alt="Dough being shaped at the bench." /><figcaption>THE SHAPING</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1600&q=85&auto=format&fit=crop" alt="Bread baking in the oven." /><figcaption>THE OVEN</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop" alt="Freshly baked bread on a plate." /><figcaption>THE COUNTER</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop" alt="A cup of coffee beside warm bread." /><figcaption>THE MERIENDA</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop" alt="The counter and shutter of the panaderia." /><figcaption>THE CORNER</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 07 / GOOD TO KNOW</span><span>HOURS, ORDERS &amp; KEEPING FRESH</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+63445550176" style="color:var(--pandesal);font-weight:700;">(044) 555 0176</a>. Or just follow the smell to the corner of Paseo del Congreso.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What time is the first pandesal out?</summary><p>Around five in the morning, seven days a week — the first batch of pandesal is the whole reason a panaderia opens before the sun, and there's usually a small queue of early risers, tricycle drivers and titas waiting with their bags when the shutter goes half up. We bake pandesal in waves after that too, so there's a warm batch again around merienda time in the mid-afternoon, which is when a lot of families do their second run of the day. If you want pandesal genuinely hot from the oven, come for the five o'clock batch or ask us what time the next tray is due — it's worth timing your visit. The daily breads never need an order; just walk up and buy by the piece or the bag.</p></details>
+        <details><summary>What's the difference between pandesal, monay and the sweet breads?</summary><p>Pandesal is the soft, lightly sweet, breadcrumb-dusted morning roll — the everyday staple, eaten warm, split and filled or dunked in coffee. Monay is denser and rounder, a heartier plain bread that keeps well and fills you up. Then there's the sweet and rich end of the counter: ensaymada, coiled and brushed with butter, sugar and grated cheese; mamon, a light sponge; Spanish bread, rolled around a sweet buttery filling; pan de coco, filled with sweet grated coconut; and hopia. Roughly, pandesal and monay are your daily bread, and the rest are for merienda, coffee, gifts and celebrations. Tell us who it's for and how you'll eat it and we'll point you to the right thing.</p></details>
+        <details><summary>Can I order ahead for a fiesta or office?</summary><p>Yes, and we'd encourage it for anything beyond a bag or two, especially around fiestas, Christmas and school events when the counter is busy. We take orders for ensaymada trays, mixed bread platters, big pandesal quantities and simple celebration cakes, boxed and ready for the time you need them, so you're not queuing behind the daily crowd. A day's notice is usually plenty for breads; a little more for cakes and large trays. Message or call us with the quantities, the date and the time, and whether you'll collect or need it set aside, and we'll confirm and have it waiting. Ordering ahead also means you get it at its freshest, baked to your pick-up time.</p></details>
+        <details><summary>Do you supply sari-sari stores and canteens wholesale?</summary><p>Yes — wholesale delivery to the neighbourhood stores, canteens, carinderias and offices around Malolos is a core part of what we do, and for many of them we're a standing daily order delivered fresh before they open. It's the quiet backbone of the bakery: our delivery run goes out early, before the streets fill, so the pandesal is on your shelf warm and ready for the morning rush. If you run a store or a canteen and want to take our bread, talk to us about quantities, timing and your route — we'll work out a standing order that fits your morning and a fair wholesale price, and we pride ourselves on never being late, because your customers are counting on that bread being there.</p></details>
+        <details><summary>How should I keep pandesal and bread fresh?</summary><p>Honestly, the best answer is to eat it warm and soon — pandesal and most of our breads are at their glorious best within an hour or two of baking, which is exactly why we bake in waves through the day. For bread you're keeping until later or the next day, wrap it well and store it at room temperature rather than the fridge, which actually dries bread out faster. A quick warm-up in a low oven, toaster or even a hot pan brings day-old pandesal back to life beautifully, soft inside with a little crisp — many people prefer it that way, split and filled. Richer breads like ensaymada keep a little longer thanks to the butter, and freeze well; just thaw and warm before serving.</p></details>
+        <details><summary>Are you really still using the original recipes?</summary><p>Yes, in the way that matters — the recipes came down from our founder to his children and then to us, and the character of the bread is unchanged, even if the details have been quietly tuned over fifty years. Flour changes, the weather changes, the humidity in Bulacan does its own thing to a dough, and any baker worth their salt adjusts to keep the result the same rather than letting it drift; that's not changing the recipe, it's honouring it. What we've never done is cheapen it — swap in worse fat, cut the proofing time, or truck in frozen dough — because the whole reason people have come to this corner for three generations is that the pandesal tastes like the pandesal they remember.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 08 / WE BAKE FOR</span><span>MALOLOS &amp; AROUND</span></div>
+    <ul class="area-list">
+      <li>Malolos</li><li>Guiguinto</li><li>Plaridel</li><li>Calumpit</li><li>Bulacan</li><li>Wholesale delivery</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 09 / THE ESSENTIALS</span><span>HOW WE BAKE</span></div>
+    <div class="creds">
+      <div><div class="label">Since 1975</div><div class="detail">Three generations on the same corner</div></div>
+      <div><div class="label">From 5AM</div><div class="detail">Hot pandesal, then baked in waves all day</div></div>
+      <div><div class="label">Shaped here</div><div class="detail">Mixed, proofed &amp; baked in our own oven</div></div>
+      <div><div class="label">Wholesale</div><div class="detail">Fresh daily to Malolos stores &amp; canteens</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BATCH 10 / THE CORNER</span><span>PASEO DEL CONGRESO, MALOLOS</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Panaderia de San Roque</strong><br />
+          9 Paseo del Congreso<br />
+          Malolos, Bulacan 3000<br /><br />
+          <a href="tel:+63445550176" data-bind="business.phoneDisplay">(044) 555 0176</a><br />
+          <a href="mailto:hello@sanroquebakery.ph" data-bind="business.email">hello@sanroquebakery.ph</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>DAILY</span><span>5AM – 8PM</span></div>
+          <div class="row"><span>HOT BATCHES</span><span>5AM &amp; 3PM</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. We're on the corner of Paseo del Congreso near the old church — look for the queue and the open shutter.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Panaderia de San Roque, Malolos" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=120.7964%2C14.8333%2C120.8264%2C14.8533&layer=mapnik&marker=14.8433%2C120.8114"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">BATCH 11 / COME BY</div>
+    <h2 data-bind="cta.heading">Come for the five o'clock <em>batch.</em></h2>
+    <p data-bind="cta.body">Hot pandesal from five, ensaymada and mamon, the everyday breads a Filipino morning is built on, and reliable wholesale to the neighbourhood stores — baked on the same Malolos corner since 1975. Order ahead or just follow your nose.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Order or enquire</a>
+      <a class="btn btn-ghost" href="tel:+63445550176" data-bind="cta.secondary.label">(044) 555 0176</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/63445550176" data-bind="messaging.whatsapp" aria-label="Message the bakery">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:26px;">Panaderia de <span style="color:var(--pandesal);font-style:italic;">San Roque</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;">A neighbourhood bakery in Malolos, Bulacan — hot pandesal from five and the breads a Filipino morning is built on, since 1975.</p>
+      </div>
+      <div>
+        <h4>The bakery</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:var(--mid-d);">
+          9 Paseo del Congreso<br />Malolos, Bulacan 3000<br />
+          <a href="tel:+63445550176">(044) 555 0176</a><br />
+          <a href="mailto:hello@sanroquebakery.ph">hello@sanroquebakery.ph</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">What we bake</a><a href="#about">The bakery</a><a href="#location">Find us</a><a href="#book">Order</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> PANADERIA DE SAN ROQUE</span>
+      <span>HOT PANDESAL FROM FIVE · MALOLOS</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/be.html
+++ b/public/template-previews/be.html
@@ -1,0 +1,525 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Kapeng Barako Lipa — heritage Liberica coffee, roasted & ground in Lipa, Batangas</title>
+<meta name="description" content="Kapeng Barako Lipa roasts heritage Batangas barako — bold, smoky Liberica coffee — from farms on the slopes of Mt. Malarayat, roasted in small batches and ground to order, sold as beans, ground and in the café. Reviving the coffee that made Lipa rich. Since 2013." />
+<link href="https://fonts.googleapis.com/css2?family=Zilla+Slab:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Kapeng Barako Lipa", phone: "+63 43 555 0171", phoneDisplay: "(043) 555 0171", email: "kape@barakolipa.ph", foundedYear: 2013 },
+  hero: {
+    kicker: "Heritage barako coffee · Liberica · roasted in Lipa, Batangas",
+    headline: "The coffee that once made this city rich. We brought it back.",
+    lede: "A roastery and café reviving kapeng barako — the bold, smoky Liberica coffee that made Lipa the coffee capital of the country before blight nearly wiped it out. We work with heritage farms on the slopes of Mt. Malarayat, roast in small batches, and grind to order for the strong, aromatic cup Batangueños grew up on. Beans, ground, and brewed strong in the café.",
+    primaryCta: { label: "Order beans or visit", href: "#book" },
+    secondaryCta: { label: "The coffee", href: "#services" },
+    image: "https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "A cup of dark coffee beside roasted beans."
+  },
+  trust: { years: "Reviving barako since 2013" },
+  about: {
+    heading: "Barako almost disappeared. Losing it would have meant losing Lipa's story.",
+    paragraphs: [
+      "Kapeng Barako Lipa is a roastery and café built to save a coffee. Barako is the Batangas name for coffee made from Liberica beans — big, bold, intensely aromatic, with a smoky, woody character and a punch that gave the drink, and eventually strong men, the name 'barako.' In the 1800s Lipa grew rich on it; Batangas was one of the great coffee regions of the world. Then coffee rust blight arrived, the farms collapsed, and barako nearly vanished from the country it once fed.",
+      "We started in 2013 to bring it back properly. We work directly with the heritage farms still growing Liberica on the volcanic slopes of Mt. Malarayat, buy their cherries at a fair price, and roast in small batches so the beans are fresh, not stale from a warehouse. Barako is a bruising, difficult bean to grow and roast well, which is part of why it faded — but done right, nothing else tastes like it: bold, smoky, and unmistakably Batangas.",
+      "We sell whole beans and grind to order — because barako loses its soul sitting pre-ground on a shelf — and we brew it strong in the café the traditional way, black, in a cup that wakes the dead. We also stock the kapeng barako our lolos drank, and the local sweets that go with it. This isn't nostalgia for its own sake; it's keeping a living Batangas craft alive, one bold cup at a time."
+    ],
+    portrait: "https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "Roasted coffee beans spilling from a scoop."
+  },
+  services: [
+    { name: "Whole-bean barako", description: "Heritage Liberica beans from Mt. Malarayat farms, roasted in small batches for freshness and bagged whole. Bold, smoky and aromatic — the real Batangas barako, best ground just before you brew." },
+    { name: "Ground to order", description: "We grind your barako to your brew — for the traditional cloth strainer, French press, drip or espresso — right when you order, because pre-ground beans on a shelf lose exactly what makes barako barako." },
+    { name: "The café — brewed strong", description: "Barako brewed the traditional way, black and strong enough to wake the dead, plus barako-based drinks for the modern palate. Sit with a cup and the local sweets, the way merienda is meant to be." },
+    { name: "Barako blends & single-origin", description: "Pure Liberica for the purists, and balanced barako blends for those easing in — plus other heritage Batangas beans in season. We'll steer you by how bold a cup you can handle." },
+    { name: "Farm-direct, fair trade", description: "We buy cherries directly from the heritage growers at a fair price, because reviving barako means the farms have to survive too. Every bag supports a farmer keeping a near-lost crop alive on the mountain." },
+    { name: "Wholesale & pasalubong", description: "Bags of roasted barako for cafés, offices and shops, plus pasalubong packs to carry the taste of Batangas home. Order beans shipped nationwide, or set up a standing wholesale supply." }
+  ],
+  why: [
+    { title: "Real Liberica, from Lipa.", body: "Barako means Liberica, and ours comes from the heritage farms on Mt. Malarayat that never stopped growing it. This is the genuine Batangas bean — not robusta relabelled, not a blend pretending. The real thing." },
+    { title: "Roasted small, ground fresh.", body: "We roast in small batches and grind to order, because barako's bold aroma fades fast once it's roasted and ground. Freshness is the difference between a cup that sings and one that's just bitter." },
+    { title: "Saving a crop, not just selling coffee.", body: "Barako nearly died out, and the farms nearly with it. Buying direct at fair prices keeps the growers going and the heritage alive. Every bag is a small vote for barako's survival." }
+  ],
+  how: [
+    { step: "01", title: "Tell us your cup", body: "Pure barako or an easing-in blend? Cloth strainer, press, drip or espresso? First time with Liberica or a lifelong Batangueño? Tell us and we'll match you to the right roast and grind." },
+    { step: "02", title: "Beans or ground", body: "Buy whole beans to grind at home for the freshest cup, or have us grind to your brew method on the spot. We'll bag it fresh with the roast date, so you know exactly what you've got." },
+    { step: "03", title: "Brew it bold", body: "Barako wants to be strong and black — that's the point. We'll share how the lolos brewed it with the cloth strainer, plus modern methods, so you get the smoky, aromatic cup at its best." },
+    { step: "04", title: "Re-order or go wholesale", body: "Hooked? We ship beans nationwide, do pasalubong packs, and set up standing supply for cafés and offices. Message us and keep the barako — and the farms — going strong." }
+  ],
+  testimonials: [
+    { quote: "As a Batangueño, this is the barako my lolo drank — bold, smoky, no messing about. Freshly roasted, ground to order, and you can taste that it's the real Liberica, not some watered-down blend. I'm proud someone is keeping this alive in Lipa. My mornings are loyal to this cup now.", name: "Ariel M.", context: "Lipa local" },
+    { quote: "I thought I knew coffee until I had proper barako here. It's unlike anything — this deep, woody, almost smoky intensity. The staff explained the whole history and matched me to a blend to start. I've since gone full pure-Liberica. Buy the beans and grind fresh; it's a revelation.", name: "Denise R.", context: "specialty-coffee convert" },
+    { quote: "We switched our café to their wholesale barako and customers immediately noticed. Fresh, consistent, genuinely local, and there's a real story to tell about the Malarayat farms. Reliable delivery too. Supporting the revival of Batangas coffee and serving a better cup — easy decision.", name: "Café owner, Tagaytay", context: "wholesale account" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=1600&q=85&auto=format&fit=crop", alt: "A cup of dark coffee beside roasted beans." },
+    { src: "https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=1600&q=85&auto=format&fit=crop", alt: "Roasted coffee beans spilling from a scoop." },
+    { src: "https://images.unsplash.com/photo-1442512595331-e89e73853f31?w=1600&q=85&auto=format&fit=crop", alt: "Coffee cherries on the branch." },
+    { src: "https://images.unsplash.com/photo-1511537190424-bbbab87ac5eb?w=1600&q=85&auto=format&fit=crop", alt: "Green coffee beans being sorted." },
+    { src: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop", alt: "A black coffee on a wooden table." },
+    { src: "https://images.unsplash.com/photo-1442550528053-c431ecb55509?w=1600&q=85&auto=format&fit=crop", alt: "A coffee roaster at work." }
+  ],
+  faq: [
+    { q: "What is kapeng barako, and how is it different from other coffee?", a: "Kapeng barako is coffee made primarily from Liberica beans, and it's most associated with Batangas, especially Lipa and the surrounding towns. It's quite different from the two coffees most people know: it's not Arabica (the smoother, more acidic specialty standard) nor mainstream Robusta (the strong, cheap workhorse of instant coffee). Liberica beans are large and irregular, and they produce a cup with a distinctive bold, full-bodied, intensely aromatic character — smoky, woody, sometimes almost fruity or floral underneath, with a real punch. That strength is where the name comes from: 'barako' evokes a wild boar and, by extension, toughness and machismo, which is how Batangueños have long thought of their coffee. If your only reference points are a delicate pour-over or a supermarket blend, barako will surprise you — it's assertive and unmistakable. It rewards being brewed strong and drunk black, the traditional way, and once people acquire the taste, ordinary coffee can feel a little thin by comparison." },
+    { q: "Why did barako nearly disappear, and why does reviving it matter?", a: "In the 1800s, Batangas — and Lipa in particular — was one of the great coffee regions of the world, and barako made the area genuinely wealthy; there's real history in those grand old Lipa houses built on coffee money. Then coffee rust blight (and later other pressures) devastated the plantations, and the industry largely collapsed, with land converted to other crops and barako declining from a national staple to a regional rarity. On top of that, Liberica is simply a harder, lower-yielding, more labour-intensive bean to grow and process well than the commercial alternatives, so as the global market standardised around Arabica and Robusta, barako had little economic momentum left. Reviving it matters for a few reasons: it's a genuine part of Philippine and Batangas heritage that would be a real loss to let vanish; it's a distinctive coffee that deserves a place in the world's cups on its own merits; and supporting the remaining heritage farms gives growers a reason to keep cultivating it rather than abandoning the trees. We see selling barako as keeping a living tradition alive, not embalming a dead one." },
+    { q: "Do you really source directly from the farms?", a: "Yes — we work directly with heritage Liberica growers on the volcanic slopes of Mt. Malarayat and the surrounding Batangas uplands, buying their coffee cherries at a fair price rather than going through layers of middlemen. This matters for both quality and ethics. On quality, buying direct lets us know exactly whose trees the beans came from, select for ripeness and care, and control freshness from cherry to roast. On ethics and sustainability, the honest truth is that barako only survives if growing it is worth the farmers' while: Liberica is demanding to cultivate and the trees are often old, so if growers can't earn fairly from it, they'll understandably switch to easier, more profitable crops and the heritage disappears for good. Paying a fair farm-gate price is therefore not charity or marketing — it's the actual mechanism by which barako gets to survive. When you buy a bag from us, a real share of that supports a specific farming family keeping a near-lost crop alive on the mountain, and we're glad to tell you more about the farms we work with." },
+    { q: "Should I buy whole beans or ground, and how should I brew barako?", a: "Buy whole beans and grind just before brewing if you possibly can — this is true for all coffee but especially for barako, whose bold aroma and character fade noticeably once the beans are ground and exposed to air. We roast in small batches and grind to order for exactly this reason, and every bag is dated so you know its freshness. As for brewing: barako is traditionally made strong and drunk black, and it genuinely shines that way. The classic Batangas method uses a cloth strainer (the 'coffee sock' or bahag), essentially a rustic pour-over that produces a robust, full cup, and it's worth trying for the authentic experience. But barako also works beautifully in a French press (great for its body), in drip machines, and even pulled as a bold, unusual espresso. Whatever method, lean towards a stronger brew than you might for Arabica — under-brewed barako sells itself short. Tell us how you like to drink coffee and we'll recommend a roast, grind and method to suit; if you're new to Liberica, we'll often suggest starting with a blend and working towards pure barako." },
+    { q: "I find barako too strong or bitter — is it for me?", a: "Maybe, with the right approach — barako is assertive by nature, but 'too strong or bitter' is often a brewing or roast issue rather than the bean's fault. A few things help. First, we offer barako blends as well as pure Liberica; a blend eases you into the flavour with a bit less intensity, and it's how a lot of people build a taste for it. Second, brewing technique matters enormously: bitterness usually comes from over-extraction — water too hot, grind too fine, or brewing too long — so a slightly coarser grind, water just off the boil, and not over-steeping can transform the cup from harsh to bold-but-smooth. Third, while purists drink it black, there's absolutely no shame in a little sugar or milk while you're getting used to it; plenty of lifelong barako drinkers take it with muscovado. Come to the café and let us brew you a properly made cup — a lot of people who think they dislike barako have actually only had it badly made or stale. If, after a well-brewed cup, it's genuinely not for you, that's fine too; taste is personal, and we'd rather match you to a coffee you love than sell you one you won't finish." },
+    { q: "Can I get barako shipped, as pasalubong, or for my café?", a: "Yes to all three. For individuals, we ship roasted barako beans and ground coffee nationwide, so you can keep your supply going wherever you are, and we do pasalubong packs specifically designed to carry the taste of Batangas home to family or send to relatives — barako is a wonderful, distinctive gift precisely because it's so tied to place. For businesses, wholesale is a core part of what we do: we supply cafés, restaurants, offices and shops with freshly roasted barako on a regular basis, and there's a genuine story to tell your own customers about serving a revived heritage Philippine coffee from the Malarayat farms, which many find compelling. Wholesale customers get consistent supply, fair pricing and the freshness that comes from small-batch roasting to order rather than warehouse stock. Whether you want a single pasalubong bag, a monthly home delivery, or a standing café supply, message us with what you need and we'll sort quantities, grind, roast level and terms. Keeping barako alive depends on more people drinking it, so we're always glad to help it reach a new cup." }
+  ],
+  area: { places: ["Lipa", "Batangas City", "Tanauan", "Tagaytay", "Batangas", "Nationwide shipping"] },
+  credentials: [
+    { label: "Since 2013", detail: "Reviving Lipa's heritage barako" },
+    { label: "Real Liberica", detail: "From Mt. Malarayat heritage farms" },
+    { label: "Small-batch", detail: "Roasted fresh, ground to order" },
+    { label: "Farm-direct", detail: "Fair prices keep the growers going" }
+  ],
+  location: { name: "Kapeng Barako Lipa", addressStreet: "19 C.M. Recto Avenue", addressLocality: "Lipa", addressRegion: "Batangas", addressPostcode: "4217", addressCountry: "Philippines" },
+  cta: { heading: "Taste the coffee that built Lipa.", body: "Heritage Batangas barako — bold, smoky Liberica from the Mt. Malarayat farms, roasted in small batches and ground to order, brewed strong in the café or bagged for home. Reviving a near-lost coffee since 2013.", primary: { label: "Order beans or visit", href: "#book" }, secondary: { label: "(043) 555 0171", href: "tel:+63435550171" } },
+  messaging: { whatsapp: "https://wa.me/63435550171", messenger: "https://m.me/barakolipa" }
+};
+</script>
+
+<style>
+  :root {
+    --bean:#241812; --bean-2:#1a110c; --oat:#efe4d0; --oat-2:#f7efdf; --ink:#2c2119; --ink-2:#52443a;
+    --barako:#b5471f; --gold:#cf9137; --leaf:#5f7a44;
+    --mid:#8a7963; --mid-d:#c9b393; --rule:rgba(44,33,25,0.14); --rule-d:rgba(239,228,208,0.16);
+    --disp:"Zilla Slab",Georgia,serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--oat);color:var(--ink);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--barako);}
+  .wrap{width:min(1240px,92vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.15em;text-transform:uppercase;color:var(--barako);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:700;font-size:clamp(38px,5.4vw,78px);line-height:1.04;margin:0 0 0.32em;letter-spacing:-0.01em;}
+  .h2 em{font-style:normal;color:var(--barako);}
+  .body{color:var(--mid);line-height:1.7;}
+  section{padding:clamp(76px,9vw,130px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:16px 32px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:3px;}
+  .btn-primary{background:var(--barako);color:var(--oat-2);} .btn-primary:hover{background:var(--bean);}
+  .btn-ghost{border:1.5px solid var(--bean);color:var(--bean);} .btn-ghost:hover{background:var(--bean);color:var(--oat-2);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.15em;text-transform:uppercase;color:var(--mid);border-bottom:1.5px solid var(--rule);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,60px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(239,228,208,0.93);backdrop-filter:blur(10px);border-bottom:1.5px solid var(--bean);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:15px 0;}
+  .wm{font-family:var(--disp);font-weight:700;font-size:23px;text-decoration:none;letter-spacing:-0.01em;color:var(--bean);}
+  .wm span{color:var(--barako);}
+  .nav-links{display:flex;gap:26px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;text-transform:uppercase;color:var(--mid);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,66px) 0 clamp(60px,7vw,100px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:700;font-size:clamp(42px,6.4vw,98px);line-height:1.0;letter-spacing:-0.02em;margin:0 0 34px;max-width:17ch;color:var(--bean);}
+  .hero-headline em{font-style:normal;color:var(--barako);}
+  .hero-lower{display:grid;grid-template-columns:1.15fr 0.85fr;gap:clamp(30px,4vw,64px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:4px;}
+  .hero-photo::after{content:"HERITAGE LIBERICA · SINCE 2013";position:absolute;left:14px;bottom:14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.12em;background:var(--gold);color:var(--bean);padding:7px 12px;border-radius:3px;}
+  .hero-right .lede{color:var(--mid);font-size:clamp(15px,1.5vw,17.5px);line-height:1.74;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--bean);color:var(--oat-2);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(247,239,223,0.86);font-weight:700;}
+
+  .about{background:var(--oat-2);color:var(--ink);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:4px;}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.78;margin:0 0 1em;color:#4d3d31;}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:1.5px solid var(--bean);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid var(--rule);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(181,71,31,0.1);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;color:var(--leaf);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:700;font-size:clamp(24px,2.6vw,34px);margin:0;line-height:1.06;letter-spacing:-0.01em;}
+  .svc-row p{color:var(--mid);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--bean);color:var(--oat);}
+  .why .sw-head{color:var(--mid-d);border-color:var(--rule-d);}
+  .why .h2{color:var(--oat);} .why .h2 em{color:var(--gold);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.16em;color:var(--gold);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:700;font-size:28px;margin:0 0 10px;line-height:1.1;letter-spacing:-0.01em;}
+  .why-grid p{color:var(--mid-d);margin:0;font-size:14.5px;line-height:1.72;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:1.5px solid var(--rule);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--leaf);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:700;font-size:24px;margin:8px 0 8px;line-height:1.1;letter-spacing:-0.01em;}
+  .how-grid p{color:var(--mid);margin:0;font-size:13.5px;line-height:1.66;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--bean-2);color:var(--oat);}
+  .t-quote{font-family:var(--disp);font-weight:700;font-size:clamp(28px,3.7vw,54px);line-height:1.1;max-width:26ch;margin:0 0 24px;letter-spacing:-0.01em;}
+  .t-quote em{font-style:normal;color:var(--gold);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--gold);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:1.5px solid var(--rule-d);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.74;margin:0 0 12px;color:var(--mid-d);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:4px;}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--barako);color:var(--oat-2);font-family:var(--mono);font-size:9px;letter-spacing:0.08em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule);padding:22px 0;}
+  .faq-list details:first-child{border-top:1.5px solid var(--bean);}
+  .faq-list summary{font-family:var(--disp);font-weight:700;font-size:22px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.16;letter-spacing:-0.01em;}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--barako);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--mid);font-size:14.5px;max-width:64ch;line-height:1.74;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.08em;text-transform:uppercase;padding:10px 20px;border:1.5px solid var(--bean);border-radius:3px;font-weight:700;color:var(--mid);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:1.5px solid var(--rule);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--barako);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:700;font-size:20px;line-height:1.18;letter-spacing:-0.01em;}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--bean);color:var(--oat);padding:34px;border-radius:4px;}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:700;font-size:22px;line-height:1.3;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:500;color:var(--mid-d);}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:1px solid var(--rule-d);padding-top:18px;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--mid-d);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--mid-d);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:4px;border:1.5px solid var(--bean);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.3) invert(0.9) hue-rotate(160deg) brightness(0.9) sepia(0.2);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--barako);color:var(--oat-2);padding:clamp(84px,10vw,150px) 0;text-align:center;}
+  .cta-band .kick{color:var(--oat-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:700;font-size:clamp(44px,6.5vw,106px);line-height:1.0;margin:14px auto 18px;max-width:15ch;}
+  .cta-band h2 em{font-style:normal;color:var(--gold);}
+  .cta-band p{color:rgba(247,239,223,0.92);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--oat-2);color:var(--barako);} .cta-band .btn-primary:hover{background:var(--bean);color:var(--oat-2);}
+  .cta-band .btn-ghost{border-color:var(--oat-2);color:var(--oat-2);} .cta-band .btn-ghost:hover{background:var(--oat-2);color:var(--barako);}
+
+  footer{background:var(--bean-2);color:var(--oat);border-top:1.5px solid var(--rule-d);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--gold);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:var(--mid-d);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid var(--rule-d);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--barako);color:var(--oat-2);padding:13px 20px;border-radius:3px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;box-shadow:0 8px 24px rgba(181,71,31,0.4);}
+  .msg-fab a:hover{background:var(--bean);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"CafeOrCoffeeShop","name":"Kapeng Barako Lipa","description":"Roastery and café reviving heritage Batangas barako — bold, smoky Liberica coffee from Mt. Malarayat farms, roasted in small batches and ground to order, sold as beans and ground and brewed in the café. Since 2013.","url":"https://barakolipa.ph/","telephone":"+63435550171","email":"kape@barakolipa.ph","address":{"@type":"PostalAddress","streetAddress":"19 C.M. Recto Avenue","addressLocality":"Lipa","addressRegion":"Batangas","postalCode":"4217","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":13.9410,"longitude":121.1620},"areaServed":["Lipa","Batangas City","Tanauan","Tagaytay"],"image":["https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=1600"],"foundingDate":"2013"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What is kapeng barako and how is it different?","acceptedAnswer":{"@type":"Answer","text":"Kapeng barako is coffee made mainly from Liberica beans, most associated with Batangas, especially Lipa. It's neither Arabica nor mainstream Robusta — Liberica beans are large and irregular and give a bold, full-bodied, intensely aromatic cup: smoky, woody, with a real punch. The name evokes toughness and machismo. It rewards being brewed strong and drunk black, the traditional way, and once you acquire the taste, ordinary coffee can feel thin."}},
+{"@type":"Question","name":"Why did barako nearly disappear, and why revive it?","acceptedAnswer":{"@type":"Answer","text":"In the 1800s Batangas, and Lipa especially, was a great coffee region that grew wealthy on barako. Then coffee rust blight devastated the plantations and the industry largely collapsed; Liberica is also harder and lower-yielding than Arabica or Robusta, so it lost economic momentum. Reviving it matters because it's genuine Philippine heritage, a distinctive coffee worth its place, and supporting the heritage farms gives growers a reason to keep the trees. We see it as keeping a living tradition alive."}},
+{"@type":"Question","name":"Do you really source directly from the farms?","acceptedAnswer":{"@type":"Answer","text":"Yes — we work directly with heritage Liberica growers on Mt. Malarayat and the Batangas uplands, buying cherries at a fair price rather than through middlemen. It lets us control quality and freshness and know whose trees the beans came from. Crucially, barako only survives if growing it is worth the farmers' while, so a fair farm-gate price is the actual mechanism by which it endures — not charity. A real share of each bag supports a specific family keeping a near-lost crop alive."}},
+{"@type":"Question","name":"Should I buy whole beans or ground, and how do I brew barako?","acceptedAnswer":{"@type":"Answer","text":"Buy whole beans and grind just before brewing — barako's bold aroma fades once ground. We roast small-batch and grind to order, and date every bag. Brew it strong and black to let it shine: the traditional cloth strainer (coffee sock) is worth trying, but it's also great in a French press, drip, or as a bold espresso. Lean stronger than you would for Arabica. Tell us how you drink coffee and we'll recommend a roast, grind and method; newcomers often start with a blend."}},
+{"@type":"Question","name":"I find barako too strong or bitter — is it for me?","acceptedAnswer":{"@type":"Answer","text":"Maybe, with the right approach — 'too bitter' is often a brewing or freshness issue. We offer blends as well as pure Liberica to ease you in. Bitterness usually comes from over-extraction, so a coarser grind, water just off the boil and not over-steeping help a lot. Purists drink it black, but there's no shame in a little muscovado or milk while you adjust. Come to the café for a properly made cup — many who think they dislike barako have only had it stale or badly brewed."}},
+{"@type":"Question","name":"Can I get barako shipped, as pasalubong, or for my café?","acceptedAnswer":{"@type":"Answer","text":"Yes to all three. We ship roasted beans and ground coffee nationwide and do pasalubong packs to carry the taste of Batangas home. For businesses, wholesale is core — we supply cafés, restaurants, offices and shops with freshly roasted barako on a regular basis, with a genuine heritage story to tell your customers, consistent supply, fair pricing and small-batch freshness. Message us with what you need and we'll sort quantities, grind, roast level and terms."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Kapeng Barako <span>Lipa</span></a>
+    <nav class="nav-links">
+      <a href="#about">The roastery</a><a href="#services">The coffee</a><a href="#location">Find us</a><a href="#book">Order</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Heritage barako coffee · Liberica · roasted in Lipa, Batangas</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      The coffee that once made this city <em>rich.</em> We brought it back.
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=2000&q=85&auto=format&fit=crop"
+             alt="A cup of dark coffee beside roasted beans." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A roastery and café reviving kapeng barako — the bold, smoky Liberica coffee that made Lipa the coffee capital of the country before blight nearly wiped it out. We work with heritage farms on the slopes of Mt. Malarayat, roast in small batches, and grind to order for the strong, aromatic cup Batangueños grew up on. Beans, ground, and brewed strong in the café.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Order beans or visit</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">The coffee</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Reviving barako since 2013</span>
+    <span>Real Liberica, from Lipa</span>
+    <span>Small-batch, ground to order</span>
+    <span>Farm-direct &amp; fair</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 01 / THE ROASTERY</span><span>SLOPES OF MT. MALARAYAT</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">Barako almost disappeared. Losing it would have meant losing Lipa's <em>story.</em></h2>
+        <p>Kapeng Barako Lipa is a roastery and café built to save a coffee. Barako is the Batangas name for coffee made from Liberica beans — big, bold, intensely aromatic, with a smoky, woody character and a punch that gave the drink, and eventually strong men, the name "barako." In the 1800s Lipa grew rich on it; Batangas was one of the great coffee regions of the world. Then coffee rust blight arrived, the farms collapsed, and barako nearly vanished from the country it once fed.</p>
+        <p>We started in 2013 to bring it back properly. We work directly with the heritage farms still growing Liberica on the volcanic slopes of Mt. Malarayat, buy their cherries at a fair price, and roast in small batches so the beans are fresh, not stale from a warehouse. Barako is a bruising, difficult bean to grow and roast well, which is part of why it faded — but done right, nothing else tastes like it: bold, smoky, and unmistakably Batangas.</p>
+        <p>We sell whole beans and grind to order — because barako loses its soul sitting pre-ground on a shelf — and we brew it strong in the café the traditional way, black, in a cup that wakes the dead. We also stock the kapeng barako our lolos drank, and the local sweets that go with it. This isn't nostalgia for its own sake; it's keeping a living Batangas craft alive, one bold cup at a time.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=1200&q=85&auto=format&fit=crop"
+           alt="Roasted coffee beans spilling from a scoop." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" data-component="SERVICES" data-variant="v78" data-screen-label="Services">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 02 / THE COFFEE</span><span>BEANS · GROUND · CAFÉ · WHOLESALE</span></div>
+    <h2 class="h2">The coffee.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Whole-bean barako</h3><p>Heritage Liberica beans from Mt. Malarayat farms, roasted in small batches for freshness and bagged whole. Bold, smoky and aromatic — the real Batangas barako, best ground just before you brew.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>Ground to order</h3><p>We grind your barako to your brew — cloth strainer, French press, drip or espresso — right when you order, because pre-ground beans on a shelf lose exactly what makes barako barako.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>The café — brewed strong</h3><p>Barako brewed the traditional way, black and strong enough to wake the dead, plus barako-based drinks for the modern palate. Sit with a cup and the local sweets, the way merienda is meant to be.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Blends &amp; single-origin</h3><p>Pure Liberica for the purists, and balanced barako blends for those easing in — plus other heritage Batangas beans in season. We'll steer you by how bold a cup you can handle.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Farm-direct, fair trade</h3><p>We buy cherries directly from the heritage growers at a fair price, because reviving barako means the farms have to survive too. Every bag supports a farmer keeping a near-lost crop alive on the mountain.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Wholesale &amp; pasalubong</h3><p>Bags of roasted barako for cafés, offices and shops, plus pasalubong packs to carry the taste of Batangas home. Order beans shipped nationwide, or set up a standing wholesale supply.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 03 / THE DIFFERENCE</span><span>WHY OURS IS THE REAL BARAKO</span></div>
+    <h2 class="h2">Why ours is the real <em>barako.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Real Liberica, from Lipa.</h3><p>Barako means Liberica, and ours comes from the heritage farms on Mt. Malarayat that never stopped growing it. This is the genuine Batangas bean — not robusta relabelled, not a blend pretending. The real thing.</p></div>
+      <div><span class="no">02 / 03</span><h3>Roasted small, ground fresh.</h3><p>We roast in small batches and grind to order, because barako's bold aroma fades fast once it's roasted and ground. Freshness is the difference between a cup that sings and one that's just bitter.</p></div>
+      <div><span class="no">03 / 03</span><h3>Saving a crop, not just coffee.</h3><p>Barako nearly died out, and the farms nearly with it. Buying direct at fair prices keeps the growers going and the heritage alive. Every bag is a small vote for barako's survival.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 04 / HOW IT GOES</span><span>CUP · BEANS · BREW · RE-ORDER</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Tell us your cup</h3><p>Pure barako or an easing-in blend? Cloth strainer, press, drip or espresso? First time with Liberica or a lifelong Batangueño? Tell us and we'll match you to the right roast and grind.</p></li>
+      <li><span class="step">STEP 02</span><h3>Beans or ground</h3><p>Buy whole beans to grind at home for the freshest cup, or have us grind to your brew method on the spot. We'll bag it fresh with the roast date, so you know exactly what you've got.</p></li>
+      <li><span class="step">STEP 03</span><h3>Brew it bold</h3><p>Barako wants to be strong and black — that's the point. We'll share how the lolos brewed it with the cloth strainer, plus modern methods, so you get the smoky, aromatic cup at its best.</p></li>
+      <li><span class="step">STEP 04</span><h3>Re-order or go wholesale</h3><p>Hooked? We ship beans nationwide, do pasalubong packs, and set up standing supply for cafés and offices. Message us and keep the barako — and the farms — going strong.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 05 / FROM THE CUP</span><span>THE BARAKO MY LOLO DRANK</span></div>
+    <blockquote class="t-quote">“This is the barako my lolo drank — bold, smoky, no messing about. My mornings are <em>loyal to this cup</em> now.”</blockquote>
+    <div class="t-attr">Ariel M. — Lipa local</div>
+    <div class="t-sub">
+      <figure><blockquote>“I thought I knew coffee until I had proper barako here. This deep, woody, almost smoky intensity. The staff explained the whole history and matched me to a blend to start. I've since gone full pure-Liberica. Buy the beans and grind fresh; it's a revelation.”</blockquote><figcaption>Denise R. — specialty-coffee convert</figcaption></figure>
+      <figure><blockquote>“We switched our café to their wholesale barako and customers immediately noticed. Fresh, consistent, genuinely local, and there's a real story to tell about the Malarayat farms. Reliable delivery too. Supporting the revival of Batangas coffee and serving a better cup — easy decision.”</blockquote><figcaption>Café owner, Tagaytay — wholesale account</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--oat-2);">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 06 / CHERRY TO CUP</span><span>BOLD, SMOKY &amp; BATANGAS</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?w=1600&q=85&auto=format&fit=crop" alt="A cup of dark coffee beside roasted beans." /><figcaption>THE CUP</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=1600&q=85&auto=format&fit=crop" alt="Roasted coffee beans spilling from a scoop." /><figcaption>THE ROAST</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1442512595331-e89e73853f31?w=1600&q=85&auto=format&fit=crop" alt="Coffee cherries on the branch." /><figcaption>THE CHERRY</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1511537190424-bbbab87ac5eb?w=1600&q=85&auto=format&fit=crop" alt="Green coffee beans being sorted." /><figcaption>THE SORT</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop" alt="A black coffee on a wooden table." /><figcaption>THE BLACK</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1442550528053-c431ecb55509?w=1600&q=85&auto=format&fit=crop" alt="A coffee roaster at work." /><figcaption>THE ROASTER</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 07 / GOOD TO KNOW</span><span>THE BEAN, THE HISTORY &amp; THE BREW</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+63435550171" style="color:var(--barako);font-weight:700;">(043) 555 0171</a>. New to Liberica? Come to the café and let us brew you a proper cup.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What is kapeng barako, and how is it different from other coffee?</summary><p>Kapeng barako is coffee made primarily from Liberica beans, most associated with Batangas, especially Lipa and the surrounding towns. It's quite different from the two coffees most people know: it's not Arabica (the smoother, more acidic specialty standard) nor mainstream Robusta (the strong, cheap workhorse of instant coffee). Liberica beans are large and irregular, and they produce a cup with a distinctive bold, full-bodied, intensely aromatic character — smoky, woody, sometimes almost fruity or floral underneath, with a real punch. That strength is where the name comes from: 'barako' evokes a wild boar and, by extension, toughness. If your only reference points are a delicate pour-over or a supermarket blend, barako will surprise you — it's assertive and unmistakable, and rewards being brewed strong and drunk black.</p></details>
+        <details><summary>Why did barako nearly disappear, and why does reviving it matter?</summary><p>In the 1800s, Batangas — and Lipa in particular — was one of the great coffee regions of the world, and barako made the area genuinely wealthy. Then coffee rust blight and later pressures devastated the plantations, and the industry largely collapsed, with barako declining from a national staple to a regional rarity. Liberica is also a harder, lower-yielding, more labour-intensive bean than the commercial alternatives, so as the market standardised around Arabica and Robusta, it had little economic momentum left. Reviving it matters because it's genuine Philippine and Batangas heritage that would be a real loss to let vanish; it's a distinctive coffee that deserves a place on its own merits; and supporting the heritage farms gives growers a reason to keep cultivating it. We see selling barako as keeping a living tradition alive.</p></details>
+        <details><summary>Do you really source directly from the farms?</summary><p>Yes — we work directly with heritage Liberica growers on the volcanic slopes of Mt. Malarayat and the surrounding Batangas uplands, buying cherries at a fair price rather than through layers of middlemen. On quality, this lets us know whose trees the beans came from, select for ripeness and control freshness from cherry to roast. On sustainability, the honest truth is that barako only survives if growing it is worth the farmers' while: Liberica is demanding and the trees are often old, so if growers can't earn fairly, they'll switch to easier crops and the heritage disappears. A fair farm-gate price is therefore the actual mechanism by which barako survives — not charity. A real share of each bag supports a specific family keeping a near-lost crop alive.</p></details>
+        <details><summary>Should I buy whole beans or ground, and how should I brew barako?</summary><p>Buy whole beans and grind just before brewing if you can — this is true for all coffee but especially barako, whose bold aroma fades noticeably once ground and exposed to air. We roast small-batch and grind to order for that reason, and date every bag. As for brewing: barako is traditionally made strong and drunk black, and it genuinely shines that way. The classic Batangas method uses a cloth strainer (the coffee sock), essentially a rustic pour-over producing a robust cup, and it's worth trying for the authentic experience. But barako also works beautifully in a French press, in drip machines, and as a bold espresso. Lean towards a stronger brew than for Arabica. Tell us how you drink coffee and we'll recommend a roast, grind and method; newcomers often start with a blend.</p></details>
+        <details><summary>I find barako too strong or bitter — is it for me?</summary><p>Maybe, with the right approach — barako is assertive by nature, but 'too strong or bitter' is often a brewing or roast issue rather than the bean's fault. We offer blends as well as pure Liberica; a blend eases you into the flavour with a bit less intensity. Brewing technique matters enormously: bitterness usually comes from over-extraction — water too hot, grind too fine, or brewing too long — so a coarser grind, water just off the boil, and not over-steeping can transform the cup. And while purists drink it black, there's no shame in a little muscovado or milk while you're getting used to it. Come to the café and let us brew you a properly made cup — a lot of people who think they dislike barako have only had it stale or badly made.</p></details>
+        <details><summary>Can I get barako shipped, as pasalubong, or for my café?</summary><p>Yes to all three. For individuals, we ship roasted barako beans and ground coffee nationwide, and we do pasalubong packs designed to carry the taste of Batangas home or send to relatives — barako is a wonderful, distinctive gift precisely because it's so tied to place. For businesses, wholesale is a core part of what we do: we supply cafés, restaurants, offices and shops with freshly roasted barako on a regular basis, and there's a genuine story to tell your own customers about serving a revived heritage Philippine coffee from the Malarayat farms. Wholesale customers get consistent supply, fair pricing and small-batch freshness. Whether you want a single pasalubong bag, a monthly home delivery, or a standing café supply, message us and we'll sort quantities, grind, roast level and terms.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 08 / WE SERVE</span><span>BATANGAS &amp; BEYOND</span></div>
+    <ul class="area-list">
+      <li>Lipa</li><li>Batangas City</li><li>Tanauan</li><li>Tagaytay</li><li>Batangas</li><li>Nationwide shipping</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 09 / THE ESSENTIALS</span><span>HOW WE ROAST</span></div>
+    <div class="creds">
+      <div><div class="label">Since 2013</div><div class="detail">Reviving Lipa's heritage barako</div></div>
+      <div><div class="label">Real Liberica</div><div class="detail">From Mt. Malarayat heritage farms</div></div>
+      <div><div class="label">Small-batch</div><div class="detail">Roasted fresh, ground to order</div></div>
+      <div><div class="label">Farm-direct</div><div class="detail">Fair prices keep the growers going</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>ROAST 10 / THE ROASTERY</span><span>C.M. RECTO AVE, LIPA</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Kapeng Barako Lipa</strong><br />
+          19 C.M. Recto Avenue<br />
+          Lipa, Batangas 4217<br /><br />
+          <a href="tel:+63435550171" data-bind="business.phoneDisplay">(043) 555 0171</a><br />
+          <a href="mailto:kape@barakolipa.ph" data-bind="business.email">kape@barakolipa.ph</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>MON – SUN</span><span>7AM – 8PM</span></div>
+          <div class="row"><span>WHOLESALE</span><span>BY ENQUIRY</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. We're on C.M. Recto Avenue in Lipa — the roastery and café are in one. Walk in for a cup and beans, or enquire for wholesale.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Kapeng Barako Lipa, Lipa" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=121.1470%2C13.9310%2C121.1770%2C13.9510&layer=mapnik&marker=13.9410%2C121.1620"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">ROAST 11 / ORDER</div>
+    <h2 data-bind="cta.heading">Taste the coffee that built <em>Lipa.</em></h2>
+    <p data-bind="cta.body">Heritage Batangas barako — bold, smoky Liberica from the Mt. Malarayat farms, roasted in small batches and ground to order, brewed strong in the café or bagged for home. Reviving a near-lost coffee since 2013.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Order beans or visit</a>
+      <a class="btn btn-ghost" href="tel:+63435550171" data-bind="cta.secondary.label">(043) 555 0171</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/63435550171" data-bind="messaging.whatsapp" aria-label="Message the roastery">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:23px;color:var(--oat);">Kapeng Barako <span style="color:var(--gold);">Lipa</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;color:var(--mid-d);">A roastery and café reviving heritage Batangas barako — bold, smoky Liberica from Mt. Malarayat, since 2013.</p>
+      </div>
+      <div>
+        <h4>The roastery</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:var(--mid-d);">
+          19 C.M. Recto Avenue<br />Lipa, Batangas 4217<br />
+          <a href="tel:+63435550171">(043) 555 0171</a><br />
+          <a href="mailto:kape@barakolipa.ph">kape@barakolipa.ph</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">The coffee</a><a href="#about">The roastery</a><a href="#location">Find us</a><a href="#book">Order</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> KAPENG BARAKO LIPA</span>
+      <span>HERITAGE LIBERICA · BATANGAS</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/bf.html
+++ b/public/template-previews/bf.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Andok's Kanto Grill — lechon manok, liempo & pork barbecue off the rotisserie, Cabanatuan</title>
+<meta name="description" content="Andok's Kanto Grill roasts lechon manok in Cabanatuan — whole chickens marinated overnight and turned on the rotisserie until the skin crackles, plus grilled liempo, pork barbecue sticks, java rice and atchara. Take-out, delivery and party trays. Turning the spit since 2008." />
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Andok's Kanto Grill", phone: "+63 44 555 0193", phoneDisplay: "(044) 555 0193", email: "orders@kantogrill.ph", foundedYear: 2008 },
+  hero: {
+    kicker: "Lechon manok · liempo · pork BBQ · Cabanatuan, Nueva Ecija",
+    headline: "Whole chickens turning on the spit. That smell does the advertising.",
+    lede: "A roadside rotisserie grill in Cabanatuan — whole chickens marinated overnight in soy, calamansi, lemongrass and garlic, then turned slowly over coals until the skin goes crackling-gold and the meat falls off the bone. Plus grilled liempo, pork barbecue on sticks, java rice and house atchara. Take-out, delivery, and party trays that make you everyone's favourite person.",
+    primaryCta: { label: "Order for pick-up", href: "#book" },
+    secondaryCta: { label: "Off the grill", href: "#services" },
+    image: "https://images.unsplash.com/photo-1598515214211-89d3c73ae83b?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "Chicken roasting over glowing coals on a grill."
+  },
+  trust: { years: "Turning the spit since 2008" },
+  about: {
+    heading: "One chicken, one fire, one job: get the skin right.",
+    paragraphs: [
+      "Andok's Kanto Grill is a roadside lechon manok stand in Cabanatuan, and lechon manok — literally 'roast chicken' — is one of the great everyday Filipino dinners. It's the thing you grab on the way home when you don't want to cook: a whole roasted chicken in a bag, a tub of java rice, some atchara, and dinner's done for a family of five for the price of a couple of fast-food meals. Every kanto in the country has one. Not every one gets it right.",
+      "We've been turning the spit since 2008, and the whole discipline is in two places: the marinade and the fire. Our chickens sit overnight in soy, calamansi, lemongrass, garlic and pepper, so the flavour is in the meat rather than brushed on the outside. Then they're skewered whole and turned slowly over live coals — not baked in a gas oven — so the fat renders down, the skin dries and crisps to that lacquered crackling gold, and the meat inside stays properly juicy.",
+      "Beyond the chicken we grill liempo (pork belly) marinated the same way, skewers of pork barbecue glazed sweet and sticky, and we cook the java rice and pickle the green-papaya atchara that go with them. Everything's built for take-out and delivery — bagged hot, ready in minutes — and we do party trays for fiestas, birthdays and offices. Roadside food, done seriously. Follow the smoke to the kanto."
+    ],
+    portrait: "https://images.unsplash.com/photo-1432139555190-58524dae6a55?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "Meat grilling over an open charcoal fire."
+  },
+  services: [
+    { name: "Whole lechon manok", description: "The headliner: a whole chicken marinated overnight and rotisserie-roasted over coals to crackling-gold skin and juicy meat. Bagged hot with sauce, ready to carry home. Order whole or half." },
+    { name: "Grilled liempo", description: "Pork belly marinated in the same soy-calamansi-lemongrass blend and grilled over coals until the edges char and the fat renders — chopped and served with rice and vinegar dip. The pork order to get." },
+    { name: "Pork barbecue sticks", description: "The classic Filipino BBQ skewer: pork marinated sweet-savoury and glazed as it grills, sticky, charred and dangerously easy to eat five of. Sold by the stick — nobody has ever bought only one." },
+    { name: "Java rice & sides", description: "Golden java rice cooked with annatto and garlic, plus plain rice, house-pickled green-papaya atchara and our vinegar-chili dip — the sides that turn a roast chicken into a proper Filipino meal." },
+    { name: "Take-out & delivery", description: "Everything bagged hot and ready in minutes for the drive home, or delivered around Cabanatuan. Message us your order ahead and it'll be off the spit and waiting when you pull up. No queue." },
+    { name: "Party trays & fiesta orders", description: "Multiple chickens, trays of liempo and barbecue, rice and atchara, scaled to your headcount for birthdays, fiestas and office parties. Order a day ahead and we'll have the coals going for you." }
+  ],
+  why: [
+    { title: "Marinated overnight.", body: "Soy, calamansi, lemongrass, garlic and pepper, worked into the chicken the night before so the flavour is in the meat. A quick brush of sauce at the end fools nobody, least of all a Filipino." },
+    { title: "Roasted over live coals.", body: "Real charcoal on a turning spit, not a gas oven. That's where the smoke, the rendered fat and the lacquered crackling skin come from — and skin is the entire reason people choose one stand over another." },
+    { title: "Cheapest good dinner in town.", body: "A whole chicken, java rice and atchara feeds a family for less than a couple of fast-food meals. It's honest, filling, genuinely delicious food at a price that respects your wallet." }
+  ],
+  how: [
+    { step: "01", title: "Message or pull up", body: "Order ahead by phone or chat so it's ready when you arrive, or just pull up at the kanto and see what's turning. Peak dinner hours move fast — ordering ahead skips the queue entirely." },
+    { step: "02", title: "Pick your spread", body: "Whole or half chicken, liempo, BBQ sticks, java or plain rice, extra atchara and dip. Feeding a crowd? Tell us the headcount and we'll tell you honestly how much you actually need." },
+    { step: "03", title: "Off the spit, into the bag", body: "Chopped or whole, bagged hot with sauce and sides, in a couple of minutes. It travels well and stays hot for the drive — though frankly the smell in the car is its own kind of torture." },
+    { step: "04", title: "Eat it with your hands", body: "Rice, chicken, a splash of vinegar dip, and no cutlery required. That's the correct way. Order party trays a day ahead for fiestas and offices and become the barangay's favourite person." }
+  ],
+  testimonials: [
+    { quote: "The skin. That's it, that's the review — the skin is perfect every single time, crackling and golden, and the meat underneath is still juicy. We buy from here at least twice a week and my kids ask for it by name. Best lechon manok in Cabanatuan, no contest.", name: "Nanay Lita", context: "twice-a-week regular" },
+    { quote: "Ordered eight chickens, trays of liempo and barbecue for my dad's 70th and it was perfect — hot, on time, generous portions, and half the price of a caterer. The titos demolished the BBQ sticks. Everyone asked where it was from. Now our default for every family occasion.", name: "Jhun R.", context: "birthday party trays" },
+    { quote: "I work late and this is my dinner three nights a week. Message the order, pull up, it's bagged and hot, and it costs less than fast food while being infinitely better. The java rice and atchara combo is genuinely great. Reliable, fast, delicious. Solid people too.", name: "Marvin S.", context: "regular take-out" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1598515214211-89d3c73ae83b?w=1600&q=85&auto=format&fit=crop", alt: "Chicken roasting over glowing coals on a grill." },
+    { src: "https://images.unsplash.com/photo-1432139555190-58524dae6a55?w=1600&q=85&auto=format&fit=crop", alt: "Meat grilling over an open charcoal fire." },
+    { src: "https://images.unsplash.com/photo-1555939594-58d7cb561ad1?w=1600&q=85&auto=format&fit=crop", alt: "Grilled meat plated with rice." },
+    { src: "https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?w=1600&q=85&auto=format&fit=crop", alt: "Skewers cooking on a charcoal grill." },
+    { src: "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop", alt: "A plate of grilled food with rice." },
+    { src: "https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop", alt: "A roadside food stall in the evening." }
+  ],
+  faq: [
+    { q: "What is lechon manok, and how is it different from ordinary roast chicken?", a: "Lechon manok is the Filipino take on roast chicken, and while the basic idea — a whole chicken roasted until golden — is universal, the execution is distinctly ours. The chicken is marinated, usually in a soy-based mixture with calamansi, garlic, pepper and often lemongrass (tanglad) stuffed into the cavity, so it's seasoned through rather than just on the surface. It's then roasted whole on a rotisserie spit, traditionally over live charcoal, which slowly renders the fat, bastes the bird in its own juices as it turns, and dries the skin into that signature crackling, lacquered gold finish. The result is smokier, more savoury and more aromatic than a typical oven roast, with skin that's the main event. It's also sold in a specific way that's part of the culture: from roadside stands and kanto stalls, bagged hot to take home with rice and atchara, cheap enough to be a regular family dinner rather than a Sunday occasion. That combination — the marinade, the charcoal spit, and the everyday accessibility — is what makes lechon manok its own thing." },
+    { q: "Do you really use charcoal, or is it a gas oven?", a: "Real charcoal, on a turning spit — and it genuinely matters, which is why we're happy to be asked. Gas rotisseries are faster, cleaner and cheaper to run, and plenty of places use them, but charcoal does two things gas can't quite match: it imparts a subtle smokiness through the skin and into the meat, and the radiant heat crisps the skin in a way that produces that proper crackling texture rather than a softer roast finish. Since skin is the single thing customers judge a lechon manok on, we're not willing to trade it. The trade-off on our side is more work — managing the fire, watching the turn, dealing with heat and smoke all day — and slightly longer cook times, which is why ordering ahead at peak hours is worth doing. But the difference is on the plate, and our regulars can tell instantly. If you've been buying lechon manok that arrives pale and soft-skinned, try one off a real charcoal spit; it's a different food." },
+    { q: "How much chicken should I order for a group?", a: "As a practical guide, a whole chicken comfortably feeds around three to four people as a main dish with rice and sides, or stretches further if it's part of a bigger spread with liempo, barbecue and other viands on the table. For a family dinner, one chicken plus rice and atchara is the classic order. For parties, the honest rule is that people always eat more lechon manok than they think they will, especially with barbecue sticks in the mix, so we'd rather help you slightly over-order than have you run short in front of guests — and leftovers are excellent the next day, or turned into a quick chicken sopas or fried rice. Tell us the headcount, the occasion and what else you're serving, and we'll give you a straight recommendation on how many chickens, how many trays of liempo and how many sticks of barbecue you actually need. For fiestas and big gatherings, ordering at least a day ahead lets us marinate properly and have the coals going for your pick-up time." },
+    { q: "Can you deliver, and will it still be hot and crisp?", a: "Yes, we deliver around Cabanatuan, and we pack specifically to protect the thing that matters most — the skin. Lechon manok travels reasonably well because it's roasted whole and holds its heat, but the enemy is trapped steam: if a hot chicken is sealed tightly in plastic for too long, its own moisture softens that crackling skin you paid for. So we bag it to vent, get it moving quickly, and time cooking to your pick-up or delivery window rather than letting it sit under a lamp. Our honest advice at your end: open the bag when it arrives rather than leaving it sealed, and eat it soon — within the hour is ideal. If you need it later, keep it uncovered somewhere warm rather than wrapped, and a few minutes in a hot oven or air fryer will bring the skin right back. For big orders and parties, tell us your serving time and we'll plan the roast around it so it lands at its best." },
+    { q: "What's the difference between liempo and pork barbecue?", a: "They're both grilled pork and both excellent, but they're different cuts and different experiences. Liempo is pork belly — a slab of layered fat and meat, marinated in our soy-calamansi-lemongrass blend and grilled over coals until the outside chars and the fat renders, then chopped and served with rice and a vinegar-chili dip. It's rich, meaty and substantial: an ulam, a proper main dish. Pork barbecue is the classic Filipino skewer: smaller pieces of pork, marinated in a sweeter, more soy-and-banana-ketchup-leaning mixture and basted repeatedly as it grills so it develops a sticky, caramelised glaze. It's snackier, sweeter, sold by the stick, and it's the thing you buy 'just a couple' of and then eat five. Most tables order both: liempo as the main event alongside the chicken, and a handful of barbecue sticks because nobody can resist them. If you're not sure, get one of each and see which your family reaches for first." },
+    { q: "Do you do party trays and fiesta orders?", a: "Yes, and it's a big part of what we do, because roast chicken and grilled pork are exactly what Filipino gatherings run on. We'll put together multiple whole chickens, trays of chopped liempo, batches of barbecue sticks, java or plain rice and atchara, all scaled to your headcount and packed for a party table — for birthdays, fiestas, baptisms, reunions, office parties and school events. It's considerably cheaper than conventional catering and, frankly, more popular with guests. We ask for at least a day's notice so we can marinate the chickens properly overnight (that step can't be rushed) and plan the fire for your timing, and more notice during fiesta season, Christmas and long weekends when we're busiest. Just message or call with your date, time, headcount and any preferences, and we'll suggest quantities honestly, confirm a price, and have everything hot and ready for pick-up or delivery. Bring lechon manok to a party and you will be thanked repeatedly." }
+  ],
+  area: { places: ["Cabanatuan", "Sta. Rosa", "Talavera", "San Leonardo", "Nueva Ecija", "Delivery & party trays"] },
+  credentials: [
+    { label: "Since 2008", detail: "Turning the spit at the kanto" },
+    { label: "Marinated overnight", detail: "Soy, calamansi, lemongrass & garlic" },
+    { label: "Live charcoal", detail: "Real coals, real crackling skin" },
+    { label: "Trays & delivery", detail: "Fiesta orders around Nueva Ecija" }
+  ],
+  location: { name: "Andok's Kanto Grill", addressStreet: "47 Maharlika Highway, Barangay Mabini", addressLocality: "Cabanatuan", addressRegion: "Nueva Ecija", addressPostcode: "3100", addressCountry: "Philippines" },
+  cta: { heading: "Dinner's sorted. Follow the smoke.", body: "Whole lechon manok marinated overnight and roasted over live coals, grilled liempo, sticky pork barbecue, java rice and atchara — take-out, delivery and party trays around Cabanatuan. Turning the spit since 2008.", primary: { label: "Order for pick-up", href: "#book" }, secondary: { label: "(044) 555 0193", href: "tel:+63445550193" } },
+  messaging: { whatsapp: "https://wa.me/63445550193", messenger: "https://m.me/kantogrill" }
+};
+</script>
+
+<style>
+  :root {
+    --char:#171310; --char-2:#0f0c0a; --bone:#f6efe3; --bone-2:#fdf8ef; --ink:#231c16; --ink-2:#4b3f34;
+    --skin:#d9902f; --glaze:#c2451f; --calamansi:#8fa63c;
+    --mid:#8b7c6a; --mid-d:#c7b49a; --rule-d:rgba(246,239,227,0.15);
+    --disp:"Archivo",system-ui,sans-serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--char);color:var(--bone);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--skin);}
+  .wrap{width:min(1280px,93vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.15em;text-transform:uppercase;color:var(--skin);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:900;font-size:clamp(38px,5.4vw,80px);line-height:0.98;margin:0 0 0.3em;letter-spacing:-0.025em;}
+  .h2 em{font-style:normal;color:var(--glaze);}
+  .body{color:var(--mid-d);line-height:1.7;}
+  section{padding:clamp(74px,9vw,126px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:16px 32px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:2px;}
+  .btn-primary{background:var(--glaze);color:var(--bone-2);} .btn-primary:hover{background:var(--skin);color:var(--char);}
+  .btn-ghost{border:1.5px solid rgba(246,239,227,0.4);color:var(--bone);} .btn-ghost:hover{background:var(--bone);color:var(--char);border-color:var(--bone);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.15em;text-transform:uppercase;color:var(--mid-d);border-bottom:1.5px solid var(--rule-d);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,58px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(23,19,16,0.92);backdrop-filter:blur(10px);border-bottom:1.5px solid var(--rule-d);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:15px 0;}
+  .wm{font-family:var(--disp);font-weight:900;font-size:21px;text-decoration:none;letter-spacing:-0.03em;text-transform:uppercase;}
+  .wm span{color:var(--skin);}
+  .nav-links{display:flex;gap:26px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:900;font-size:clamp(40px,6.4vw,98px);line-height:0.92;letter-spacing:-0.03em;margin:0 0 32px;max-width:17ch;}
+  .hero-headline .em{color:var(--skin);}
+  .hero-headline .out{-webkit-text-stroke:1.5px var(--glaze);color:transparent;}
+  .hero-lower{display:grid;grid-template-columns:1.15fr 0.85fr;gap:clamp(30px,4vw,64px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:3px;}
+  .hero-photo::after{content:"OVER LIVE COALS · SINCE 2008";position:absolute;left:14px;bottom:14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.12em;background:var(--glaze);color:var(--bone-2);padding:7px 12px;border-radius:2px;}
+  .hero-right .lede{color:var(--mid-d);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--skin);color:var(--char);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(23,19,16,0.82);font-weight:700;}
+
+  .about{background:var(--bone);color:var(--ink);}
+  .about .h2{color:var(--ink);} .about .h2 em{color:var(--glaze);}
+  .about .sw-head{color:var(--mid);border-color:rgba(35,28,22,0.16);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:3px;}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.76;margin:0 0 1em;color:#463a2e;}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:1.5px solid var(--rule-d);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid rgba(246,239,227,0.12);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(194,69,31,0.12);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.1em;color:var(--skin);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:800;font-size:clamp(24px,2.6vw,34px);margin:0;line-height:1.0;letter-spacing:-0.025em;}
+  .svc-row p{color:var(--mid-d);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--bone);color:var(--ink);}
+  .why .sw-head{color:var(--mid);border-color:rgba(35,28,22,0.16);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.16em;color:var(--glaze);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:800;font-size:27px;margin:0 0 10px;line-height:1.0;letter-spacing:-0.025em;}
+  .why-grid p{color:#463a2e;margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:3px solid var(--glaze);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--skin);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:800;font-size:22px;margin:8px 0 8px;line-height:1.02;letter-spacing:-0.025em;}
+  .how-grid p{color:var(--mid-d);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--char-2);}
+  .t-quote{font-family:var(--disp);font-weight:800;font-size:clamp(28px,3.7vw,54px);line-height:1.04;max-width:25ch;margin:0 0 24px;letter-spacing:-0.03em;}
+  .t-quote em{font-style:normal;color:var(--skin);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:1.5px solid var(--rule-d);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:var(--mid-d);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:3px;}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--glaze);color:var(--bone-2);font-family:var(--mono);font-size:9px;letter-spacing:0.1em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule-d);padding:22px 0;}
+  .faq-list details:first-child{border-top:1.5px solid var(--rule-d);}
+  .faq-list summary{font-family:var(--disp);font-weight:800;font-size:21px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.14;letter-spacing:-0.025em;}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--skin);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--mid-d);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.08em;text-transform:uppercase;padding:10px 20px;border:1.5px solid rgba(246,239,227,0.3);border-radius:2px;font-weight:700;color:var(--mid-d);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:1.5px solid var(--rule-d);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--skin);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:800;font-size:19px;line-height:1.12;letter-spacing:-0.025em;}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--bone);color:var(--ink);padding:34px;border-radius:3px;}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:800;font-size:20px;line-height:1.26;letter-spacing:-0.025em;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:500;color:#463a2e;}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:1px solid rgba(35,28,22,0.16);padding-top:18px;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--mid);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--mid);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:3px;border:1.5px solid rgba(246,239,227,0.2);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.3) invert(0.9) hue-rotate(160deg) brightness(0.9);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--glaze);color:var(--bone-2);padding:clamp(80px,10vw,144px) 0;text-align:center;}
+  .cta-band .kick{color:var(--bone-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:900;font-size:clamp(42px,6.2vw,102px);line-height:0.94;margin:14px auto 18px;max-width:15ch;letter-spacing:-0.03em;}
+  .cta-band h2 em{font-style:normal;color:var(--skin);}
+  .cta-band p{color:rgba(253,248,239,0.92);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--bone-2);color:var(--glaze);} .cta-band .btn-primary:hover{background:var(--skin);color:var(--char);}
+  .cta-band .btn-ghost{border-color:var(--bone-2);color:var(--bone-2);} .cta-band .btn-ghost:hover{background:var(--bone-2);color:var(--glaze);}
+
+  footer{background:var(--char);border-top:1.5px solid var(--rule-d);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--skin);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:var(--mid-d);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid var(--rule-d);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--glaze);color:var(--bone-2);padding:13px 20px;border-radius:2px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;box-shadow:0 8px 24px rgba(194,69,31,0.4);}
+  .msg-fab a:hover{background:var(--skin);color:var(--char);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Restaurant","name":"Andok's Kanto Grill","description":"Roadside rotisserie grill in Cabanatuan — whole lechon manok marinated overnight and roasted over live coals, plus grilled liempo, pork barbecue sticks, java rice and atchara, with take-out, delivery and party trays. Since 2008.","servesCuisine":"Filipino","url":"https://kantogrill.ph/","telephone":"+63445550193","email":"orders@kantogrill.ph","address":{"@type":"PostalAddress","streetAddress":"47 Maharlika Highway, Barangay Mabini","addressLocality":"Cabanatuan","addressRegion":"Nueva Ecija","postalCode":"3100","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":15.4860,"longitude":120.9670},"areaServed":["Cabanatuan","Sta. Rosa","Talavera","San Leonardo"],"image":["https://images.unsplash.com/photo-1598515214211-89d3c73ae83b?w=1600"],"foundingDate":"2008"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What is lechon manok and how is it different from ordinary roast chicken?","acceptedAnswer":{"@type":"Answer","text":"Lechon manok is the Filipino take on roast chicken: marinated in a soy-based mixture with calamansi, garlic, pepper and often lemongrass stuffed in the cavity, so it's seasoned through rather than just on the surface, then roasted whole on a rotisserie spit over live charcoal. The turning bastes the bird in its own juices and dries the skin to a crackling, lacquered gold. It's smokier and more savoury than an oven roast, and it's sold from roadside kanto stands, bagged hot with rice and atchara, cheap enough to be a regular family dinner."}},
+{"@type":"Question","name":"Do you really use charcoal, or is it a gas oven?","acceptedAnswer":{"@type":"Answer","text":"Real charcoal on a turning spit. Gas rotisseries are faster and cheaper to run, but charcoal imparts a subtle smokiness and its radiant heat crisps the skin into proper crackling rather than a softer roast finish. Since skin is what customers judge a lechon manok on, we won't trade it. The trade-off is more work and slightly longer cook times, which is why ordering ahead at peak hours helps. If you've been buying pale, soft-skinned lechon manok, try one off a real charcoal spit."}},
+{"@type":"Question","name":"How much chicken should I order for a group?","acceptedAnswer":{"@type":"Answer","text":"A whole chicken comfortably feeds three to four as a main with rice and sides, and stretches further as part of a bigger spread with liempo and barbecue. For a family dinner, one chicken plus rice and atchara is the classic order. For parties, people always eat more than expected, so we'd rather help you slightly over-order — leftovers are excellent the next day. Tell us the headcount, occasion and what else you're serving and we'll recommend honestly. Order a day ahead for fiestas."}},
+{"@type":"Question","name":"Can you deliver, and will it still be hot and crisp?","acceptedAnswer":{"@type":"Answer","text":"Yes, we deliver around Cabanatuan and pack to protect the skin. Lechon manok holds its heat well, but the enemy is trapped steam — sealed tightly in plastic, its own moisture softens the crackling. So we bag it to vent, move it quickly, and time cooking to your window rather than letting it sit under a lamp. At your end: open the bag on arrival and eat within the hour; if keeping it later, leave it uncovered somewhere warm and a few minutes in a hot oven or air fryer brings the skin back."}},
+{"@type":"Question","name":"What's the difference between liempo and pork barbecue?","acceptedAnswer":{"@type":"Answer","text":"Liempo is pork belly — a slab of layered fat and meat marinated in our soy-calamansi-lemongrass blend and grilled over coals until charred and rendered, then chopped and served with rice and vinegar dip. It's rich and substantial, a proper main. Pork barbecue is the classic skewer: smaller pieces in a sweeter marinade, basted repeatedly for a sticky caramelised glaze — snackier, sold by the stick. Most tables order both: liempo as the main event, barbecue because nobody can resist."}},
+{"@type":"Question","name":"Do you do party trays and fiesta orders?","acceptedAnswer":{"@type":"Answer","text":"Yes — multiple whole chickens, trays of chopped liempo, batches of barbecue sticks, java or plain rice and atchara, scaled to your headcount for birthdays, fiestas, baptisms, reunions and office parties. It's considerably cheaper than conventional catering and more popular with guests. We ask for at least a day's notice so we can marinate overnight and plan the fire for your timing, more during fiesta season and holidays. Message with date, time, headcount and preferences and we'll suggest quantities and confirm a price."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Andok's <span>Kanto Grill</span></a>
+    <nav class="nav-links">
+      <a href="#about">The grill</a><a href="#services">Off the grill</a><a href="#location">Find us</a><a href="#book">Order</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Lechon manok · liempo · pork BBQ · Cabanatuan, Nueva Ecija</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      Whole chickens turning on the <span class="out">spit.</span> That smell does the <span class="em">advertising.</span>
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1598515214211-89d3c73ae83b?w=2000&q=85&auto=format&fit=crop"
+             alt="Chicken roasting over glowing coals on a grill." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A roadside rotisserie grill in Cabanatuan — whole chickens marinated overnight in soy, calamansi, lemongrass and garlic, then turned slowly over coals until the skin goes crackling-gold and the meat falls off the bone. Plus grilled liempo, pork barbecue on sticks, java rice and house atchara. Take-out, delivery, and party trays that make you everyone's favourite person.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Order for pick-up</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">Off the grill</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Turning the spit since 2008</span>
+    <span>Marinated overnight</span>
+    <span>Roasted over live coals</span>
+    <span>Take-out · delivery · trays</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 01 / THE GRILL</span><span>ON THE MAHARLIKA HIGHWAY</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">One chicken, one fire, one job: get the skin <em>right.</em></h2>
+        <p>Andok's Kanto Grill is a roadside lechon manok stand in Cabanatuan, and lechon manok — literally "roast chicken" — is one of the great everyday Filipino dinners. It's the thing you grab on the way home when you don't want to cook: a whole roasted chicken in a bag, a tub of java rice, some atchara, and dinner's done for a family of five for the price of a couple of fast-food meals. Every kanto in the country has one. Not every one gets it right.</p>
+        <p>We've been turning the spit since 2008, and the whole discipline is in two places: the marinade and the fire. Our chickens sit overnight in soy, calamansi, lemongrass, garlic and pepper, so the flavour is in the meat rather than brushed on the outside. Then they're skewered whole and turned slowly over live coals — not baked in a gas oven — so the fat renders down, the skin dries and crisps to that lacquered crackling gold, and the meat inside stays properly juicy.</p>
+        <p>Beyond the chicken we grill liempo (pork belly) marinated the same way, skewers of pork barbecue glazed sweet and sticky, and we cook the java rice and pickle the green-papaya atchara that go with them. Everything's built for take-out and delivery — bagged hot, ready in minutes — and we do party trays for fiestas, birthdays and offices. Roadside food, done seriously. Follow the smoke to the kanto.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?w=1200&q=85&auto=format&fit=crop"
+           alt="Meat grilling over an open charcoal fire." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" class="testimonials" data-component="SERVICES" data-variant="v78" data-screen-label="Services" style="background:var(--char);">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 02 / OFF THE GRILL</span><span>MANOK · LIEMPO · BBQ · TRAYS</span></div>
+    <h2 class="h2">Off the grill.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Whole lechon manok</h3><p>The headliner: a whole chicken marinated overnight and rotisserie-roasted over coals to crackling-gold skin and juicy meat. Bagged hot with sauce, ready to carry home. Order whole or half.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>Grilled liempo</h3><p>Pork belly marinated in the same soy-calamansi-lemongrass blend and grilled over coals until the edges char and the fat renders — chopped and served with rice and vinegar dip. The pork order to get.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>Pork barbecue sticks</h3><p>The classic Filipino BBQ skewer: pork marinated sweet-savoury and glazed as it grills, sticky, charred and dangerously easy to eat five of. Sold by the stick — nobody has ever bought only one.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Java rice &amp; sides</h3><p>Golden java rice cooked with annatto and garlic, plus plain rice, house-pickled green-papaya atchara and our vinegar-chili dip — the sides that turn a roast chicken into a proper Filipino meal.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Take-out &amp; delivery</h3><p>Everything bagged hot and ready in minutes for the drive home, or delivered around Cabanatuan. Message us your order ahead and it'll be off the spit and waiting when you pull up. No queue.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Party trays &amp; fiesta orders</h3><p>Multiple chickens, trays of liempo and barbecue, rice and atchara, scaled to your headcount for birthdays, fiestas and office parties. Order a day ahead and we'll have the coals going for you.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 03 / THE DIFFERENCE</span><span>WHY THE SKIN CRACKLES</span></div>
+    <h2 class="h2">Why the skin <em>crackles.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Marinated overnight.</h3><p>Soy, calamansi, lemongrass, garlic and pepper, worked into the chicken the night before so the flavour is in the meat. A quick brush of sauce at the end fools nobody, least of all a Filipino.</p></div>
+      <div><span class="no">02 / 03</span><h3>Roasted over live coals.</h3><p>Real charcoal on a turning spit, not a gas oven. That's where the smoke, the rendered fat and the lacquered crackling skin come from — and skin is the entire reason people choose one stand over another.</p></div>
+      <div><span class="no">03 / 03</span><h3>Cheapest good dinner in town.</h3><p>A whole chicken, java rice and atchara feeds a family for less than a couple of fast-food meals. Honest, filling, genuinely delicious food at a price that respects your wallet.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 04 / HOW IT GOES</span><span>ORDER · PICK · BAG · EAT</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Message or pull up</h3><p>Order ahead by phone or chat so it's ready when you arrive, or just pull up at the kanto and see what's turning. Peak dinner hours move fast — ordering ahead skips the queue entirely.</p></li>
+      <li><span class="step">STEP 02</span><h3>Pick your spread</h3><p>Whole or half chicken, liempo, BBQ sticks, java or plain rice, extra atchara and dip. Feeding a crowd? Tell us the headcount and we'll tell you honestly how much you actually need.</p></li>
+      <li><span class="step">STEP 03</span><h3>Off the spit, into the bag</h3><p>Chopped or whole, bagged hot with sauce and sides, in a couple of minutes. It travels well and stays hot for the drive — though the smell in the car is its own kind of torture.</p></li>
+      <li><span class="step">STEP 04</span><h3>Eat it with your hands</h3><p>Rice, chicken, a splash of vinegar dip, and no cutlery required. That's the correct way. Order party trays a day ahead for fiestas and become the barangay's favourite person.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 05 / FROM THE KANTO</span><span>THAT'S IT, THAT'S THE REVIEW</span></div>
+    <blockquote class="t-quote">“The skin. That's it, that's the review — perfect every single time. <em>Best in Cabanatuan, no contest.</em>”</blockquote>
+    <div class="t-attr">Nanay Lita — twice-a-week regular</div>
+    <div class="t-sub">
+      <figure><blockquote>“Ordered eight chickens, trays of liempo and barbecue for my dad's 70th and it was perfect — hot, on time, generous portions, and half the price of a caterer. The titos demolished the BBQ sticks. Everyone asked where it was from. Now our default for every family occasion.”</blockquote><figcaption>Jhun R. — birthday party trays</figcaption></figure>
+      <figure><blockquote>“I work late and this is my dinner three nights a week. Message the order, pull up, it's bagged and hot, and it costs less than fast food while being infinitely better. The java rice and atchara combo is genuinely great. Reliable, fast, delicious. Solid people too.”</blockquote><figcaption>Marvin S. — regular take-out</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--bone);">
+  <div class="wrap">
+    <div class="sw-head" style="color:var(--mid);border-color:rgba(35,28,22,0.16);"><span>SPIT 06 / AT THE FIRE</span><span>SMOKE, GLAZE &amp; GOLD</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1598515214211-89d3c73ae83b?w=1600&q=85&auto=format&fit=crop" alt="Chicken roasting over glowing coals on a grill." /><figcaption>THE SPIT</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?w=1600&q=85&auto=format&fit=crop" alt="Meat grilling over an open charcoal fire." /><figcaption>THE COALS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1555939594-58d7cb561ad1?w=1600&q=85&auto=format&fit=crop" alt="Grilled meat plated with rice." /><figcaption>THE PLATE</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?w=1600&q=85&auto=format&fit=crop" alt="Skewers cooking on a charcoal grill." /><figcaption>THE STICKS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop" alt="A plate of grilled food with rice." /><figcaption>THE JAVA RICE</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop" alt="A roadside food stall in the evening." /><figcaption>THE KANTO</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 07 / BEFORE YOU ORDER</span><span>COALS, PORTIONS &amp; TRAYS</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Before you order.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+63445550193" style="color:var(--skin);font-weight:700;">(044) 555 0193</a>. Order ahead at dinner time; the queue at the kanto is real.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What is lechon manok, and how is it different from ordinary roast chicken?</summary><p>Lechon manok is the Filipino take on roast chicken, and while the basic idea is universal, the execution is distinctly ours. The chicken is marinated, usually in a soy-based mixture with calamansi, garlic, pepper and often lemongrass stuffed into the cavity, so it's seasoned through rather than just on the surface. It's then roasted whole on a rotisserie spit, traditionally over live charcoal, which slowly renders the fat, bastes the bird in its own juices as it turns, and dries the skin into that signature crackling, lacquered gold finish. The result is smokier, more savoury and more aromatic than a typical oven roast, with skin that's the main event. It's also sold from roadside kanto stalls, bagged hot to take home with rice and atchara, cheap enough to be a regular family dinner rather than a Sunday occasion.</p></details>
+        <details><summary>Do you really use charcoal, or is it a gas oven?</summary><p>Real charcoal, on a turning spit — and it genuinely matters. Gas rotisseries are faster, cleaner and cheaper to run, and plenty of places use them, but charcoal does two things gas can't quite match: it imparts a subtle smokiness through the skin and into the meat, and the radiant heat crisps the skin in a way that produces that proper crackling texture rather than a softer roast finish. Since skin is the single thing customers judge a lechon manok on, we're not willing to trade it. The trade-off on our side is more work — managing the fire, watching the turn, dealing with heat and smoke all day — and slightly longer cook times, which is why ordering ahead at peak hours is worth doing. If you've been buying lechon manok that arrives pale and soft-skinned, try one off a real charcoal spit; it's a different food.</p></details>
+        <details><summary>How much chicken should I order for a group?</summary><p>As a practical guide, a whole chicken comfortably feeds around three to four people as a main dish with rice and sides, or stretches further if it's part of a bigger spread with liempo, barbecue and other viands on the table. For a family dinner, one chicken plus rice and atchara is the classic order. For parties, the honest rule is that people always eat more lechon manok than they think they will, so we'd rather help you slightly over-order than have you run short in front of guests — and leftovers are excellent the next day, or turned into chicken sopas or fried rice. Tell us the headcount, the occasion and what else you're serving, and we'll give you a straight recommendation. For fiestas and big gatherings, ordering at least a day ahead lets us marinate properly and have the coals going for your pick-up time.</p></details>
+        <details><summary>Can you deliver, and will it still be hot and crisp?</summary><p>Yes, we deliver around Cabanatuan, and we pack specifically to protect the thing that matters most — the skin. Lechon manok travels reasonably well because it's roasted whole and holds its heat, but the enemy is trapped steam: if a hot chicken is sealed tightly in plastic for too long, its own moisture softens that crackling skin. So we bag it to vent, get it moving quickly, and time cooking to your pick-up or delivery window rather than letting it sit under a lamp. Our honest advice at your end: open the bag when it arrives rather than leaving it sealed, and eat it soon — within the hour is ideal. If you need it later, keep it uncovered somewhere warm rather than wrapped, and a few minutes in a hot oven or air fryer will bring the skin right back.</p></details>
+        <details><summary>What's the difference between liempo and pork barbecue?</summary><p>They're both grilled pork and both excellent, but they're different cuts and different experiences. Liempo is pork belly — a slab of layered fat and meat, marinated in our soy-calamansi-lemongrass blend and grilled over coals until the outside chars and the fat renders, then chopped and served with rice and a vinegar-chili dip. It's rich, meaty and substantial: an ulam, a proper main dish. Pork barbecue is the classic Filipino skewer: smaller pieces of pork in a sweeter marinade, basted repeatedly as it grills so it develops a sticky, caramelised glaze. It's snackier, sweeter, sold by the stick, and it's the thing you buy 'just a couple' of and then eat five. Most tables order both. If you're not sure, get one of each and see which your family reaches for first.</p></details>
+        <details><summary>Do you do party trays and fiesta orders?</summary><p>Yes, and it's a big part of what we do, because roast chicken and grilled pork are exactly what Filipino gatherings run on. We'll put together multiple whole chickens, trays of chopped liempo, batches of barbecue sticks, java or plain rice and atchara, all scaled to your headcount and packed for a party table — for birthdays, fiestas, baptisms, reunions, office parties and school events. It's considerably cheaper than conventional catering and, frankly, more popular with guests. We ask for at least a day's notice so we can marinate the chickens properly overnight and plan the fire for your timing, and more notice during fiesta season, Christmas and long weekends. Message or call with your date, time, headcount and preferences, and we'll suggest quantities honestly and have everything hot and ready.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 08 / WE DELIVER TO</span><span>NUEVA ECIJA</span></div>
+    <ul class="area-list">
+      <li>Cabanatuan</li><li>Sta. Rosa</li><li>Talavera</li><li>San Leonardo</li><li>Nueva Ecija</li><li>Delivery &amp; party trays</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 09 / THE ESSENTIALS</span><span>HOW WE ROAST</span></div>
+    <div class="creds">
+      <div><div class="label">Since 2008</div><div class="detail">Turning the spit at the kanto</div></div>
+      <div><div class="label">Marinated overnight</div><div class="detail">Soy, calamansi, lemongrass &amp; garlic</div></div>
+      <div><div class="label">Live charcoal</div><div class="detail">Real coals, real crackling skin</div></div>
+      <div><div class="label">Trays &amp; delivery</div><div class="detail">Fiesta orders around Nueva Ecija</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>SPIT 10 / THE KANTO</span><span>MAHARLIKA HIGHWAY, CABANATUAN</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Andok's Kanto Grill</strong><br />
+          47 Maharlika Highway, Barangay Mabini<br />
+          Cabanatuan, Nueva Ecija 3100<br /><br />
+          <a href="tel:+63445550193" data-bind="business.phoneDisplay">(044) 555 0193</a><br />
+          <a href="mailto:orders@kantogrill.ph" data-bind="business.email">orders@kantogrill.ph</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>DAILY</span><span>10AM – 9PM</span></div>
+          <div class="row"><span>DINNER RUSH</span><span>5PM – 7PM</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. We're on the Maharlika Highway in Barangay Mabini — look for the spit and follow the smoke. Order ahead to skip the dinner queue.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Andok's Kanto Grill, Cabanatuan" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=120.9520%2C15.4760%2C120.9820%2C15.4960&layer=mapnik&marker=15.4860%2C120.9670"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">SPIT 11 / ORDER</div>
+    <h2 data-bind="cta.heading">Dinner's sorted. Follow the <em>smoke.</em></h2>
+    <p data-bind="cta.body">Whole lechon manok marinated overnight and roasted over live coals, grilled liempo, sticky pork barbecue, java rice and atchara — take-out, delivery and party trays around Cabanatuan. Turning the spit since 2008.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Order for pick-up</a>
+      <a class="btn btn-ghost" href="tel:+63445550193" data-bind="cta.secondary.label">(044) 555 0193</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/63445550193" data-bind="messaging.whatsapp" aria-label="Message the grill">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:21px;">Andok's <span style="color:var(--skin);">Kanto Grill</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;">A roadside rotisserie in Cabanatuan — lechon manok, liempo and BBQ over live coals since 2008.</p>
+      </div>
+      <div>
+        <h4>The grill</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:var(--mid-d);">
+          47 Maharlika Highway, Brgy. Mabini<br />Cabanatuan, Nueva Ecija 3100<br />
+          <a href="tel:+63445550193">(044) 555 0193</a><br />
+          <a href="mailto:orders@kantogrill.ph">orders@kantogrill.ph</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">Off the grill</a><a href="#about">The grill</a><a href="#location">Find us</a><a href="#book">Order</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> ANDOK'S KANTO GRILL</span>
+      <span>OVER LIVE COALS · CABANATUAN</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/bg.html
+++ b/public/template-previews/bg.html
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Mang Kanor Vulcanizing — 24-hour tire repair, vulcanize, patch & roadside rescue, Antipolo</title>
+<meta name="description" content="Mang Kanor Vulcanizing is a 24-hour tire and vulcanizing shop in Antipolo — flat-tire repair, hot and cold vulcanizing, patch and plug, tube and tubeless, wheel balancing, plus roadside rescue when you're stuck on the highway. Keeping Antipolo rolling since 2001." />
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800;900&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Mang Kanor Vulcanizing", phone: "+63 917 555 0247", phoneDisplay: "0917 555 0247", email: "help@mangkanortire.ph", foundedYear: 2001 },
+  hero: {
+    kicker: "24-hour vulcanizing & tire repair · roadside rescue · Antipolo, Rizal",
+    headline: "Flat at 3AM on the Marcos Highway? We're the light that's still on.",
+    lede: "A 24-hour vulcanizing and tire shop on the Antipolo road — flats patched, plugged and vulcanized, tubes and tubeless, cars, trucks, tricycles and motors. We balance wheels, sell secondhand and new tires, and when you're stranded on the highway with a blowout, we come to you. Fast, fair, and open when everyone else is closed. The light that's always on.",
+    primaryCta: { label: "Call for rescue", href: "#book" },
+    secondaryCta: { label: "What we fix", href: "#services" },
+    image: "https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "A tire being worked on in a repair shop."
+  },
+  trust: { years: "Keeping Antipolo rolling since 2001" },
+  about: {
+    heading: "A flat tire doesn't check the clock. Neither do we.",
+    paragraphs: [
+      "Mang Kanor Vulcanizing is a tire-repair and vulcanizing shop on the Antipolo road, and 'vulcanizing' — from the process of bonding rubber with heat — is the Filipino catch-all for tire repair: patching a puncture, plugging a hole, sealing a tube, whatever it takes to get a flat rolling again. You'll find a vulcanizing shop on nearly every provincial roadside in the country, because tires go flat everywhere, at every hour, and someone has to fix them.",
+      "We've been that someone here since 2001, and the thing that sets us apart is simple: we don't close. A flat tire doesn't wait for business hours — it happens at 3AM on the highway, on the way to the hospital, on the last trip home after a long shift. So we keep the light on around the clock, with someone always ready to patch, plug, vulcanize, change or balance a wheel, for cars, trucks, jeepneys, tricycles and motorbikes alike. Fast, honest, and priced the way roadside repair should be.",
+      "And when you can't reach us — stuck on the shoulder with a blowout and no spare — we come to you. Call, tell us where you are, and we'll roll out with the tools to get you moving or towed. We also sell good secondhand and new tires, do minor roadside mechanical fixes, and keep the tricycles and delivery riders of Antipolo on the road. It's not glamorous work. It's the work that gets everybody else home. Twenty-four hours, every day, we're here for it."
+    ],
+    portrait: "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "A mechanic's hands working on a wheel."
+  },
+  services: [
+    { name: "Flat repair — patch & plug", description: "Punctures found, cleaned and sealed — cold-patch, plug, or a proper vulcanized patch for a lasting fix. Tubeless and tube-type, cars to trucks. We find the leak you can't and get you rolling fast." },
+    { name: "Hot & cold vulcanizing", description: "The real thing: bonding a patch to the tire or tube with heat and pressure for a repair that holds, not a temporary plug that fails on the next long drive. The right fix for the damage, explained honestly." },
+    { name: "Tire change & wheel balancing", description: "Worn or blown tires swapped, valves replaced, and wheels balanced so your ride is smooth and your tires wear evenly. We'll tell you straight when a tire's done and when it's got life left in it." },
+    { name: "New & secondhand tires", description: "Good used tires at a fair price when the budget's tight, and new tires when you want the miles — cars, tricycles, motorbikes and light trucks. Honest advice on tread, age and what's safe to buy." },
+    { name: "24-hour roadside rescue", description: "Stranded with a flat or blowout and no spare? Call us. We roll out with tools and tires to fix you on the shoulder or get you to the shop — day, night, weekend, holiday. The number to save before you need it." },
+    { name: "Trikes, motors & fleet", description: "We keep Antipolo's tricycles, delivery riders and small fleets rolling with fast turnaround and standing arrangements — because when your wheels are your income, downtime costs money. Priority, fair rates, always open." }
+  ],
+  why: [
+    { title: "Open 24 hours. Genuinely.", body: "Not 'til late' — actually around the clock, every day of the year. A flat at 3AM is exactly when you need us most, and exactly when everyone else is shut. The light stays on. That's the whole promise." },
+    { title: "We come to you.", body: "Stranded on the highway with no spare? Call and we roll out with tools and tires. You don't have to limp a ruined tire to us or sleep in the car till morning — roadside rescue is a phone call away." },
+    { title: "Honest about the fix.", body: "We'll tell you when a patch will hold and when a tire's genuinely done — no scaring you into a new tire you don't need, no cheap plug on damage that needs vulcanizing. Fair fix, fair price, plainly explained." }
+  ],
+  how: [
+    { step: "01", title: "Roll in, or call", body: "Drive, ride or wheel in any hour — no appointment. Or if you're stranded, call and tell us where you are and what happened. We'll talk you through it and roll out if you need rescue." },
+    { step: "02", title: "We find the damage", body: "We locate the leak or assess the blowout, then tell you honestly what it needs — a plug, a patch, a proper vulcanize, or a new tire — and what it'll cost, before we touch it. No surprises." },
+    { step: "03", title: "Fixed fast", body: "Most flats are patched or plugged and balanced in minutes, not hours, because you've got somewhere to be. Vulcanized repairs take a little longer but hold far better. Either way, we don't dawdle." },
+    { step: "04", title: "Back on the road", body: "Rolling again, with a straight answer on whether the fix is permanent or a get-home measure, and when to check the tire next. Save our number — the flat you don't have yet will thank you." }
+  ],
+  testimonials: [
+    { quote: "Blew a tire on the Marcos Highway at 1AM with my kids in the car and no spare. Called Mang Kanor and he came out within the hour, fixed it on the shoulder, and charged a completely fair price. I nearly cried from relief. Saved his number in bold. A genuine lifesaver, literally.", name: "Rowena F.", context: "roadside rescue, 1AM" },
+    { quote: "I drive a tricycle and my tires are my livelihood. Mang Kanor patches me up fast, tells me straight when a tire's really done, and never overcharges. Every trike driver in our area goes to him because he's fair and he's always open. Solid, honest, reliable. Salamat, Mang Kanor.", name: "Kuya Dan", context: "tricycle driver" },
+    { quote: "Came in with a slow leak I'd been ignoring and he found a nail I'd never have spotted, vulcanized it properly instead of just plugging it, and explained exactly why. Been back three times since for the family cars. This is what a neighbourhood shop should be — skilled, honest, always there.", name: "Engr. Villamor", context: "regular customer" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=1600&q=85&auto=format&fit=crop", alt: "A tire being worked on in a repair shop." },
+    { src: "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=1600&q=85&auto=format&fit=crop", alt: "A mechanic's hands working on a wheel." },
+    { src: "https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?w=1600&q=85&auto=format&fit=crop", alt: "A polished wheel and tire." },
+    { src: "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=1600&q=85&auto=format&fit=crop", alt: "Tools laid out in a workshop." },
+    { src: "https://images.unsplash.com/photo-1503376780353-7e6692767b70?w=1600&q=85&auto=format&fit=crop", alt: "A car headlight at night." },
+    { src: "https://images.unsplash.com/photo-1502877338535-766e1452684a?w=1600&q=85&auto=format&fit=crop", alt: "A road at night with headlights." }
+  ],
+  faq: [
+    { q: "What does 'vulcanizing' actually mean, and how is it different from just plugging a tire?", a: "Vulcanizing, strictly speaking, is the process of treating rubber with heat (and often pressure and a curing agent) to bond it strongly — it's the same principle that makes tire rubber durable in the first place. In a Filipino roadside context, 'vulcanizing shop' has become the general term for any tire-repair shop, but the actual vulcanizing repair means bonding a rubber patch to the tire or tube with heat so it becomes, in effect, part of the tire — a strong, lasting fix. A plug, by contrast, is a quick repair where a sticky strip is pushed into the puncture from the outside; it's fast and gets you moving, and it's fine as a temporary or minor fix, but it's not as reliable long-term as a proper patch, especially for larger holes or highway speeds. A cold patch (glued from the inside) sits in between. The right choice depends on where the damage is, how big it is, and how you'll use the tire — and part of our job is telling you honestly which your tire actually needs rather than defaulting to the quickest or most expensive option." },
+    { q: "Are you really open 24 hours?", a: "Yes — genuinely around the clock, every day, including nights, weekends and holidays, and it's the single most important thing about us. Flat tires and blowouts don't keep office hours; in fact they have a cruel habit of happening at the worst possible times — late at night, on a dark stretch of highway, on the way to something urgent, when every other shop is shuttered. Being truly 24-hour means that when you're stuck at 3AM, there's a lit shop and a real person ready to help rather than a locked gate and a long, anxious wait until morning. There's always someone on hand to patch, plug, vulcanize, change or balance a tire whatever the hour. If you're ever unsure, just call the number before you set out or when you're stuck — someone will answer, and we'll tell you straight whether to come in or whether we should come to you." },
+    { q: "I'm stranded on the road with a flat and no spare — can you come to me?", a: "Yes — roadside rescue is exactly what we're here for, and it's a call away, day or night. If you're stuck on the shoulder with a flat or a blowout and either no spare, a spare that's also flat, or no way to change it safely yourself, don't panic and don't risk changing it in a dangerous spot: call us, tell us as precisely as you can where you are (landmark, kilometre marker, direction of travel) and what's happened, and we'll roll out to you with the tools and, if needed, a tire to get you moving again on the spot or get your vehicle safely to the shop. While you wait, get yourself and any passengers to a safe position away from traffic, put on your hazard lights, and set up your early-warning device if you have one. We serve the Antipolo area and the surrounding highways; if you're a bit further out, call anyway and we'll tell you honestly whether we can reach you or point you to the fastest help. Save our number now — roadside rescue is the thing you'll be endlessly glad you had before you ever need it." },
+    { q: "Do you repair tricycle, motorbike and truck tires too, not just cars?", a: "Yes — we handle the whole range of what rolls on Filipino roads: cars and vans, motorbikes and scooters, tricycles, jeepneys, and light-to-medium trucks. Tricycles and motorbikes especially are a big part of what we do, because for so many people here those two or three wheels aren't a hobby, they're a livelihood, and a flat means lost income for every hour it's off the road. So we prioritise fast turnaround for trike drivers and delivery riders, keep the right patches, tubes and tools for smaller wheels on hand, and offer fair, standing arrangements for regulars whose wheels are their work. Trucks and larger vehicles we handle too, within the limits of our equipment — and if something genuinely needs specialist heavy-truck gear we don't have, we'll tell you honestly and point you the right way rather than fumble it. Whatever you drive or ride, roll in and we'll sort it; and if you run a small fleet, talk to us about a standing arrangement." },
+    { q: "Should I buy a secondhand tire, or is that a false economy?", a: "It depends, and we'll give you the honest answer for your situation rather than just pushing the more profitable option. A good secondhand tire — sound tread depth, no sidewall damage, not too old, properly inspected — can be a genuinely sensible, safe choice when the budget is tight, and for many drivers and especially trike operators it's the practical reality; we stock decent used tires precisely because not everyone can drop the money on new rubber every time. That said, secondhand is a false economy if the tire is worn near its limit, cracked with age, or previously badly repaired, because you'll be back sooner and, more importantly, a bad tire is a safety risk at speed. New tires cost more up front but give you the full tread life and the peace of mind, which matters more the more highway driving you do. Our approach is simple: we tell you what we'd honestly buy in your position, show you the tread and condition so you can see for yourself, and never sell you a tire — new or used — that we wouldn't put on our own vehicle. Sometimes the right answer is a good used tire; sometimes it's new; we'll say which." },
+    { q: "How do I know if a repair will hold or if I need a new tire?", a: "The honest short answer is that it depends on where and how bad the damage is, and a trustworthy shop will assess it and tell you plainly — which is exactly what we do before touching your tire. As a general guide: a clean puncture in the central tread area is usually safely repairable with a proper patch or vulcanized repair and will hold for the life of the tire. Damage in the sidewall or shoulder, a very large hole or gash, a tire that's been driven flat and overheated, or one that's simply worn down to the limit or cracked with age, generally can't be safely repaired and needs replacing — patching those is a false economy and a genuine safety risk. We'll always show you the damage, explain whether it's a permanent fix or just a get-you-home measure, and give you a straight recommendation with the reasons, so the decision is yours and informed rather than pressured. We would far rather tell you honestly that a cheap patch is all you need than upsell you a tire — and equally, we won't send you back onto the highway on a repair we don't trust. Ask us anything; explaining it is part of the job." }
+  ],
+  area: { places: ["Antipolo", "Marikina", "Cainta", "Taytay", "Rizal", "Highway roadside rescue"] },
+  credentials: [
+    { label: "Since 2001", detail: "Keeping Antipolo's wheels rolling" },
+    { label: "Open 24 hours", detail: "Every night, weekend and holiday" },
+    { label: "Roadside rescue", detail: "We come to you when you're stuck" },
+    { label: "Honest fixes", detail: "The right repair, plainly explained" }
+  ],
+  location: { name: "Mang Kanor Vulcanizing", addressStreet: "Km 22 Marcos Highway, Mayamot", addressLocality: "Antipolo", addressRegion: "Rizal", addressPostcode: "1870", addressCountry: "Philippines" },
+  cta: { heading: "Save the number now. Thank yourself at 3AM.", body: "24-hour flat repair, vulcanizing, wheel balancing, tires and roadside rescue for cars, trucks, trikes and motors — fast, fair, and open when everyone else is closed. Keeping Antipolo rolling since 2001.", primary: { label: "Call for rescue", href: "#book" }, secondary: { label: "0917 555 0247", href: "tel:+639175550247" } },
+  messaging: { whatsapp: "https://wa.me/639175550247", messenger: "https://m.me/mangkanortire" }
+};
+</script>
+
+<style>
+  :root {
+    --asphalt:#191b1e; --asphalt-2:#0f1113; --steel:#eceff2; --steel-2:#f6f8fa; --ink:#1e2226; --ink-2:#454b52;
+    --hazard:#f5c518; --alert:#e23b2e; --go:#2f9e57;
+    --mid:#83898f; --mid-d:#b5bcc3; --rule-d:rgba(236,239,242,0.15);
+    --disp:"Archivo",system-ui,sans-serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--asphalt);color:var(--steel);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--hazard);}
+  .wrap{width:min(1280px,93vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.15em;text-transform:uppercase;color:var(--hazard);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:900;font-size:clamp(38px,5.4vw,80px);line-height:0.98;margin:0 0 0.3em;letter-spacing:-0.02em;}
+  .h2 em{font-style:normal;color:var(--hazard);}
+  .body{color:var(--mid-d);line-height:1.7;}
+  section{padding:clamp(74px,9vw,126px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:16px 32px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:2px;}
+  .btn-primary{background:var(--alert);color:var(--steel-2);} .btn-primary:hover{background:var(--hazard);color:var(--asphalt);}
+  .btn-ghost{border:1.5px solid rgba(236,239,242,0.4);color:var(--steel);} .btn-ghost:hover{background:var(--steel);color:var(--asphalt);border-color:var(--steel);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.15em;text-transform:uppercase;color:var(--mid-d);border-bottom:1.5px solid var(--rule-d);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,58px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(25,27,30,0.92);backdrop-filter:blur(10px);border-bottom:1.5px solid var(--rule-d);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:15px 0;}
+  .wm{font-family:var(--disp);font-weight:900;font-size:21px;text-decoration:none;letter-spacing:-0.03em;text-transform:uppercase;}
+  .wm span{color:var(--hazard);}
+  .nav-links{display:flex;gap:26px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.09em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:900;font-size:clamp(40px,6.4vw,98px);line-height:0.92;letter-spacing:-0.03em;margin:0 0 32px;max-width:17ch;}
+  .hero-headline .em{color:var(--hazard);}
+  .hero-headline .em2{color:var(--alert);}
+  .hero-lower{display:grid;grid-template-columns:1.15fr 0.85fr;gap:clamp(30px,4vw,64px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:3px;}
+  .hero-photo::after{content:"OPEN 24 HOURS · SINCE 2001";position:absolute;left:14px;bottom:14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.12em;background:var(--hazard);color:var(--asphalt);padding:7px 12px;border-radius:2px;}
+  .hero-right .lede{color:var(--mid-d);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--hazard);color:var(--asphalt);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(25,27,30,0.82);font-weight:700;}
+
+  .about{background:var(--steel);color:var(--ink);}
+  .about .h2{color:var(--ink);} .about .h2 em{color:var(--alert);}
+  .about .sw-head{color:var(--mid);border-color:rgba(30,34,38,0.16);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:3px;}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.76;margin:0 0 1em;color:#3b4148;}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:1.5px solid var(--rule-d);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid rgba(236,239,242,0.12);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(226,59,46,0.12);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.1em;color:var(--hazard);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:800;font-size:clamp(24px,2.6vw,34px);margin:0;line-height:1.0;letter-spacing:-0.02em;}
+  .svc-row p{color:var(--mid-d);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--steel);color:var(--ink);}
+  .why .sw-head{color:var(--mid);border-color:rgba(30,34,38,0.16);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.16em;color:var(--alert);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:800;font-size:27px;margin:0 0 10px;line-height:1.0;letter-spacing:-0.02em;}
+  .why-grid p{color:#3b4148;margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:3px solid var(--alert);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--hazard);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:800;font-size:22px;margin:8px 0 8px;line-height:1.02;letter-spacing:-0.02em;}
+  .how-grid p{color:var(--mid-d);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--asphalt-2);}
+  .t-quote{font-family:var(--disp);font-weight:800;font-size:clamp(28px,3.7vw,54px);line-height:1.04;max-width:25ch;margin:0 0 24px;letter-spacing:-0.025em;}
+  .t-quote em{font-style:normal;color:var(--hazard);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:1.5px solid var(--rule-d);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:var(--mid-d);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:3px;}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--alert);color:var(--steel-2);font-family:var(--mono);font-size:9px;letter-spacing:0.1em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule-d);padding:22px 0;}
+  .faq-list details:first-child{border-top:1.5px solid var(--rule-d);}
+  .faq-list summary{font-family:var(--disp);font-weight:800;font-size:21px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.14;letter-spacing:-0.02em;}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--hazard);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--mid-d);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.08em;text-transform:uppercase;padding:10px 20px;border:1.5px solid rgba(236,239,242,0.3);border-radius:2px;font-weight:700;color:var(--mid-d);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:1.5px solid var(--rule-d);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--hazard);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:800;font-size:19px;line-height:1.12;letter-spacing:-0.02em;}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--steel);color:var(--ink);padding:34px;border-radius:3px;}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:800;font-size:20px;line-height:1.26;letter-spacing:-0.02em;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:500;color:#3b4148;}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:1px solid rgba(30,34,38,0.16);padding-top:18px;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--mid);}
+  .hours .row strong{color:var(--go);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--mid);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:3px;border:1.5px solid rgba(236,239,242,0.2);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.3) invert(0.9) hue-rotate(180deg) brightness(0.92);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--alert);color:var(--steel-2);padding:clamp(80px,10vw,144px) 0;text-align:center;}
+  .cta-band .kick{color:var(--steel-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:900;font-size:clamp(42px,6.2vw,102px);line-height:0.94;margin:14px auto 18px;max-width:15ch;letter-spacing:-0.03em;}
+  .cta-band h2 em{font-style:normal;color:var(--hazard);}
+  .cta-band p{color:rgba(246,248,250,0.92);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--steel-2);color:var(--alert);} .cta-band .btn-primary:hover{background:var(--hazard);color:var(--asphalt);}
+  .cta-band .btn-ghost{border-color:var(--steel-2);color:var(--steel-2);} .cta-band .btn-ghost:hover{background:var(--steel-2);color:var(--alert);}
+
+  footer{background:var(--asphalt);border-top:1.5px solid var(--rule-d);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--hazard);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:var(--mid-d);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid var(--rule-d);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--mid-d);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--alert);color:var(--steel-2);padding:13px 20px;border-radius:2px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;box-shadow:0 8px 24px rgba(226,59,46,0.4);}
+  .msg-fab a:hover{background:var(--hazard);color:var(--asphalt);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"AutoRepair","name":"Mang Kanor Vulcanizing","description":"24-hour vulcanizing and tire-repair shop in Antipolo, Rizal — flat repair, hot and cold vulcanizing, patch and plug, tube and tubeless, wheel balancing, new and used tires, plus roadside rescue. Since 2001.","url":"https://mangkanortire.ph/","telephone":"+639175550247","email":"help@mangkanortire.ph","address":{"@type":"PostalAddress","streetAddress":"Km 22 Marcos Highway, Mayamot","addressLocality":"Antipolo","addressRegion":"Rizal","postalCode":"1870","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":14.6180,"longitude":121.1500},"areaServed":["Antipolo","Marikina","Cainta","Taytay","Rizal"],"openingHours":"Mo-Su 00:00-23:59","image":["https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=1600"],"foundingDate":"2001"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What does 'vulcanizing' mean, and how is it different from plugging a tire?","acceptedAnswer":{"@type":"Answer","text":"Vulcanizing is treating rubber with heat and pressure to bond it strongly. In a Filipino roadside context 'vulcanizing shop' means any tire-repair shop, but the actual vulcanizing repair bonds a rubber patch to the tire or tube with heat so it becomes part of the tire — a strong, lasting fix. A plug is a quick sticky strip pushed in from outside: fast and fine as a temporary or minor fix, but less reliable long-term, especially for larger holes or highway speeds. A cold patch sits between. The right choice depends on the damage, and part of our job is telling you honestly which your tire needs."}},
+{"@type":"Question","name":"Are you really open 24 hours?","acceptedAnswer":{"@type":"Answer","text":"Yes — genuinely around the clock, every day including nights, weekends and holidays, and it's the most important thing about us. Flats and blowouts don't keep office hours; they happen late at night, on dark highways, on the way to something urgent. Being truly 24-hour means that when you're stuck at 3AM there's a lit shop and a real person ready to help, not a locked gate. There's always someone to patch, plug, vulcanize, change or balance a tire. If unsure, call the number before you set out or when stuck — someone will answer."}},
+{"@type":"Question","name":"I'm stranded with a flat and no spare — can you come to me?","acceptedAnswer":{"@type":"Answer","text":"Yes — roadside rescue is exactly what we're here for, day or night. Call, tell us as precisely as you can where you are (landmark, km marker, direction) and what happened, and we'll roll out with tools and if needed a tire to get you moving or your vehicle safely to the shop. While waiting, get to a safe spot away from traffic, hazard lights on, early-warning device out. We serve Antipolo and surrounding highways; if further out, call anyway and we'll tell you honestly if we can reach you. Save our number now."}},
+{"@type":"Question","name":"Do you repair tricycle, motorbike and truck tires too?","acceptedAnswer":{"@type":"Answer","text":"Yes — cars, vans, motorbikes, scooters, tricycles, jeepneys and light-to-medium trucks. Tricycles and motorbikes especially, because for many people those wheels are a livelihood and a flat means lost income. We prioritise fast turnaround for trike drivers and delivery riders, keep the right patches, tubes and tools on hand, and offer fair standing arrangements for regulars. Trucks we handle within our equipment; if something needs specialist heavy-truck gear we don't have, we'll say so honestly. Run a small fleet? Ask about a standing arrangement."}},
+{"@type":"Question","name":"Should I buy a secondhand tire, or is that a false economy?","acceptedAnswer":{"@type":"Answer","text":"It depends, and we give the honest answer for your situation. A good secondhand tire — sound tread, no sidewall damage, not too old, properly inspected — can be sensible and safe when budget is tight, which is why we stock decent used tires. But it's a false economy if the tire is near its limit, cracked with age, or badly repaired, because a bad tire is a safety risk at speed. New tires cost more but give full tread life and peace of mind, matering more with highway driving. We tell you what we'd honestly buy in your position and never sell a tire we wouldn't put on our own vehicle."}},
+{"@type":"Question","name":"How do I know if a repair will hold or if I need a new tire?","acceptedAnswer":{"@type":"Answer","text":"It depends on where and how bad the damage is, and we assess and tell you plainly before touching the tire. Generally: a clean puncture in the central tread is usually safely repairable with a patch or vulcanized repair and holds for the tire's life. Sidewall or shoulder damage, a very large hole, a tire driven flat and overheated, or one worn to the limit or age-cracked, generally can't be safely repaired and needs replacing. We show you the damage, explain whether it's permanent or a get-home measure, and recommend with reasons — we'd rather tell you a cheap patch is all you need than upsell, and we won't send you out on a repair we don't trust."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Mang Kanor <span>Vulcanizing</span></a>
+    <nav class="nav-links">
+      <a href="#about">The shop</a><a href="#services">What we fix</a><a href="#location">Find us</a><a href="#book">Call</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">24-hour vulcanizing & tire repair · roadside rescue · Antipolo, Rizal</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      Flat at 3AM on the Marcos Highway? We're the light that's <span class="em">still on.</span>
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=2000&q=85&auto=format&fit=crop"
+             alt="A tire being worked on in a repair shop." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A 24-hour vulcanizing and tire shop on the Antipolo road — flats patched, plugged and vulcanized, tubes and tubeless, cars, trucks, tricycles and motors. We balance wheels, sell secondhand and new tires, and when you're stranded on the highway with a blowout, we come to you. Fast, fair, and open when everyone else is closed. The light that's always on.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Call for rescue</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">What we fix</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Keeping Antipolo rolling since 2001</span>
+    <span>Open 24 hours, genuinely</span>
+    <span>Roadside rescue</span>
+    <span>Cars · trucks · trikes · motors</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 01 / THE SHOP</span><span>KM 22, MARCOS HIGHWAY</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">A flat tire doesn't check the clock. Neither do <em>we.</em></h2>
+        <p>Mang Kanor Vulcanizing is a tire-repair and vulcanizing shop on the Antipolo road, and "vulcanizing" — from the process of bonding rubber with heat — is the Filipino catch-all for tire repair: patching a puncture, plugging a hole, sealing a tube, whatever it takes to get a flat rolling again. You'll find a vulcanizing shop on nearly every provincial roadside in the country, because tires go flat everywhere, at every hour, and someone has to fix them.</p>
+        <p>We've been that someone here since 2001, and the thing that sets us apart is simple: we don't close. A flat tire doesn't wait for business hours — it happens at 3AM on the highway, on the way to the hospital, on the last trip home after a long shift. So we keep the light on around the clock, with someone always ready to patch, plug, vulcanize, change or balance a wheel, for cars, trucks, jeepneys, tricycles and motorbikes alike. Fast, honest, and priced the way roadside repair should be.</p>
+        <p>And when you can't reach us — stuck on the shoulder with a blowout and no spare — we come to you. Call, tell us where you are, and we'll roll out with the tools to get you moving or towed. We also sell good secondhand and new tires, do minor roadside mechanical fixes, and keep the tricycles and delivery riders of Antipolo on the road. It's not glamorous work. It's the work that gets everybody else home. Twenty-four hours, every day, we're here for it.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=1200&q=85&auto=format&fit=crop"
+           alt="A mechanic's hands working on a wheel." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" class="testimonials" data-component="SERVICES" data-variant="v78" data-screen-label="Services" style="background:var(--asphalt);">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 02 / WHAT WE FIX</span><span>PATCH · VULCANIZE · BALANCE · RESCUE</span></div>
+    <h2 class="h2">What we fix.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>Flat repair — patch &amp; plug</h3><p>Punctures found, cleaned and sealed — cold-patch, plug, or a proper vulcanized patch for a lasting fix. Tubeless and tube-type, cars to trucks. We find the leak you can't and get you rolling fast.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>Hot &amp; cold vulcanizing</h3><p>The real thing: bonding a patch to the tire or tube with heat and pressure for a repair that holds, not a temporary plug that fails on the next long drive. The right fix for the damage, explained honestly.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>Tire change &amp; wheel balancing</h3><p>Worn or blown tires swapped, valves replaced, and wheels balanced so your ride is smooth and your tires wear evenly. We'll tell you straight when a tire's done and when it's got life left.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>New &amp; secondhand tires</h3><p>Good used tires at a fair price when the budget's tight, and new tires when you want the miles — cars, tricycles, motorbikes and light trucks. Honest advice on tread, age and what's safe to buy.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>24-hour roadside rescue</h3><p>Stranded with a flat or blowout and no spare? Call us. We roll out with tools and tires to fix you on the shoulder or get you to the shop — day, night, weekend, holiday. Save the number before you need it.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Trikes, motors &amp; fleet</h3><p>We keep Antipolo's tricycles, delivery riders and small fleets rolling with fast turnaround and standing arrangements — because when your wheels are your income, downtime costs money. Priority, fair rates, always open.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 03 / THE DIFFERENCE</span><span>WHY YOU SAVE OUR NUMBER</span></div>
+    <h2 class="h2">Why you save our <em>number.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Open 24 hours. Genuinely.</h3><p>Not 'til late' — actually around the clock, every day of the year. A flat at 3AM is exactly when you need us most, and exactly when everyone else is shut. The light stays on. That's the whole promise.</p></div>
+      <div><span class="no">02 / 03</span><h3>We come to you.</h3><p>Stranded on the highway with no spare? Call and we roll out with tools and tires. You don't have to limp a ruined tire to us or sleep in the car till morning — roadside rescue is a phone call away.</p></div>
+      <div><span class="no">03 / 03</span><h3>Honest about the fix.</h3><p>We'll tell you when a patch will hold and when a tire's genuinely done — no scaring you into a new tire you don't need, no cheap plug on damage that needs vulcanizing. Fair fix, fair price, plainly explained.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 04 / HOW IT GOES</span><span>ROLL IN · ASSESS · FIX · GO</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Roll in, or call</h3><p>Drive, ride or wheel in any hour — no appointment. Or if you're stranded, call and tell us where you are and what happened. We'll talk you through it and roll out if you need rescue.</p></li>
+      <li><span class="step">STEP 02</span><h3>We find the damage</h3><p>We locate the leak or assess the blowout, then tell you honestly what it needs — a plug, a patch, a proper vulcanize, or a new tire — and what it'll cost, before we touch it. No surprises.</p></li>
+      <li><span class="step">STEP 03</span><h3>Fixed fast</h3><p>Most flats are patched or plugged and balanced in minutes, not hours, because you've got somewhere to be. Vulcanized repairs take a little longer but hold far better. Either way, we don't dawdle.</p></li>
+      <li><span class="step">STEP 04</span><h3>Back on the road</h3><p>Rolling again, with a straight answer on whether the fix is permanent or a get-home measure, and when to check the tire next. Save our number — the flat you don't have yet will thank you.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 05 / FROM THE ROADSIDE</span><span>A GENUINE LIFESAVER</span></div>
+    <blockquote class="t-quote">“Blew a tire at 1AM with my kids and no spare. He came within the hour and charged a fair price. <em>A genuine lifesaver, literally.</em>”</blockquote>
+    <div class="t-attr">Rowena F. — roadside rescue, 1AM</div>
+    <div class="t-sub">
+      <figure><blockquote>“I drive a tricycle and my tires are my livelihood. Mang Kanor patches me up fast, tells me straight when a tire's really done, and never overcharges. Every trike driver in our area goes to him because he's fair and he's always open. Solid, honest, reliable. Salamat, Mang Kanor.”</blockquote><figcaption>Kuya Dan — tricycle driver</figcaption></figure>
+      <figure><blockquote>“Came in with a slow leak I'd been ignoring and he found a nail I'd never have spotted, vulcanized it properly instead of just plugging it, and explained exactly why. Been back three times since for the family cars. This is what a neighbourhood shop should be — skilled, honest, always there.”</blockquote><figcaption>Engr. Villamor — regular customer</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--steel);">
+  <div class="wrap">
+    <div class="sw-head" style="color:var(--mid);border-color:rgba(30,34,38,0.16);"><span>BAY 06 / IN THE BAY</span><span>RUBBER, TOOLS &amp; NIGHT SHIFT</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=1600&q=85&auto=format&fit=crop" alt="A tire being worked on in a repair shop." /><figcaption>THE REPAIR</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=1600&q=85&auto=format&fit=crop" alt="A mechanic's hands working on a wheel." /><figcaption>THE HANDS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?w=1600&q=85&auto=format&fit=crop" alt="A polished wheel and tire." /><figcaption>THE WHEEL</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=1600&q=85&auto=format&fit=crop" alt="Tools laid out in a workshop." /><figcaption>THE TOOLS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1503376780353-7e6692767b70?w=1600&q=85&auto=format&fit=crop" alt="A car headlight at night." /><figcaption>THE NIGHT SHIFT</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1502877338535-766e1452684a?w=1600&q=85&auto=format&fit=crop" alt="A road at night with headlights." /><figcaption>THE HIGHWAY</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 07 / GOOD TO KNOW</span><span>VULCANIZING, RESCUE &amp; TIRES</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Stuck right now? Call <a href="tel:+639175550247" style="color:var(--hazard);font-weight:700;">0917 555 0247</a> — someone answers, any hour. Save it before you need it.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What does 'vulcanizing' actually mean, and how is it different from just plugging a tire?</summary><p>Vulcanizing, strictly speaking, is the process of treating rubber with heat (and often pressure and a curing agent) to bond it strongly — the same principle that makes tire rubber durable in the first place. In a Filipino roadside context, 'vulcanizing shop' has become the general term for any tire-repair shop, but the actual vulcanizing repair means bonding a rubber patch to the tire or tube with heat so it becomes, in effect, part of the tire — a strong, lasting fix. A plug, by contrast, is a quick repair where a sticky strip is pushed into the puncture from the outside; it's fast and gets you moving, and it's fine as a temporary or minor fix, but it's not as reliable long-term as a proper patch, especially for larger holes or highway speeds. A cold patch (glued from the inside) sits in between. The right choice depends on where the damage is, how big it is, and how you'll use the tire — and part of our job is telling you honestly which your tire actually needs.</p></details>
+        <details><summary>Are you really open 24 hours?</summary><p>Yes — genuinely around the clock, every day, including nights, weekends and holidays, and it's the single most important thing about us. Flat tires and blowouts don't keep office hours; in fact they have a cruel habit of happening at the worst possible times — late at night, on a dark stretch of highway, on the way to something urgent, when every other shop is shuttered. Being truly 24-hour means that when you're stuck at 3AM, there's a lit shop and a real person ready to help rather than a locked gate and a long, anxious wait until morning. There's always someone on hand to patch, plug, vulcanize, change or balance a tire whatever the hour. If you're ever unsure, just call the number before you set out or when you're stuck — someone will answer, and we'll tell you straight whether to come in or whether we should come to you.</p></details>
+        <details><summary>I'm stranded on the road with a flat and no spare — can you come to me?</summary><p>Yes — roadside rescue is exactly what we're here for, and it's a call away, day or night. If you're stuck on the shoulder with a flat or a blowout and either no spare, a spare that's also flat, or no way to change it safely yourself, don't panic and don't risk changing it in a dangerous spot: call us, tell us as precisely as you can where you are (landmark, kilometre marker, direction of travel) and what's happened, and we'll roll out to you with the tools and, if needed, a tire to get you moving again on the spot or get your vehicle safely to the shop. While you wait, get yourself and any passengers to a safe position away from traffic, put on your hazard lights, and set up your early-warning device if you have one. We serve the Antipolo area and the surrounding highways; if you're a bit further out, call anyway and we'll tell you honestly whether we can reach you. Save our number now.</p></details>
+        <details><summary>Do you repair tricycle, motorbike and truck tires too, not just cars?</summary><p>Yes — we handle the whole range of what rolls on Filipino roads: cars and vans, motorbikes and scooters, tricycles, jeepneys, and light-to-medium trucks. Tricycles and motorbikes especially are a big part of what we do, because for so many people here those two or three wheels aren't a hobby, they're a livelihood, and a flat means lost income for every hour it's off the road. So we prioritise fast turnaround for trike drivers and delivery riders, keep the right patches, tubes and tools for smaller wheels on hand, and offer fair, standing arrangements for regulars whose wheels are their work. Trucks and larger vehicles we handle too, within the limits of our equipment — and if something genuinely needs specialist heavy-truck gear we don't have, we'll tell you honestly and point you the right way rather than fumble it. Whatever you drive or ride, roll in and we'll sort it.</p></details>
+        <details><summary>Should I buy a secondhand tire, or is that a false economy?</summary><p>It depends, and we'll give you the honest answer for your situation rather than just pushing the more profitable option. A good secondhand tire — sound tread depth, no sidewall damage, not too old, properly inspected — can be a genuinely sensible, safe choice when the budget is tight, and for many drivers and especially trike operators it's the practical reality; we stock decent used tires precisely because not everyone can drop the money on new rubber every time. That said, secondhand is a false economy if the tire is worn near its limit, cracked with age, or previously badly repaired, because you'll be back sooner and, more importantly, a bad tire is a safety risk at speed. New tires cost more up front but give you the full tread life and the peace of mind. Our approach is simple: we tell you what we'd honestly buy in your position, show you the tread and condition, and never sell you a tire we wouldn't put on our own vehicle.</p></details>
+        <details><summary>How do I know if a repair will hold or if I need a new tire?</summary><p>The honest short answer is that it depends on where and how bad the damage is, and a trustworthy shop will assess it and tell you plainly — which is exactly what we do before touching your tire. As a general guide: a clean puncture in the central tread area is usually safely repairable with a proper patch or vulcanized repair and will hold for the life of the tire. Damage in the sidewall or shoulder, a very large hole or gash, a tire that's been driven flat and overheated, or one that's simply worn down to the limit or cracked with age, generally can't be safely repaired and needs replacing — patching those is a false economy and a genuine safety risk. We'll always show you the damage, explain whether it's a permanent fix or just a get-you-home measure, and give you a straight recommendation with the reasons. We would far rather tell you honestly that a cheap patch is all you need than upsell you a tire — and equally, we won't send you back onto the highway on a repair we don't trust.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 08 / WE COVER</span><span>ANTIPOLO &amp; THE HIGHWAYS</span></div>
+    <ul class="area-list">
+      <li>Antipolo</li><li>Marikina</li><li>Cainta</li><li>Taytay</li><li>Rizal</li><li>Highway roadside rescue</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 09 / THE ESSENTIALS</span><span>HOW WE WORK</span></div>
+    <div class="creds">
+      <div><div class="label">Since 2001</div><div class="detail">Keeping Antipolo's wheels rolling</div></div>
+      <div><div class="label">Open 24 hours</div><div class="detail">Every night, weekend and holiday</div></div>
+      <div><div class="label">Roadside rescue</div><div class="detail">We come to you when you're stuck</div></div>
+      <div><div class="label">Honest fixes</div><div class="detail">The right repair, plainly explained</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>BAY 10 / THE SHOP</span><span>KM 22, MARCOS HIGHWAY</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Mang Kanor Vulcanizing</strong><br />
+          Km 22 Marcos Highway, Mayamot<br />
+          Antipolo, Rizal 1870<br /><br />
+          <a href="tel:+639175550247" data-bind="business.phoneDisplay">0917 555 0247</a><br />
+          <a href="mailto:help@mangkanortire.ph" data-bind="business.email">help@mangkanortire.ph</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>EVERY DAY</span><strong>OPEN 24 HOURS</strong></div>
+          <div class="row"><span>ROADSIDE RESCUE</span><span>ANYTIME</span></div>
+          <p class="gbp-note">Live details on our Google Business Profile. We're right on Marcos Highway at Km 22 in Mayamot — look for the lit shop and the stack of tires. Never closed. Call before you set out if unsure.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Mang Kanor Vulcanizing, Antipolo" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=121.1350%2C14.6080%2C121.1650%2C14.6280&layer=mapnik&marker=14.6180%2C121.1500"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">BAY 11 / CALL</div>
+    <h2 data-bind="cta.heading">Save the number now. Thank yourself at <em>3AM.</em></h2>
+    <p data-bind="cta.body">24-hour flat repair, vulcanizing, wheel balancing, tires and roadside rescue for cars, trucks, trikes and motors — fast, fair, and open when everyone else is closed. Keeping Antipolo rolling since 2001.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Call for rescue</a>
+      <a class="btn btn-ghost" href="tel:+639175550247" data-bind="cta.secondary.label">0917 555 0247</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/639175550247" data-bind="messaging.whatsapp" aria-label="Message the shop">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:21px;">Mang Kanor <span style="color:var(--hazard);">Vulcanizing</span></div>
+        <p class="body" style="margin-top:12px;max-width:34ch;">A 24-hour vulcanizing and tire shop on the Antipolo road — flats, tires and roadside rescue, always open, since 2001.</p>
+      </div>
+      <div>
+        <h4>The shop</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:var(--mid-d);">
+          Km 22 Marcos Highway, Mayamot<br />Antipolo, Rizal 1870<br />
+          <a href="tel:+639175550247">0917 555 0247</a><br />
+          <a href="mailto:help@mangkanortire.ph">help@mangkanortire.ph</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">What we fix</a><a href="#about">The shop</a><a href="#location">Find us</a><a href="#book">Call</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> MANG KANOR VULCANIZING</span>
+      <span>OPEN 24 HOURS · ANTIPOLO</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>

--- a/public/template-previews/bh.html
+++ b/public/template-previews/bh.html
@@ -1,0 +1,526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ube & Yelo — halo-halo, mais con yelo & kakanin, made the Pampanga way in Angeles City</title>
+<meta name="description" content="Ube & Yelo is a halo-halo haus in Angeles City, Pampanga — tall halo-halo layered with sweet beans, nata, sago, leche flan and hand-grated ube, topped with our own ube ice cream, plus mais con yelo and kakanin. Mixed to order, the Kapampangan way. Since 2016." />
+<link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@500;700;800&family=Hanken+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+
+<script>
+const CONFIG = {
+  business: { name: "Ube & Yelo", phone: "+63 917 555 0355", phoneDisplay: "0917 555 0355", email: "hello@ubeandyelo.ph", foundedYear: 2016 },
+  hero: {
+    kicker: "Halo-halo haus · mais con yelo · kakanin · Angeles City, Pampanga",
+    headline: "Halo means mix. So mix it — all the way to the bottom.",
+    lede: "A halo-halo haus in Angeles City, layering the tall glass the Kapampangan way: sweet beans, kaong, nata de coco, sago and macapuno under finely shaved ice, crowned with a slab of our own leche flan and a scoop of hand-grated ube ice cream. Poured with evaporated milk, made to order, and meant to be stirred into glorious purple chaos before the ice melts.",
+    primaryCta: { label: "Order or visit", href: "#book" },
+    secondaryCta: { label: "What's in the glass", href: "#services" },
+    image: "https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=2000&q=85&auto=format&fit=crop",
+    imageAlt: "A colourful frozen dessert counter."
+  },
+  trust: { years: "Chilling glasses since 2016" },
+  about: {
+    heading: "The whole joy is the stir. Don't sip it neat — halo, halo, mix it.",
+    paragraphs: [
+      "Ube & Yelo is a halo-halo haus, and halo-halo — literally 'mix-mix' — is the Philippines' great summer dessert: a tall glass built in layers of sweet preserved fruits and beans, jellies and ice, milk and something rich on top, that you're meant to stir together into one cold, sweet, purple rush. Pampanga takes its halo-halo seriously — this is the province famous for it — and we build ours the way it should be built: proper ingredients, generous hands, and shaved ice fine as snow.",
+      "We opened in 2016 because too much halo-halo had become a scoop of gritty ice with a token spoonful of beans. Ours goes the other way: sweetened kidney and garbanzo beans, kaong, nata de coco, sago, macapuno and sweet plantain cooked and prepared by us, layered under finely shaved ice, then topped with a real slab of home-made leche flan and a scoop of ube ice cream we churn from hand-grated purple yam. Evaporated milk poured over at the counter, in front of you.",
+      "Beyond the flagship glass we make mais con yelo, saba con yelo, our own ube and cheese ice creams, and a rotating counter of kakanin — sapin-sapin, biko, kutsinta and puto — the Filipino rice-cake sweets that belong beside a cold dessert. It's a small, bright, friendly place built for merienda, for beating the Pampanga heat, and for the simple pleasure of stirring a glass to the bottom."
+    ],
+    portrait: "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1200&q=85&auto=format&fit=crop",
+    portraitAlt: "A sweet layered dessert served in a glass."
+  },
+  services: [
+    { name: "The halo-halo", description: "The tall glass, built in layers: sweet beans, kaong, nata de coco, sago, macapuno and sweet plantain under snow-fine shaved ice, topped with home-made leche flan and a scoop of our ube ice cream, milk poured over. Special or overload — you choose the crown." },
+    { name: "Mais & saba con yelo", description: "The simpler cousins done properly — sweet corn or caramelised saba banana with shaved ice and milk, cold and comforting. The everyday merienda for when a full halo-halo is more than you need." },
+    { name: "House-churned ice cream", description: "Ube from hand-grated purple yam, sweet cheese (queso), and mango in season — dense, real Filipino ice cream by the scoop, in a cup, or crowning your glass. No powders, no shortcuts." },
+    { name: "Kakanin counter", description: "A rotating counter of rice-cake sweets — sapin-sapin, biko, kutsinta, puto and suman — steamed fresh, the traditional merienda that belongs beside a cold dessert or wrapped up to take home." },
+    { name: "Take-home & bilao", description: "Halo-halo kits and tubs of ice cream to take home, plus bilao of kakanin for fiestas, birthdays and pasalubong — the whole cold-and-sweet spread, boxed for the road. Order a day ahead." },
+    { name: "Merienda combos", description: "A cold glass and a warm rice cake, or ice cream and a hot cup — the little merienda pairings that make an afternoon, at a price that keeps students and families coming back all summer." }
+  ],
+  why: [
+    { title: "Ingredients we make ourselves.", body: "The beans, the leche flan, the ube ice cream, the kakanin — cooked and prepared by us, not scooped from a supplier's bucket. That's the difference between a real halo-halo and a sad one." },
+    { title: "Ice shaved fine as snow.", body: "Coarse, crunchy ice ruins a halo-halo. Ours is shaved fine so it melts into the milk and beans instead of sitting on top like gravel — soft, cold and mixable to the last spoon." },
+    { title: "Built generous, the Pampanga way.", body: "Pampanga is halo-halo country and we hold the line: layers all the way down, real leche flan, a proper scoop of ube. Stir to the bottom and there's still something good waiting." }
+  ],
+  how: [
+    { step: "01", title: "Pick your glass", body: "Classic halo-halo, or the overload with extra flan and a double scoop of ube. Or go simpler with mais con yelo or a cup of house ice cream. Tell us how sweet a tooth you've got." },
+    { step: "02", title: "We build it to order", body: "Layered fresh at the counter — beans and jellies first, snow-fine ice next, leche flan and ube ice cream on top, evaporated milk poured over in front of you. Nothing pre-made and melting in a fridge." },
+    { step: "03", title: "Mix it, all the way down", body: "This is the important part: stir it. Halo-halo means mix-mix — fold the flan and ube through the ice and beans until it's one cold purple swirl, and eat it before the ice gives up." },
+    { step: "04", title: "Take some home", body: "Loved it? Take home an ice cream tub, a halo-halo kit, or a bilao of kakanin for the family. Message us a day ahead for fiesta and party orders and we'll have it boxed." }
+  ],
+  testimonials: [
+    { quote: "I've had halo-halo all over the country and this is the one I drive back to Angeles for. The ube ice cream is unreal, the flan is real flan, and the ice actually melts like it should. Every spoon to the bottom has something in it. This is how it's supposed to be.", name: "Patricia G.", context: "regular, drives from Manila" },
+    { quote: "My kids call it 'the purple place.' We come every hot afternoon of summer and the mais con yelo has become their whole personality. Friendly, generous, spotlessly clean, and priced so a family can actually afford to make it a habit. We love it here.", name: "The Sison family", context: "summer regulars" },
+    { quote: "Ordered bilao of kakanin and tubs of ube ice cream for my mom's birthday and everyone lost their minds. The sapin-sapin was the best I've had since my lola's. Delivered on time, beautifully packed. Ube & Yelo, you made the party. Salamat!", name: "Jules M.", context: "birthday order" }
+  ],
+  gallery: [
+    { src: "https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1600&q=85&auto=format&fit=crop", alt: "A colourful frozen dessert counter." },
+    { src: "https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1600&q=85&auto=format&fit=crop", alt: "A layered dessert served in a glass." },
+    { src: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop", alt: "A cold sweet drink on the counter." },
+    { src: "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop", alt: "Sweet rice cakes plated." },
+    { src: "https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1600&q=85&auto=format&fit=crop", alt: "A dessert being prepared by hand." },
+    { src: "https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop", alt: "The bright dessert haus interior." }
+  ],
+  faq: [
+    { q: "What exactly goes into your halo-halo?", a: "Layers, and a lot of them — that's the whole point of halo-halo, which literally means 'mix-mix.' A classic glass of ours is built from the bottom up with sweetened kidney and garbanzo beans, kaong (sugar palm fruit), nata de coco, sago pearls, macapuno (sweet coconut strings) and sweet plantain, all cooked and sweetened by us; then a generous mound of snow-fine shaved ice; then evaporated milk poured over; and crowning it, a real slab of home-made leche flan and a scoop of our hand-grated ube ice cream. The 'overload' adds extra flan and a double scoop. Every component is made or prepared in-house rather than tipped out of a supplier's bucket, which is exactly why it tastes the way halo-halo is supposed to — rich, varied and interesting all the way to the bottom of the glass rather than mostly ice. If you have a preference — more beans, hold the sago, extra ube — just tell us; we build each one to order." },
+    { q: "Why does the way the ice is shaved matter so much?", a: "Because the ice is most of the dessert by volume, and coarse, crunchy, gravelly ice is the single quickest way to ruin a halo-halo. We shave ours fine — snow-fine — so that when you stir the glass, the ice folds into the evaporated milk, the leche flan and the beans to make a soft, cold, almost creamy mixture rather than sitting on top like crushed gravel that you have to crunch through. Fine ice also melts at the right rate: fast enough to blend into everything as you eat, slow enough that the glass doesn't turn to soup before you reach the bottom. It sounds like a small technical detail, but ask anyone serious about halo-halo and they'll tell you the texture of the ice is the difference between a great one and a forgettable one. It's one of the quiet things we're fussiest about." },
+    { q: "What's the difference between halo-halo, mais con yelo and saba con yelo?", a: "They're a family of shaved-ice desserts that share the same cold, milky base but differ in what's in them. Halo-halo is the maximalist one — many layers of beans, jellies, fruits, flan and ice cream — the full production, meant to be mixed. Mais con yelo is the pared-back cousin: sweet corn kernels with shaved ice and milk, simple and comforting, and a lot of people's everyday favourite when a whole halo-halo feels like too much. Saba con yelo is the same idea with caramelised saba banana instead of corn. All three are wonderful and all three are properly Filipino; halo-halo is the special-occasion, beat-the-heat centrepiece, while the con yelos are the easy, cheaper, no-fuss merienda. If you're new to it, we often suggest starting with mais con yelo and working up to the full halo-halo overload once you're hooked." },
+    { q: "Is your ube ice cream really made from real ube?", a: "Yes — our ube ice cream is churned from real purple yam that we cook and grate by hand, not flavoured and coloured with ube extract or powder, and the difference is immediately obvious in both taste and colour. Real ube has a gentle, nutty, almost vanilla-like sweetness and a natural deep-violet colour that's softer and more muted than the electric purple of the artificial stuff; it tastes like a vegetable-root dessert should, rich and rounded rather than one-note sweet. Making it this way is more work and more expensive — real ube isn't cheap and preparing it is laborious — but it's central to who we are, right there in our name. We churn our cheese (queso) and seasonal mango ice creams with the same no-shortcuts approach. You can have any of them by the scoop, in a cup, in a cone, as a take-home tub, or crowning your halo-halo. Once you've tasted real ube, the fake kind is hard to go back to." },
+    { q: "Can I order for a party, fiesta or as pasalubong?", a: "Yes, and it's popular — a cold, colourful spread is a joy at any Filipino celebration, and half our weekend orders are for birthdays, fiestas and family gatherings. We do take-home halo-halo kits (components packed separately so you assemble and pour at home for maximum freshness), tubs of our house-churned ice cream, and bilao of freshly steamed kakanin — sapin-sapin, biko, kutsinta, puto and suman — which make gorgeous, generous pasalubong and party platters. We ask for at least a day's notice, and more during summer weekends and fiesta season, so we can prepare everything fresh rather than rushing it, and we can arrange delivery around Angeles or have it ready for pick-up. Tell us the headcount, the date and what you'd like — or let us put together a spread — and we'll sort quantities and a fair price. It's the easiest way to be the one who brought the dessert everyone remembers." },
+    { q: "Do you have a quiet, family-friendly place to sit?", a: "Yes — we're a small, bright, friendly haus built exactly for merienda: somewhere to duck out of the Pampanga heat, sit down with a cold glass, and let the kids demolish a mais con yelo. It's spotlessly kept — with cold desserts and ice cream, cleanliness isn't optional and we take it seriously — and it's designed to be an easy, unpretentious spot for families, students, barkadas and anyone in need of something cold and sweet in the afternoon. There's seating for dining in, it's air-conditioned against the summer, and we've deliberately kept prices where a family can make a visit a regular habit rather than a rare treat, because that's what a neighbourhood dessert haus should be. Come in, take a booth, order a glass each, and stir. And if you'd rather take it away, everything travels too."  }
+  ],
+  area: { places: ["Angeles City", "Mabalacat", "San Fernando", "Clark", "Pampanga", "Delivery & pick-up"] },
+  credentials: [
+    { label: "Since 2016", detail: "A halo-halo haus in Angeles City" },
+    { label: "Made in-house", detail: "Beans, leche flan, ube ice cream & kakanin" },
+    { label: "Snow-fine ice", detail: "Shaved fine so it mixes, not crunches" },
+    { label: "Take-home", detail: "Kits, tubs & bilao for parties & pasalubong" }
+  ],
+  location: { name: "Ube & Yelo", addressStreet: "56 Sto. Rosario St", addressLocality: "Angeles City", addressRegion: "Pampanga", addressPostcode: "2009", addressCountry: "Philippines" },
+  cta: { heading: "Beat the heat. Stir it to the bottom.", body: "Tall halo-halo built the Pampanga way, mais con yelo, house-churned ube and cheese ice cream, and a counter of fresh kakanin — made to order in Angeles City since 2016. Visit the haus or order a spread for the party.", primary: { label: "Order or visit", href: "#book" }, secondary: { label: "0917 555 0355", href: "tel:+639175550355" } },
+  messaging: { whatsapp: "https://wa.me/639175550355", messenger: "https://m.me/ubeandyelo" }
+};
+</script>
+
+<style>
+  :root {
+    --milk:#fbf1f5; --milk-2:#fff8fb; --ube:#5b2a86; --ube-2:#43206a; --ink:#2c1c33; --ink-2:#584663;
+    --leche:#e8b23e; --mango:#f28b3c; --rosa:#e5568f;
+    --mid:#96849c; --rule:rgba(44,28,51,0.12);
+    --disp:"Unbounded",system-ui,sans-serif; --sans:"Hanken Grotesk",system-ui,sans-serif; --mono:"Space Mono",ui-monospace,monospace;
+  }
+  *,*::before,*::after{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{background:var(--milk);color:var(--ink);font-family:var(--sans);font-size:16.5px;line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden;}
+  img{max-width:100%;display:block;} a{color:inherit;} a:hover{color:var(--rosa);}
+  .wrap{width:min(1240px,92vw);margin-inline:auto;}
+  .kick{font-family:var(--mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--rosa);font-weight:700;}
+  .h2{font-family:var(--disp);font-weight:800;font-size:clamp(34px,4.8vw,68px);line-height:1.04;margin:0 0 0.34em;letter-spacing:-0.02em;}
+  .h2 em{font-style:normal;color:var(--rosa);}
+  .body{color:var(--ink-2);line-height:1.7;}
+  section{padding:clamp(74px,9vw,126px) 0;}
+  .btn{display:inline-flex;align-items:center;padding:15px 30px;font-family:var(--mono);font-weight:700;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;text-decoration:none;transition:0.16s;border-radius:999px;}
+  .btn-primary{background:var(--ube);color:var(--milk-2);} .btn-primary:hover{background:var(--rosa);}
+  .btn-ghost{border:2px solid var(--ube);color:var(--ube);} .btn-ghost:hover{background:var(--ube);color:var(--milk-2);}
+  .sw-head{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--mono);font-size:10.5px;letter-spacing:0.14em;text-transform:uppercase;color:var(--mid);border-bottom:2px solid var(--rule);padding-bottom:12px;margin-bottom:clamp(34px,4.5vw,58px);font-weight:700;}
+
+  .nav{position:sticky;top:0;z-index:50;background:rgba(251,241,245,0.93);backdrop-filter:blur(10px);border-bottom:2px solid var(--ube);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0;}
+  .wm{font-family:var(--disp);font-weight:800;font-size:20px;text-decoration:none;letter-spacing:-0.03em;color:var(--ube);}
+  .wm span{color:var(--rosa);}
+  .nav-links{display:flex;gap:24px;font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase;color:var(--ink-2);font-weight:700;}
+  .nav-links a{text-decoration:none;}
+  @media(max-width:760px){.nav-links{display:none;}}
+
+  .hero{padding:clamp(30px,5vw,64px) 0 clamp(56px,7vw,96px);position:relative;}
+  .hero-headline{font-family:var(--disp);font-weight:800;font-size:clamp(34px,5.4vw,80px);line-height:1.0;letter-spacing:-0.03em;margin:0 0 32px;max-width:17ch;color:var(--ube);}
+  .hero-headline .em{color:var(--rosa);}
+  .hero-headline .em2{color:var(--mango);}
+  .hero-lower{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(30px,4vw,60px);align-items:end;}
+  .hero-photo{position:relative;}
+  .hero-photo img{width:100%;aspect-ratio:16/10;object-fit:cover;border-radius:18px;border:3px solid var(--ube);}
+  .hero-photo::after{content:"HALO, HALO · MIX IT · SINCE 2016";position:absolute;left:-8px;top:-14px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:0.08em;background:var(--leche);color:var(--ink);padding:8px 14px;border-radius:999px;border:2.5px solid var(--ube);transform:rotate(-3deg);}
+  .hero-right .lede{color:var(--ink-2);font-size:clamp(15px,1.5vw,17.5px);line-height:1.72;max-width:44ch;}
+  .hero-ctas{margin-top:26px;display:flex;gap:13px;flex-wrap:wrap;}
+  @media(max-width:820px){.hero-lower{grid-template-columns:1fr;} }
+
+  .trust{padding:0;background:var(--ube);color:var(--milk-2);}
+  .trust .row{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;padding:15px 0;font-family:var(--mono);font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:rgba(255,248,251,0.9);font-weight:700;}
+
+  .about{background:var(--milk-2);color:var(--ink);}
+  .about-grid{display:grid;grid-template-columns:1.1fr 0.9fr;gap:clamp(38px,5vw,84px);align-items:center;}
+  .about-grid img{aspect-ratio:4/5;object-fit:cover;width:100%;border-radius:18px;border:3px solid var(--ube);}
+  .about-prose p{font-size:clamp(16px,1.55vw,19px);line-height:1.76;margin:0 0 1em;color:var(--ink-2);}
+  @media(max-width:820px){.about-grid{grid-template-columns:1fr;}}
+
+  .svc-rows{border-top:2px solid var(--ube);}
+  .svc-row{display:grid;grid-template-columns:110px 1fr 1.5fr;gap:clamp(18px,3vw,46px);padding:28px 0;border-bottom:1px solid var(--rule);align-items:baseline;transition:0.15s;}
+  .svc-row:hover{background:rgba(229,86,143,0.1);padding-left:12px;}
+  .svc-row .no{font-family:var(--mono);font-size:10.5px;letter-spacing:0.08em;color:var(--mango);text-transform:uppercase;font-weight:700;}
+  .svc-row h3{font-family:var(--disp);font-weight:700;font-size:clamp(21px,2.3vw,30px);margin:0;line-height:1.06;letter-spacing:-0.02em;color:var(--ube);}
+  .svc-row p{color:var(--ink-2);margin:0;font-size:15px;line-height:1.66;}
+  @media(max-width:760px){.svc-row{grid-template-columns:1fr;gap:8px;}}
+
+  .why{background:var(--ube);color:var(--milk-2);}
+  .why .sw-head{color:rgba(255,248,251,0.7);border-color:rgba(255,248,251,0.24);}
+  .why .h2{color:var(--milk-2);} .why .h2 em{color:var(--leche);}
+  .why-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(26px,4vw,60px);}
+  .why-grid .no{font-family:var(--mono);font-size:10px;letter-spacing:0.14em;color:var(--leche);display:block;margin-bottom:14px;text-transform:uppercase;font-weight:700;}
+  .why-grid h3{font-family:var(--disp);font-weight:700;font-size:23px;margin:0 0 10px;line-height:1.08;letter-spacing:-0.02em;}
+  .why-grid p{color:rgba(255,248,251,0.86);margin:0;font-size:14.5px;line-height:1.7;}
+  @media(max-width:760px){.why-grid{grid-template-columns:1fr;}}
+
+  .how-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(20px,3vw,42px);padding:0;margin:0;}
+  .how-grid > li{list-style:none;border-top:3px solid var(--rosa);padding-top:16px;}
+  .how-grid .step{font-family:var(--mono);font-size:10px;letter-spacing:0.12em;color:var(--mango);text-transform:uppercase;font-weight:700;}
+  .how-grid h3{font-family:var(--disp);font-weight:700;font-size:20px;margin:8px 0 8px;line-height:1.08;letter-spacing:-0.02em;color:var(--ube);}
+  .how-grid p{color:var(--ink-2);margin:0;font-size:13.5px;line-height:1.64;}
+  @media(max-width:760px){.how-grid{grid-template-columns:1fr 1fr;}}
+
+  .testimonials{background:var(--ube-2);color:var(--milk);}
+  .t-quote{font-family:var(--disp);font-weight:700;font-size:clamp(24px,3.2vw,44px);line-height:1.14;max-width:26ch;margin:0 0 24px;letter-spacing:-0.025em;}
+  .t-quote em{font-style:normal;color:var(--leche);}
+  .t-attr{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:var(--leche);margin-bottom:clamp(38px,5vw,60px);font-weight:700;}
+  .t-sub{display:grid;grid-template-columns:1fr 1fr;gap:clamp(28px,5vw,76px);border-top:2px solid rgba(251,241,245,0.22);padding-top:34px;}
+  .t-sub blockquote{font-size:15.5px;line-height:1.72;margin:0 0 12px;color:rgba(251,241,245,0.82);}
+  .t-sub figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(251,241,245,0.6);font-weight:700;}
+  .t-sub figure{margin:0;}
+  @media(max-width:760px){.t-sub{grid-template-columns:1fr;}}
+
+  .g-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;}
+  .g-grid figure{margin:0;position:relative;overflow:hidden;border-radius:14px;border:3px solid var(--ube);}
+  .g-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;transition:0.3s;}
+  .g-grid figure:hover img{transform:scale(1.04);}
+  .g-grid figcaption{position:absolute;left:0;bottom:0;background:var(--rosa);color:var(--milk-2);font-family:var(--mono);font-size:9px;letter-spacing:0.08em;text-transform:uppercase;padding:6px 10px;font-weight:700;}
+  @media(max-width:760px){.g-grid{grid-template-columns:1fr 1fr;}}
+
+  .faq-grid{display:grid;grid-template-columns:2fr 3fr;gap:clamp(36px,5vw,88px);}
+  .faq-list details{border-bottom:1px solid var(--rule);padding:22px 0;}
+  .faq-list details:first-child{border-top:2px solid var(--ube);}
+  .faq-list summary{font-family:var(--disp);font-weight:700;font-size:18px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;gap:20px;line-height:1.2;letter-spacing:-0.02em;color:var(--ube);}
+  .faq-list summary::-webkit-details-marker{display:none;}
+  .faq-list summary::after{content:"+";color:var(--rosa);font-size:24px;flex-shrink:0;transition:0.2s;}
+  .faq-list details[open] summary::after{transform:rotate(45deg);}
+  .faq-list p{margin:14px 0 0;color:var(--ink-2);font-size:14.5px;max-width:62ch;line-height:1.72;}
+  @media(max-width:760px){.faq-grid{grid-template-columns:1fr;}}
+
+  .area-list{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
+  .area-list li{list-style:none;font-family:var(--mono);font-size:10px;letter-spacing:0.06em;text-transform:uppercase;padding:10px 20px;border:2px solid var(--ube);border-radius:999px;font-weight:700;color:var(--ink-2);}
+
+  .creds{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(18px,2.5vw,36px);margin-top:clamp(26px,3.5vw,44px);}
+  .creds > div{border-top:3px solid var(--mango);padding-top:14px;}
+  .creds .label{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--rosa);margin-bottom:8px;font-weight:700;}
+  .creds .detail{font-family:var(--disp);font-weight:700;font-size:17px;line-height:1.18;letter-spacing:-0.02em;color:var(--ube);}
+  @media(max-width:760px){.creds{grid-template-columns:1fr 1fr;}}
+
+  .loc-grid{display:grid;grid-template-columns:1fr 1.4fr;gap:clamp(24px,3.5vw,48px);margin-top:clamp(28px,4vw,48px);}
+  .nap{background:var(--leche);color:var(--ink);padding:34px;border-radius:18px;border:3px solid var(--ube);}
+  .nap address{font-style:normal;font-family:var(--disp);font-weight:700;font-size:19px;line-height:1.3;letter-spacing:-0.02em;}
+  .nap a{text-decoration:none;font-family:var(--sans);font-size:15px;text-transform:none;font-weight:600;color:var(--ube-2);}
+  .hours{font-family:var(--mono);font-size:10.5px;margin-top:24px;border-top:2px solid rgba(44,28,51,0.24);padding-top:18px;letter-spacing:0.06em;text-transform:uppercase;font-weight:700;}
+  .hours .row{display:flex;justify-content:space-between;padding:4px 0;color:var(--ube-2);}
+  .hours .gbp-note{font-family:var(--sans);font-size:12.5px;color:var(--ube-2);margin-top:14px;line-height:1.62;letter-spacing:0;text-transform:none;font-weight:400;}
+  .map-frame{min-height:380px;overflow:hidden;border-radius:18px;border:3px solid var(--ube);}
+  .map-frame iframe{width:100%;height:100%;border:0;min-height:380px;filter:grayscale(0.1) contrast(1.02);}
+  @media(max-width:820px){.loc-grid{grid-template-columns:1fr;}}
+
+  .cta-band{background:var(--rosa);color:var(--milk-2);padding:clamp(80px,10vw,144px) 0;text-align:center;}
+  .cta-band .kick{color:var(--milk-2);}
+  .cta-band h2{font-family:var(--disp);font-weight:800;font-size:clamp(36px,5.6vw,92px);line-height:1.0;margin:14px auto 18px;max-width:15ch;letter-spacing:-0.03em;}
+  .cta-band h2 em{font-style:normal;color:var(--leche);}
+  .cta-band p{color:rgba(255,248,251,0.94);max-width:52ch;margin:0 auto 34px;font-size:17px;}
+  .cta-band .ctas{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;}
+  .cta-band .btn-primary{background:var(--milk-2);color:var(--rosa);} .cta-band .btn-primary:hover{background:var(--ube);color:var(--milk-2);}
+  .cta-band .btn-ghost{border-color:var(--milk-2);color:var(--milk-2);} .cta-band .btn-ghost:hover{background:var(--milk-2);color:var(--rosa);}
+
+  footer{background:var(--ube-2);color:var(--milk);border-top:3px solid var(--leche);padding:56px 0 30px;}
+  .footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:40px;}
+  .footer-grid h4{font-family:var(--mono);font-size:9.5px;letter-spacing:0.1em;text-transform:uppercase;color:var(--leche);margin:0 0 14px;font-weight:700;}
+  .footer-grid a{text-decoration:none;display:block;padding:3px 0;font-size:14.5px;color:rgba(251,241,245,0.72);}
+  .colophon{margin-top:48px;padding-top:18px;border-top:1px solid rgba(251,241,245,0.16);display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-family:var(--mono);font-size:9.5px;letter-spacing:0.08em;text-transform:uppercase;color:rgba(251,241,245,0.6);font-weight:700;}
+  @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
+
+  .msg-fab{position:fixed;right:20px;bottom:20px;z-index:100;}
+  .msg-fab a{display:inline-flex;align-items:center;gap:8px;background:var(--ube);color:var(--milk-2);padding:13px 20px;border-radius:999px;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;letter-spacing:0.05em;text-transform:uppercase;box-shadow:0 8px 24px rgba(91,42,134,0.4);border:2.5px solid var(--leche);}
+  .msg-fab a:hover{background:var(--rosa);}
+  .msg-fab svg{width:14px;height:14px;}
+</style>
+
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Restaurant","name":"Ube & Yelo","description":"Halo-halo haus in Angeles City, Pampanga — tall halo-halo layered the Kapampangan way with sweet beans, nata, sago, leche flan and hand-grated ube ice cream, plus mais con yelo and kakanin. Made to order since 2016.","servesCuisine":"Filipino desserts","url":"https://ubeandyelo.ph/","telephone":"+639175550355","email":"hello@ubeandyelo.ph","address":{"@type":"PostalAddress","streetAddress":"56 Sto. Rosario St","addressLocality":"Angeles City","addressRegion":"Pampanga","postalCode":"2009","addressCountry":"PH"},"geo":{"@type":"GeoCoordinates","latitude":15.1450,"longitude":120.5850},"areaServed":["Angeles City","Mabalacat","San Fernando","Clark"],"image":["https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1600"],"foundingDate":"2016"}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+{"@type":"Question","name":"What exactly goes into your halo-halo?","acceptedAnswer":{"@type":"Answer","text":"A classic glass is built from the bottom up with sweetened kidney and garbanzo beans, kaong, nata de coco, sago, macapuno and sweet plantain, all sweetened by us; then snow-fine shaved ice; then evaporated milk; and crowning it, a real slab of home-made leche flan and a scoop of hand-grated ube ice cream. The overload adds extra flan and a double scoop. Every component is made in-house, and we build each glass to order — more beans, hold the sago, extra ube, just ask."}},
+{"@type":"Question","name":"Why does the way the ice is shaved matter?","acceptedAnswer":{"@type":"Answer","text":"Because the ice is most of the dessert by volume, and coarse, gravelly ice ruins a halo-halo. We shave ours snow-fine so it folds into the milk, flan and beans into a soft, almost creamy mixture rather than sitting on top like crushed gravel. Fine ice also melts at the right rate — fast enough to blend as you eat, slow enough that it doesn't turn to soup. The texture of the ice is the difference between a great halo-halo and a forgettable one."}},
+{"@type":"Question","name":"What's the difference between halo-halo, mais con yelo and saba con yelo?","acceptedAnswer":{"@type":"Answer","text":"They share a cold, milky shaved-ice base but differ in what's in them. Halo-halo is the maximalist one — many layers of beans, jellies, fruits, flan and ice cream, meant to be mixed. Mais con yelo is pared-back: sweet corn with shaved ice and milk. Saba con yelo swaps in caramelised saba banana. Halo-halo is the special-occasion centrepiece; the con yelos are the easy, cheaper everyday merienda. New to it? Start with mais con yelo and work up to the halo-halo overload."}},
+{"@type":"Question","name":"Is your ube ice cream really made from real ube?","acceptedAnswer":{"@type":"Answer","text":"Yes — churned from real purple yam we cook and grate by hand, not ube extract or powder. Real ube has a gentle, nutty, vanilla-like sweetness and a natural deep-violet colour, softer than the electric purple of artificial versions. It's more work and more expensive but it's central to who we are. We churn our cheese and seasonal mango ice creams the same way. Have any by the scoop, in a cup or cone, as a take-home tub, or crowning your halo-halo."}},
+{"@type":"Question","name":"Can I order for a party, fiesta or as pasalubong?","acceptedAnswer":{"@type":"Answer","text":"Yes — we do take-home halo-halo kits (components packed separately to assemble at home), tubs of house-churned ice cream, and bilao of freshly steamed kakanin like sapin-sapin, biko, kutsinta, puto and suman. We ask for at least a day's notice, more on summer weekends and fiesta season, and can deliver around Angeles or set it for pick-up. Tell us the headcount, date and what you'd like, or let us put together a spread, and we'll sort quantities and a fair price."}},
+{"@type":"Question","name":"Do you have a quiet, family-friendly place to sit?","acceptedAnswer":{"@type":"Answer","text":"Yes — a small, bright, air-conditioned haus built for merienda, spotlessly kept because with cold desserts cleanliness isn't optional. It's an easy, unpretentious spot for families, students and barkadas, with dine-in seating and prices kept where a family can make it a regular habit. Take a booth, order a glass each, and stir — and everything travels if you'd rather take it away."}}]}
+</script>
+<script type="application/json" id="lp-config">{"business":"name, phone, phoneDisplay, email, foundedYear","hero":"kicker, headline, lede, primaryCta, secondaryCta, image, imageAlt","about":"heading, paragraphs[], portrait, portraitAlt","services":"Array<{name, description}>","why":"Array<{title, body}>","how":"Array<{step, title, body}>","testimonials":"Array<{quote, name, context}>","gallery":"Array<{src, alt}>","faq":"Array<{q, a}>","area":"{places[]}","credentials":"Array<{label, detail}>","location":"PostalAddress","cta":"{heading, body, primary, secondary}","messaging":"{whatsapp, messenger}"}</script>
+</head>
+
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wm" href="#" data-bind="business.name">Ube <span>&amp;</span> Yelo</a>
+    <nav class="nav-links">
+      <a href="#about">The haus</a><a href="#services">The glass</a><a href="#location">Find us</a><a href="#book">Order</a>
+    </nav>
+  </div>
+</header>
+
+<!-- BLOCK: HERO [required] -->
+<section class="hero" data-component="HERO" data-variant="v85" data-screen-label="Hero">
+  <div class="wrap">
+    <div class="kick" data-bind="hero.kicker" style="margin-bottom:22px;">Halo-halo haus · mais con yelo · kakanin · Angeles City, Pampanga</div>
+    <h1 class="hero-headline" data-comment-anchor="hero-headline">
+      Halo means mix. So <span class="em">mix it</span> — all the way to the <span class="em2">bottom.</span>
+    </h1>
+    <div class="hero-lower">
+      <div class="hero-photo">
+        <img src="https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=2000&q=85&auto=format&fit=crop"
+             alt="A colourful frozen dessert counter." data-bind="hero.image" data-bind-alt="hero.imageAlt" />
+      </div>
+      <div class="hero-right">
+        <p class="lede" data-bind="hero.lede">A halo-halo haus in Angeles City, layering the tall glass the Kapampangan way: sweet beans, kaong, nata de coco, sago and macapuno under finely shaved ice, crowned with a slab of our own leche flan and a scoop of hand-grated ube ice cream. Poured with evaporated milk, made to order, and meant to be stirred into glorious purple chaos before the ice melts.</p>
+        <div class="hero-ctas">
+          <a class="btn btn-primary" href="#book" data-bind="hero.primaryCta.label">Order or visit</a>
+          <a class="btn btn-ghost" href="#services" data-bind="hero.secondaryCta.label">What's in the glass</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: HERO -->
+
+<!-- BLOCK: TRUST [recommended] -->
+<section class="trust" data-component="TRUST" data-variant="v1" style="padding:0;">
+  <div class="wrap row">
+    <span data-bind="trust.years">Chilling glasses since 2016</span>
+    <span>Everything made in-house</span>
+    <span>Ice shaved fine as snow</span>
+    <span>Real ube, real leche flan</span>
+  </div>
+</section>
+<!-- /BLOCK: TRUST -->
+
+<!-- BLOCK: ABOUT [recommended] -->
+<section id="about" class="about" data-component="ABOUT" data-variant="v51" data-screen-label="About">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 01 / THE HAUS</span><span>PAMPANGA IS HALO-HALO COUNTRY</span></div>
+    <div class="about-grid">
+      <div class="about-prose">
+        <h2 class="h2">The whole joy is the stir. Don't sip it neat — halo, halo, <em>mix it.</em></h2>
+        <p>Ube &amp; Yelo is a halo-halo haus, and halo-halo — literally "mix-mix" — is the Philippines' great summer dessert: a tall glass built in layers of sweet preserved fruits and beans, jellies and ice, milk and something rich on top, that you're meant to stir together into one cold, sweet, purple rush. Pampanga takes its halo-halo seriously — this is the province famous for it — and we build ours the way it should be built: proper ingredients, generous hands, and shaved ice fine as snow.</p>
+        <p>We opened in 2016 because too much halo-halo had become a scoop of gritty ice with a token spoonful of beans. Ours goes the other way: sweetened kidney and garbanzo beans, kaong, nata de coco, sago, macapuno and sweet plantain cooked and prepared by us, layered under finely shaved ice, then topped with a real slab of home-made leche flan and a scoop of ube ice cream we churn from hand-grated purple yam. Evaporated milk poured over at the counter, in front of you.</p>
+        <p>Beyond the flagship glass we make mais con yelo, saba con yelo, our own ube and cheese ice creams, and a rotating counter of kakanin — sapin-sapin, biko, kutsinta and puto — the Filipino rice-cake sweets that belong beside a cold dessert. It's a small, bright, friendly place built for merienda, for beating the Pampanga heat, and for the simple pleasure of stirring a glass to the bottom.</p>
+      </div>
+      <img data-bind="about.portrait" data-bind-alt="about.portraitAlt"
+           src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1200&q=85&auto=format&fit=crop"
+           alt="A sweet layered dessert served in a glass." />
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: ABOUT -->
+
+<!-- BLOCK: SERVICES [required] -->
+<section id="services" data-component="SERVICES" data-variant="v78" data-screen-label="Services">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 02 / THE GLASS</span><span>HALO-HALO · CON YELO · ICE CREAM · KAKANIN</span></div>
+    <h2 class="h2">What's in the glass.</h2>
+    <div class="svc-rows">
+      <div class="svc-row"><span class="no">No. 01</span><h3>The halo-halo</h3><p>The tall glass, built in layers: sweet beans, kaong, nata de coco, sago, macapuno and sweet plantain under snow-fine shaved ice, topped with home-made leche flan and a scoop of ube ice cream, milk poured over.</p></div>
+      <div class="svc-row"><span class="no">No. 02</span><h3>Mais &amp; saba con yelo</h3><p>The simpler cousins done properly — sweet corn or caramelised saba banana with shaved ice and milk, cold and comforting. The everyday merienda for when a full halo-halo is more than you need.</p></div>
+      <div class="svc-row"><span class="no">No. 03</span><h3>House-churned ice cream</h3><p>Ube from hand-grated purple yam, sweet cheese (queso), and mango in season — dense, real Filipino ice cream by the scoop, in a cup, or crowning your glass. No powders, no shortcuts.</p></div>
+      <div class="svc-row"><span class="no">No. 04</span><h3>Kakanin counter</h3><p>A rotating counter of rice-cake sweets — sapin-sapin, biko, kutsinta, puto and suman — steamed fresh, the traditional merienda that belongs beside a cold dessert or wrapped up to take home.</p></div>
+      <div class="svc-row"><span class="no">No. 05</span><h3>Take-home &amp; bilao</h3><p>Halo-halo kits and tubs of ice cream to take home, plus bilao of kakanin for fiestas, birthdays and pasalubong — the whole cold-and-sweet spread, boxed for the road. Order a day ahead.</p></div>
+      <div class="svc-row"><span class="no">No. 06</span><h3>Merienda combos</h3><p>A cold glass and a warm rice cake, or ice cream and a hot cup — the little merienda pairings that make an afternoon, at a price that keeps students and families coming back all summer.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: SERVICES -->
+
+<!-- BLOCK: WHY-US [recommended] -->
+<section class="why" data-component="WHY-US" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 03 / THE DIFFERENCE</span><span>WHY OURS IS DIFFERENT</span></div>
+    <h2 class="h2">Why ours is <em>different.</em></h2>
+    <div class="why-grid">
+      <div><span class="no">01 / 03</span><h3>Ingredients we make ourselves.</h3><p>The beans, the leche flan, the ube ice cream, the kakanin — cooked and prepared by us, not scooped from a supplier's bucket. That's the difference between a real halo-halo and a sad one.</p></div>
+      <div><span class="no">02 / 03</span><h3>Ice shaved fine as snow.</h3><p>Coarse, crunchy ice ruins a halo-halo. Ours is shaved fine so it melts into the milk and beans instead of sitting on top like gravel — soft, cold and mixable to the last spoon.</p></div>
+      <div><span class="no">03 / 03</span><h3>Built generous, the Pampanga way.</h3><p>Pampanga is halo-halo country and we hold the line: layers all the way down, real leche flan, a proper scoop of ube. Stir to the bottom and there's still something good waiting.</p></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: WHY-US -->
+
+<!-- BLOCK: HOW-IT-WORKS [recommended] -->
+<section data-component="HOW-IT-WORKS" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 04 / HOW IT GOES</span><span>PICK · BUILD · MIX · TAKE HOME</span></div>
+    <ol class="how-grid">
+      <li><span class="step">STEP 01</span><h3>Pick your glass</h3><p>Classic halo-halo, or the overload with extra flan and a double scoop of ube. Or go simpler with mais con yelo or a cup of house ice cream. Tell us how sweet a tooth you've got.</p></li>
+      <li><span class="step">STEP 02</span><h3>We build it to order</h3><p>Layered fresh at the counter — beans and jellies first, snow-fine ice next, leche flan and ube on top, evaporated milk poured over in front of you. Nothing pre-made and melting in a fridge.</p></li>
+      <li><span class="step">STEP 03</span><h3>Mix it, all the way down</h3><p>The important part: stir it. Halo-halo means mix-mix — fold the flan and ube through the ice and beans until it's one cold purple swirl, and eat it before the ice gives up.</p></li>
+      <li><span class="step">STEP 04</span><h3>Take some home</h3><p>Loved it? Take home an ice cream tub, a halo-halo kit, or a bilao of kakanin for the family. Message us a day ahead for fiesta and party orders and we'll have it boxed.</p></li>
+    </ol>
+  </div>
+</section>
+<!-- /BLOCK: HOW-IT-WORKS -->
+
+<!-- BLOCK: TESTIMONIALS [recommended] -->
+<section class="testimonials" data-component="TESTIMONIALS" data-variant="v50">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 05 / FROM THE SPOON</span><span>EVERY SPOON HAS SOMETHING IN IT</span></div>
+    <blockquote class="t-quote">“The ube is unreal, the flan is real flan, and the ice melts like it should. This is how it's <em>supposed to be.</em>”</blockquote>
+    <div class="t-attr">Patricia G. — regular, drives from Manila</div>
+    <div class="t-sub">
+      <figure><blockquote>“My kids call it 'the purple place.' We come every hot afternoon of summer and the mais con yelo has become their whole personality. Friendly, generous, spotlessly clean, and priced so a family can actually afford to make it a habit. We love it here.”</blockquote><figcaption>The Sison family — summer regulars</figcaption></figure>
+      <figure><blockquote>“Ordered bilao of kakanin and tubs of ube ice cream for my mom's birthday and everyone lost their minds. The sapin-sapin was the best I've had since my lola's. Delivered on time, beautifully packed. Ube &amp; Yelo, you made the party. Salamat!”</blockquote><figcaption>Jules M. — birthday order</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: TESTIMONIALS -->
+
+<!-- BLOCK: GALLERY [recommended] -->
+<section data-component="GALLERY" data-variant="v78" class="about" style="background:var(--milk-2);">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 06 / AT THE COUNTER</span><span>COLD, SWEET &amp; PURPLE</span></div>
+    <div class="g-grid">
+      <figure><img src="https://images.unsplash.com/photo-1567206563064-6f60f40a2b57?w=1600&q=85&auto=format&fit=crop" alt="A colourful frozen dessert counter." /><figcaption>THE COUNTER</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=1600&q=85&auto=format&fit=crop" alt="A layered dessert served in a glass." /><figcaption>THE GLASS</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=1600&q=85&auto=format&fit=crop" alt="A cold sweet drink on the counter." /><figcaption>THE CON YELO</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1600&q=85&auto=format&fit=crop" alt="Sweet rice cakes plated." /><figcaption>THE KAKANIN</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1559925393-8be0ec4767c8?w=1600&q=85&auto=format&fit=crop" alt="A dessert being prepared by hand." /><figcaption>THE BUILD</figcaption></figure>
+      <figure><img src="https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1600&q=85&auto=format&fit=crop" alt="The bright dessert haus interior." /><figcaption>THE HAUS</figcaption></figure>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: GALLERY -->
+
+<!-- BLOCK: FAQ [recommended] -->
+<section data-component="FAQ" data-variant="v1">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 07 / GOOD TO KNOW</span><span>THE GLASS, THE ICE &amp; THE UBE</span></div>
+    <div class="faq-grid">
+      <div>
+        <h2 class="h2">Good to know.</h2>
+        <p class="body">Anything else — message us or ring <a href="tel:+639175550355" style="color:var(--rosa);font-weight:700;">0917 555 0355</a>. Or just come in, take a booth, and stir.</p>
+      </div>
+      <div class="faq-list">
+        <details><summary>What exactly goes into your halo-halo?</summary><p>Layers, and a lot of them — that's the whole point of halo-halo, which literally means "mix-mix." A classic glass of ours is built from the bottom up with sweetened kidney and garbanzo beans, kaong (sugar palm fruit), nata de coco, sago pearls, macapuno (sweet coconut strings) and sweet plantain, all cooked and sweetened by us; then a generous mound of snow-fine shaved ice; then evaporated milk poured over; and crowning it, a real slab of home-made leche flan and a scoop of our hand-grated ube ice cream. The 'overload' adds extra flan and a double scoop. Every component is made or prepared in-house, which is why it tastes rich, varied and interesting all the way to the bottom rather than mostly ice. If you have a preference — more beans, hold the sago, extra ube — just tell us; we build each one to order.</p></details>
+        <details><summary>Why does the way the ice is shaved matter so much?</summary><p>Because the ice is most of the dessert by volume, and coarse, crunchy, gravelly ice is the single quickest way to ruin a halo-halo. We shave ours fine — snow-fine — so that when you stir the glass, the ice folds into the evaporated milk, the leche flan and the beans to make a soft, cold, almost creamy mixture rather than sitting on top like crushed gravel that you have to crunch through. Fine ice also melts at the right rate: fast enough to blend into everything as you eat, slow enough that the glass doesn't turn to soup before you reach the bottom. It sounds like a small technical detail, but ask anyone serious about halo-halo and they'll tell you the texture of the ice is the difference between a great one and a forgettable one.</p></details>
+        <details><summary>What's the difference between halo-halo, mais con yelo and saba con yelo?</summary><p>They're a family of shaved-ice desserts that share the same cold, milky base but differ in what's in them. Halo-halo is the maximalist one — many layers of beans, jellies, fruits, flan and ice cream — the full production, meant to be mixed. Mais con yelo is the pared-back cousin: sweet corn kernels with shaved ice and milk, simple and comforting, and a lot of people's everyday favourite when a whole halo-halo feels like too much. Saba con yelo is the same idea with caramelised saba banana. Halo-halo is the special-occasion, beat-the-heat centrepiece, while the con yelos are the easy, cheaper, no-fuss merienda. New to it? Start with mais con yelo and work up to the full halo-halo overload once you're hooked.</p></details>
+        <details><summary>Is your ube ice cream really made from real ube?</summary><p>Yes — our ube ice cream is churned from real purple yam that we cook and grate by hand, not flavoured and coloured with ube extract or powder, and the difference is immediately obvious in both taste and colour. Real ube has a gentle, nutty, almost vanilla-like sweetness and a natural deep-violet colour that's softer and more muted than the electric purple of the artificial stuff; it tastes rich and rounded rather than one-note sweet. Making it this way is more work and more expensive, but it's central to who we are, right there in our name. We churn our cheese (queso) and seasonal mango ice creams with the same no-shortcuts approach. Have any of them by the scoop, in a cup, in a cone, as a take-home tub, or crowning your halo-halo.</p></details>
+        <details><summary>Can I order for a party, fiesta or as pasalubong?</summary><p>Yes, and it's popular — half our weekend orders are for birthdays, fiestas and family gatherings. We do take-home halo-halo kits (components packed separately so you assemble and pour at home for maximum freshness), tubs of our house-churned ice cream, and bilao of freshly steamed kakanin — sapin-sapin, biko, kutsinta, puto and suman — which make gorgeous, generous pasalubong and party platters. We ask for at least a day's notice, and more during summer weekends and fiesta season, so we can prepare everything fresh, and we can arrange delivery around Angeles or have it ready for pick-up. Tell us the headcount, the date and what you'd like — or let us put together a spread — and we'll sort quantities and a fair price.</p></details>
+        <details><summary>Do you have a quiet, family-friendly place to sit?</summary><p>Yes — we're a small, bright, friendly haus built exactly for merienda: somewhere to duck out of the Pampanga heat, sit down with a cold glass, and let the kids demolish a mais con yelo. It's spotlessly kept — with cold desserts and ice cream, cleanliness isn't optional and we take it seriously — and it's designed to be an easy, unpretentious spot for families, students and barkadas. There's seating for dining in, it's air-conditioned against the summer, and we've deliberately kept prices where a family can make a visit a regular habit rather than a rare treat. Come in, take a booth, order a glass each, and stir — and if you'd rather take it away, everything travels too.</p></details>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: FAQ -->
+
+<!-- BLOCK: SERVICE-AREA [recommended] -->
+<section data-component="SERVICE-AREA" data-variant="v1" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 08 / WE'RE SWEET ON</span><span>PAMPANGA</span></div>
+    <ul class="area-list">
+      <li>Angeles City</li><li>Mabalacat</li><li>San Fernando</li><li>Clark</li><li>Pampanga</li><li>Delivery &amp; pick-up</li>
+    </ul>
+  </div>
+</section>
+<!-- /BLOCK: SERVICE-AREA -->
+
+<!-- BLOCK: CREDENTIALS [recommended] -->
+<section data-component="CREDENTIALS" data-variant="v25" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 09 / THE ESSENTIALS</span><span>HOW WE BUILD IT</span></div>
+    <div class="creds">
+      <div><div class="label">Since 2016</div><div class="detail">A halo-halo haus in Angeles City</div></div>
+      <div><div class="label">Made in-house</div><div class="detail">Beans, leche flan, ube ice cream &amp; kakanin</div></div>
+      <div><div class="label">Snow-fine ice</div><div class="detail">Shaved fine so it mixes, not crunches</div></div>
+      <div><div class="label">Take-home</div><div class="detail">Kits, tubs &amp; bilao for parties &amp; pasalubong</div></div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CREDENTIALS -->
+
+<!-- BLOCK: LOCATION [required] -->
+<section id="location" data-component="LOCATION" data-variant="v1" data-screen-label="Location" style="padding-top:0;">
+  <div class="wrap">
+    <div class="sw-head"><span>LAYER 10 / THE HAUS</span><span>STO. ROSARIO ST, ANGELES</span></div>
+    <div class="loc-grid">
+      <div class="nap">
+        <address>
+          <strong data-bind="location.name">Ube &amp; Yelo</strong><br />
+          56 Sto. Rosario St<br />
+          Angeles City, Pampanga 2009<br /><br />
+          <a href="tel:+639175550355" data-bind="business.phoneDisplay">0917 555 0355</a><br />
+          <a href="mailto:hello@ubeandyelo.ph" data-bind="business.email">hello@ubeandyelo.ph</a>
+        </address>
+        <div class="hours">
+          <div class="row"><span>DAILY</span><span>10AM – 9PM</span></div>
+          <div class="row"><span>SUMMER</span><span>OPEN LATE</span></div>
+          <p class="gbp-note">Live hours on our Google Business Profile. We're on Sto. Rosario near the heritage district — look for the purple shopfront and the queue on a hot afternoon.</p>
+        </div>
+      </div>
+      <div class="map-frame">
+        <iframe title="Map of Ube & Yelo, Angeles City" loading="lazy"
+                src="https://www.openstreetmap.org/export/embed.html?bbox=120.5700%2C15.1350%2C120.6000%2C15.1550&layer=mapnik&marker=15.1450%2C120.5850"></iframe>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: LOCATION -->
+
+<!-- BLOCK: CTA-BAND [recommended] -->
+<section id="book" class="cta-band" data-component="CTA-BAND" data-variant="v53">
+  <div class="wrap">
+    <div class="kick">LAYER 11 / COME IN</div>
+    <h2 data-bind="cta.heading">Beat the heat. Stir it to the <em>bottom.</em></h2>
+    <p data-bind="cta.body">Tall halo-halo built the Pampanga way, mais con yelo, house-churned ube and cheese ice cream, and a counter of fresh kakanin — made to order in Angeles City since 2016. Visit the haus or order a spread for the party.</p>
+    <div class="ctas">
+      <a class="btn btn-primary" href="#book" data-bind="cta.primary.label">Order or visit</a>
+      <a class="btn btn-ghost" href="tel:+639175550355" data-bind="cta.secondary.label">0917 555 0355</a>
+    </div>
+  </div>
+</section>
+<!-- /BLOCK: CTA-BAND -->
+
+<!-- BLOCK: CLICK-TO-MESSAGE [recommended] -->
+<div class="msg-fab" data-component="CLICK-TO-MESSAGE" data-variant="v1">
+  <a href="https://wa.me/639175550355" data-bind="messaging.whatsapp" aria-label="Message the haus">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4A11 11 0 0 0 4.5 18.5L3 22l3.7-1.4A11 11 0 1 0 20 4Z"/></svg>
+    Message
+  </a>
+</div>
+<!-- /BLOCK: CLICK-TO-MESSAGE -->
+
+<!-- BLOCK: FOOTER [required] -->
+<footer data-component="FOOTER" data-variant="v1">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <div class="wm" style="font-size:22px;color:var(--milk);">Ube <span style="color:var(--leche);">&amp;</span> Yelo</div>
+        <p class="body" style="margin-top:12px;max-width:34ch;color:rgba(251,241,245,0.72);">A halo-halo haus in Angeles City, Pampanga — halo-halo, con yelo, house-churned ube ice cream and kakanin, made to order since 2016.</p>
+      </div>
+      <div>
+        <h4>The haus</h4>
+        <address style="font-style:normal;font-size:14.5px;line-height:1.7;color:rgba(251,241,245,0.72);">
+          56 Sto. Rosario St<br />Angeles City, Pampanga 2009<br />
+          <a href="tel:+639175550355">0917 555 0355</a><br />
+          <a href="mailto:hello@ubeandyelo.ph">hello@ubeandyelo.ph</a>
+        </address>
+      </div>
+      <div>
+        <h4>Index</h4>
+        <a href="#services">The glass</a><a href="#about">The haus</a><a href="#location">Find us</a><a href="#book">Order</a>
+      </div>
+    </div>
+    <div class="colophon">
+      <span>© <span id="year">2026</span> UBE &amp; YELO</span>
+      <span>HALO, HALO · MIX IT · PAMPANGA</span>
+    </div>
+  </div>
+</footer>
+<!-- /BLOCK: FOOTER -->
+
+<script>
+  (function () {
+    const get = (o,p) => p.split('.').reduce((a,k)=>{ if(a==null) return null; const m=k.match(/^(.+)\[(\d+)\]$/); return m?a[m[1]]?.[+m[2]]:a[k]; }, o);
+    document.querySelectorAll('[data-bind]').forEach(el => {
+      const v = get(CONFIG, el.dataset.bind);
+      if (v == null) return;
+      if (el.tagName === 'IMG') { el.src = v; const a = el.getAttribute('data-bind-alt'); if (a) el.alt = get(CONFIG, a) || el.alt; }
+      else if (el.tagName === 'A' && /^https?:|^mailto:|^tel:|^#/.test(String(v))) el.href = v;
+      else el.textContent = v;
+    });
+    document.getElementById('year').textContent = new Date().getFullYear();
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a new **`filipino`** template family — **7 curated PH-market landing-page designs** ported from Landing Pages v01 into the astro submission→website pipeline:

| Code | Design | Business |
|---|---|---|
| `filipino:BB` | Tindahan · Suki Storefront | sari-sari / corner store |
| `filipino:BC` | Lutong Bahay · Carinderia | turo-turo eatery |
| `filipino:BD` | Tahanan Panaderia | dark-crust bakery |
| `filipino:BE` | Barako Kapehan | coffee / kapehan |
| `filipino:BF` | Lechon Manok · Spit | dark charcoal roast chicken |
| `filipino:BG` | Vulca Bay | dark industrial vulcanizing/repair |
| `filipino:BH` | Halo Haus | pastel halo-halo dessert |

**Why this set:** the v01 lp-01–09 "flagship" designs already ship (they were ported as the v4 flagships `restaurant:AM`…`trades:AU` in #272). The untapped value in the v01 import is the long tail — and the Filipino-market niches are the most on-brand for Tendso's MSME audience with zero prior coverage.

## How

Follows `TEMPLATE-FAMILY-PLAYBOOK.md` + the `services:AS` reference. Each template = 1 `PageXX` wrapper (palette/fonts/base CSS scoped to `html[data-page="XX"]`, `lockVariant: true`) + 15 section components (112 files total). **Every section's data layer — content reads + all `data-field`/`data-image-field`/`data-href-field` paths — is byte-identical to `BB`**; only the visual re-skin differs. So admin edits + derived defaults feed every variant unchanged and the family-agnostic editor bridge needs no changes.

`index.astro` routing (`filipino:B[B-H]`) + `templateCatalog.ts` entries + 7 preview thumbnails + a `filipino` `CURATED` scheme set. **v2/v3 select these via the shared catalog** (`familyOf`/`isBranded` resolve `filipino`); **v1** (legacy hardcoded accordions) is not wired — its convergence onto the catalog is a separate, deferred follow-up.

## Verification

- **Independent scripted diff**: all 112 files' editor-hook sets identical to BB (not just self-reported by the porting agents).
- **Scope isolation**: each letter owns its `data-page` + `__filipino<L>InitMap`; no cross-letter leaks; every `var(--token)` defined in its own `PageXX` scope.
- `tsc --noEmit` clean; **parity 54/54**; **all 7 `astro build` + route + render** (82 `data-field` hooks each).
- **6-agent adversarial code-review** (contrast/mapping/HTML/a11y): 4 clean, 2 findings — fixed the concrete one (gallery subhead lost a specificity battle to global `.body` on the light gallery band in the 3 dark variants → `.gallery .gal-sub`).

## Known limitation (documented in PageBF/PageBG)

The **dark-ground variants (BD/BF/BG)** key their ground/bands to native tokens the scheme override can't remap, so an explicit admin **Color-scheme** pick renders imperfect on them. The editor resets theme to `auto` on a bespoke template pick, so the **default path is correct**; **font** picks work. Proper fix = rekey dark grounds onto themeable `--paper`/`--ink` (cf. `autoshop/PageAP`) — tracked follow-up.

## Notes
- ⚠️ **Not browser-tested locally** (Next build won't finish here) — needs visual/interaction QA on the Vercel preview with a throwaway submission. Anti-regression to check: editing one services-list item leaves siblings intact after Save.
- The all-families CSS bundle grows ~26 KB per new family (every generated site now ~1.24 MB, handled by the file-storage migration) — a scoped-split optimization is a good future task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)