### PR TITLE
fix(website): coerce websiteContent.aboutText to string (About-image save crash)

### DIFF
--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -897,7 +897,19 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             // Business info
             businessName: contentWithContact.business_name,
             tagline: contentWithContact.tagline,
-            aboutText: contentWithContact.about,
+            // `content.about` can arrive as a wrapped object on branded/bespoke
+            // families (e.g. after an admin edits the About image, which writes
+            // `about.image` and turns `about` into `{ image, ... }`). The
+            // websiteContent.aboutText column is `v.string()`, so coerce — mirror
+            // transformToAstroData's description coercion (lead > description >
+            // body > joined paragraphs > ''). Without this the mutation throws
+            // ArgumentValidationError on any About-image edit.
+            aboutText: (() => {
+                const a = contentWithContact.about as any;
+                if (typeof a === 'string') return a;
+                return a?.lead ?? a?.description ?? a?.body
+                    ?? (Array.isArray(a?.paragraphs) ? a.paragraphs.join('\n\n') : '');
+            })(),
             tone: contentWithContact.tone,
             // Hero section
             heroBadgeText: contentWithContact.hero_badge_text,


### PR DESCRIPTION
## Bug

Saving a generated website threw:
```
websiteContent:upsert  ArgumentValidationError: Value does not match validator.
Path: .aboutText  Value: {image: "…/api/storage/…"}  Validator: v.string()
```

`convex/websiteContent.ts` declares `aboutText: v.string()`, but `app/api/generate-website/route.ts` passed `contentWithContact.about` **raw**. On branded/bespoke template families, editing the **About image** writes `about.image`, turning `content.about` into a wrapped object `{ image, … }` — so the string column received an object.

It fails **after** the site HTML already persisted (`generatedWebsites.upsert` runs first), so the site saved but the request 500'd on the normalized `websiteContent` write.

## Scope

**Pre-existing + general** — hits any branded family (`salonspa`, `restaurant` flagships, the new `filipino` set, …) on any About-image edit, not just one template. Surfaced while testing the Filipino templates.

## Fix

Coerce `aboutText` to a string at the call site, mirroring the coercion `transformToAstroData` already does for the meta `description` (`lead > description > body > joined paragraphs > ''`). Frontend-only — **no schema / Convex-function change, no `convex deploy` needed**.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)