### PR TITLE
feat(editor): click-to-recolour by role (v3)

### DIFF
--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@clerk/nextjs/server'
 import { fetchQuery } from 'convex/nextjs'
 import { api } from '@/convex/_generated/api'
 import { buildAstroSite } from '@/lib/astro-builder'
+import { buildRoleColorCss } from '@/lib/roleColors'
 import { groqService } from '@/lib/services/groq.service'
 
 /**
@@ -860,7 +861,21 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             navCtaHref: (extractedContent as any)?.navCtaHref,
         }
 
-        const generatedHtml = await buildAstroSite(contentWithContact, finalCustomizations, photos)
+        let generatedHtml = await buildAstroSite(contentWithContact, finalCustomizations, photos)
+
+        // Bake per-role colour overrides (click-to-recolour) into the built HTML
+        // so they persist on Save + Publish (the live editor injects the same CSS
+        // client-side). Template-agnostic — keyed by the shared data-field
+        // selectors. See lib/roleColors.ts.
+        const __roleColorCss = buildRoleColorCss((finalCustomizations as any)?.roleColors)
+        if (__roleColorCss) {
+            const __styleTag = `<style id="role-colors">${__roleColorCss}</style>`
+            generatedHtml = generatedHtml.includes('</head>')
+                ? generatedHtml.replace('</head>', `${__styleTag}</head>`)
+                : (generatedHtml.includes('</body>')
+                    ? generatedHtml.replace('</body>', `${__styleTag}</body>`)
+                    : generatedHtml + __styleTag)
+        }
 
         // PREVIEW mode: hand the built HTML back to the editor's "Preview my site"
         // WITHOUT persisting anything — no generatedWebsites / websiteContent upsert,

--- a/components/editor/SandboxEditorV3.tsx
+++ b/components/editor/SandboxEditorV3.tsx
@@ -25,6 +25,7 @@ import type { SandboxEditorProps } from "./SandboxEditor";
 import { TEMPLATE_FAMILIES, templateByCode } from "./templateCatalog";
 import { COLOR_SCHEMES, FONT_PAIRINGS, ALL_BLOCKS, CURATED } from "./editorConstants";
 import { buildOverrideCss, buildFontHref, resolveAutoScheme } from "./themeOverride";
+import { buildRoleColorCss, roleForField, COLOR_ROLES, roleColorKey, type ColorRole, type ColorProp } from "@/lib/roleColors";
 import { useEditorDraft } from "./useEditorDraft";
 import { applyImageSlot, isImageField, uploadImage } from "./editorImageSlots";
 import ContentFieldsAuto from "./ContentFieldsAuto";
@@ -73,6 +74,25 @@ function applyThemeToIframe(iframe: HTMLIFrameElement | null, scheme: string, fo
     } catch { /* same-origin access can throw — Save still applies it for real */ }
 }
 
+// Inject per-role colour overrides (click-to-recolour) live into the preview
+// iframe. Mirrors applyThemeToIframe; the same CSS is baked into the built HTML
+// in app/api/generate-website so the colours persist on Save + Publish.
+function applyRoleColorsToIframe(iframe: HTMLIFrameElement | null, roleColors: Record<string, string> | undefined) {
+    try {
+        const doc = iframe?.contentDocument;
+        if (!doc || !doc.body) return;
+        const css = buildRoleColorCss(roleColors);
+        let styleEl = doc.getElementById("ed-role-colors") as HTMLStyleElement | null;
+        if (!css) { if (styleEl) styleEl.textContent = ""; return; }
+        if (!styleEl) {
+            styleEl = doc.createElement("style");
+            styleEl.id = "ed-role-colors";
+            doc.body.appendChild(styleEl);
+        }
+        styleEl.textContent = css;
+    } catch { /* same-origin can throw; Save bakes it in anyway */ }
+}
+
 type Panel = "design" | "content" | "media";
 
 export default function SandboxEditorV3(props: SandboxEditorProps) {
@@ -102,6 +122,10 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
     const [pendingImageField, setPendingImageField] = useState<string | null>(null);
     const [uploadError, setUploadError] = useState<string | null>(null);
     const [uploadingPhoto, setUploadingPhoto] = useState(false);
+    // Click-to-recolour (per-role): colorMode routes canvas clicks to a colour
+    // popover instead of the text/link/image editors.
+    const [colorMode, setColorMode] = useState(false);
+    const [colorPopover, setColorPopover] = useState<{ role: ColorRole; prop: ColorProp; curBg: string; curFg: string } | null>(null);
 
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const railRef = useRef<HTMLDivElement | null>(null);
@@ -188,6 +212,36 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
         }));
     }, []);
 
+    // ── Click-to-recolour (per-role) ──────────────────────────────────────
+    const applyRoleColors = useCallback(() => {
+        applyRoleColorsToIframe(iframeRef.current, (m.effectiveCustomizations as any)?.roleColors);
+    }, [m.effectiveCustomizations]);
+
+    const toggleColorMode = useCallback(() => {
+        setColorMode((prev) => {
+            const next = !prev;
+            try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:set-mode", mode: next ? "color" : "edit" }, "*"); } catch { /* ignore */ }
+            if (!next) setColorPopover(null);
+            return next;
+        });
+    }, []);
+
+    const applyRoleColor = useCallback((role: ColorRole, prop: ColorProp, color: string | null) => {
+        const key = roleColorKey(role, prop);
+        m.setRoleColor(key, color);
+        const base = (((m.effectiveCustomizations as any)?.roleColors) ?? {}) as Record<string, string>;
+        const nextMap = { ...base };
+        if (color) nextMap[key] = color; else delete nextMap[key];
+        applyRoleColorsToIframe(iframeRef.current, nextMap);
+    }, [m]);
+
+    const handleIframeLoad = useCallback(() => {
+        setupInlineEditing();
+        applyTheme();
+        applyRoleColors();
+        if (colorMode) { try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:set-mode", mode: "color" }, "*"); } catch { /* ignore */ } }
+    }, [setupInlineEditing, applyTheme, applyRoleColors, colorMode]);
+
     // ── ed:* click routing (from v1, adapted to the 3-panel rail) ─────────
     useEffect(() => {
         function onMessage(e: MessageEvent) {
@@ -206,6 +260,11 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
             }
             if (data.type === "ed:image-click" && typeof data.field === "string") {
                 setImagePickerField(data.field);
+                return;
+            }
+            if (data.type === "ed:color-click" && typeof data.field === "string") {
+                const role = roleForField(data.field, !!data.isButton);
+                setColorPopover({ role, prop: COLOR_ROLES[role].defaultProp, curBg: String(data.curBg || ""), curFg: String(data.curFg || "") });
                 return;
             }
             if (data.type === "ed:select" && typeof data.field === "string") {
@@ -526,6 +585,9 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                         </button>
                         <button type="button" onClick={m.undo} disabled={!m.canUndo} className={TB} title="Undo (Ctrl/Cmd+Z)">Undo</button>
                         <button type="button" onClick={m.redo} disabled={!m.canRedo} className={TB} title="Redo (Ctrl/Cmd+Shift+Z)">Redo</button>
+                        <button type="button" onClick={toggleColorMode} aria-pressed={colorMode} className={`${TB}${colorMode ? " ring-2 ring-neutral-900" : ""}`} title="Colour mode — click any button, heading, or text on the page to recolour its whole kind">
+                            {colorMode ? "🎨 Colors ✓" : "🎨 Colors"}
+                        </button>
                         <div className="ml-1 flex overflow-hidden rounded-lg border border-neutral-200">
                             {(Object.keys(VIEWPORTS) as Array<keyof typeof VIEWPORTS>).map((vp) => (
                                 <button key={vp} type="button" onClick={() => setViewport(vp)} className={`px-2.5 py-1.5 text-[11px] font-semibold capitalize transition-colors ${viewport === vp ? "bg-neutral-900 text-white" : "bg-white text-neutral-500 hover:bg-neutral-100"}`}>{vp}</button>
@@ -568,9 +630,9 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                         )}
                         <div className="mx-auto h-full bg-white" style={vw ? { width: vw, maxWidth: "100%", boxShadow: "0 0 0 1px rgba(0,0,0,0.06)" } : { width: "100%" }}>
                             {previewBuildHtml ? (
-                                <iframe key="v3-preview" ref={iframeRef} srcDoc={injectEditorBridge(previewBuildHtml)} title="Unsaved preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
+                                <iframe key="v3-preview" ref={iframeRef} srcDoc={injectEditorBridge(previewBuildHtml)} title="Unsaved preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={handleIframeLoad} />
                             ) : htmlContent ? (
-                                <iframe key="v3-saved" ref={iframeRef} srcDoc={previewHtml} title="Website preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={() => { setupInlineEditing(); applyTheme(); }} />
+                                <iframe key="v3-saved" ref={iframeRef} srcDoc={previewHtml} title="Website preview (v3)" className="h-full w-full border-0 bg-white" sandbox="allow-same-origin allow-scripts allow-popups" onLoad={handleIframeLoad} />
                             ) : (
                                 <div className="flex h-full items-center justify-center text-sm text-neutral-400">No website generated yet.</div>
                             )}
@@ -579,6 +641,46 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                 </div>
             </div>
 
+            {colorMode && !colorPopover && (
+                <div style={{ position: "fixed", left: "50%", bottom: 24, transform: "translateX(-50%)", zIndex: 9998, background: "#0f172a", color: "#fff", borderRadius: 999, padding: "8px 16px", fontSize: 12, fontWeight: 600, fontFamily: "ui-sans-serif, system-ui, sans-serif", boxShadow: "0 8px 24px rgba(0,0,0,0.25)" }}>
+                    🎨 Colour mode — click a button, heading, or text to recolour its kind
+                </div>
+            )}
+            {colorPopover && (() => {
+                const def = COLOR_ROLES[colorPopover.role];
+                const prop = colorPopover.prop;
+                const key = roleColorKey(colorPopover.role, prop);
+                const existing = (((m.effectiveCustomizations as any)?.roleColors) ?? {})[key] as string | undefined;
+                const fallback = prop === "bg" ? (colorPopover.curBg || "#3366cc") : (colorPopover.curFg || "#111111");
+                const value = (existing || fallback || "#000000").slice(0, 7);
+                return (
+                    <div style={{ position: "fixed", left: "50%", bottom: 24, transform: "translateX(-50%)", zIndex: 9998, background: "#fff", border: "1px solid #e2e8f0", borderRadius: 14, boxShadow: "0 16px 40px rgba(0,0,0,0.22)", padding: "12px 14px", display: "flex", alignItems: "center", gap: 12, fontFamily: "ui-sans-serif, system-ui, sans-serif", minWidth: 300 }}>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                            <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.14em", textTransform: "uppercase", color: "#64748b" }}>Recolour</span>
+                            <span style={{ fontSize: 14, fontWeight: 700, color: "#0f172a", whiteSpace: "nowrap" }}>{def.label}</span>
+                        </div>
+                        {def.props.length > 1 && (
+                            <div style={{ display: "flex", border: "1px solid #e2e8f0", borderRadius: 8, overflow: "hidden" }}>
+                                {def.props.map((p) => (
+                                    <button key={p} type="button" onClick={() => setColorPopover((c) => (c ? { ...c, prop: p } : c))}
+                                        style={{ padding: "6px 10px", fontSize: 11, fontWeight: 700, border: "none", cursor: "pointer", background: prop === p ? "#0f172a" : "#fff", color: prop === p ? "#fff" : "#64748b" }}>
+                                        {p === "bg" ? "Fill" : "Text"}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                        <input type="color" value={value} onChange={(e) => applyRoleColor(colorPopover.role, prop, e.target.value)}
+                            style={{ width: 44, height: 36, border: "1px solid #e2e8f0", borderRadius: 8, background: "#fff", cursor: "pointer", padding: 2 }}
+                            aria-label={`${def.label} ${prop === "bg" ? "fill" : "text"} colour`} />
+                        {existing && (
+                            <button type="button" onClick={() => applyRoleColor(colorPopover.role, prop, null)}
+                                style={{ fontSize: 12, color: "#64748b", background: "transparent", border: "none", cursor: "pointer", textDecoration: "underline" }}>Reset</button>
+                        )}
+                        <button type="button" onClick={() => setColorPopover(null)} aria-label="Close"
+                            style={{ marginLeft: "auto", background: "transparent", border: "none", color: "#64748b", cursor: "pointer", fontSize: 20, lineHeight: 1, paddingLeft: 6 }}>×</button>
+                    </div>
+                );
+            })()}
             <ImagePickerModal
                 open={!!imagePickerField}
                 field={imagePickerField}

--- a/components/editor/editorBridge.ts
+++ b/components/editor/editorBridge.ts
@@ -52,7 +52,8 @@ export const EDITOR_BRIDGE_SCRIPT = `
         '[data-image-field]{cursor:zoom-in;}',
         'a[data-href-field]{cursor:pointer;}',
         '[data-field]:hover,[data-image-field]:hover,a[data-href-field]:hover{outline:2px dashed rgba(59,130,246,.55);outline-offset:2px;}',
-        '[data-field].ed-focused,[data-image-field].ed-focused,a[data-href-field].ed-focused{outline:2px solid rgba(59,130,246,.85);outline-offset:2px;}'
+        '[data-field].ed-focused,[data-image-field].ed-focused,a[data-href-field].ed-focused{outline:2px solid rgba(59,130,246,.85);outline-offset:2px;}',
+        'html.ed-color-mode [data-field],html.ed-color-mode a[data-href-field]{cursor:crosshair !important;}'
     ].join('');
     document.head.appendChild(style);
 
@@ -65,11 +66,45 @@ export const EDITOR_BRIDGE_SCRIPT = `
         clearFocused();
         if (el) el.classList.add('ed-focused');
     }
+    function rgbToHex(rgb) {
+        var m = /rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/.exec(rgb || '');
+        if (!m) return '';
+        function h(n) { var s = parseInt(n, 10).toString(16); return s.length < 2 ? '0' + s : s; }
+        return '#' + h(m[1]) + h(m[2]) + h(m[3]);
+    }
 
     // ── Click handler — disambiguate link / image / text ─────────────────
+    var edColorMode = false;
     document.addEventListener('click', function (e) {
         var target = e.target;
         if (!target || !target.closest) return;
+
+        // 0. Colour mode — recolour by ROLE instead of editing. Any clickable
+        //    text / link / button element sends ed:color-click (with its current
+        //    colours so the picker starts there); images are skipped. Never
+        //    falls through to the edit routing below.
+        if (edColorMode) {
+            var colEl = target.closest('a[data-href-field],[data-field]');
+            if (colEl) {
+                e.preventDefault();
+                e.stopPropagation();
+                focusEl(colEl);
+                var _cls = (colEl.className || '') + '';
+                var _isBtn = colEl.tagName === 'BUTTON' || /\\bbtn\\b/.test(_cls) || !!(colEl.closest && colEl.closest('.btn,button'));
+                var _cs = null;
+                try { _cs = window.getComputedStyle(colEl); } catch (e2) {}
+                try {
+                    window.parent.postMessage({
+                        type: 'ed:color-click',
+                        field: colEl.getAttribute('data-field') || colEl.getAttribute('data-href-field') || '',
+                        isButton: _isBtn,
+                        curBg: _cs ? rgbToHex(_cs.backgroundColor) : '',
+                        curFg: _cs ? rgbToHex(_cs.color) : '',
+                    }, '*');
+                } catch (err) {}
+            }
+            return;
+        }
 
         // 1. Link click — highest priority. <a data-href-field> opens the
         //    link popover regardless of where on the link the user clicked.
@@ -127,6 +162,12 @@ export const EDITOR_BRIDGE_SCRIPT = `
     window.addEventListener('message', function (e) {
         var msg = e && e.data;
         if (!msg || typeof msg !== 'object' || !msg.type) return;
+
+        if (msg.type === 'ed:set-mode') {
+            edColorMode = (msg.mode === 'color');
+            try { document.documentElement.classList.toggle('ed-color-mode', edColorMode); } catch (e3) {}
+            return;
+        }
 
         if (msg.type === 'ed:update') {
             var nodes = document.querySelectorAll('[data-field="' + cssEscape(msg.field) + '"]');

--- a/components/editor/useEditorDraft.ts
+++ b/components/editor/useEditorDraft.ts
@@ -286,6 +286,17 @@ export function useEditorDraft(props: SandboxEditorProps) {
         commitState(draftRef.current, next, { coalesceKey: `theme:${field}` });
     }, [commitState, customizations]);
 
+    // Per-role colour override (click-to-recolour). Stored under
+    // customizations.roleColors keyed by "<role>:<prop>"; pass color=null to clear.
+    const setRoleColor = useCallback((key: string, color: string | null) => {
+        const base = pendingCustRef.current ?? customizations ?? {};
+        const roleColors = { ...(((base as any).roleColors as Record<string, string>) ?? {}) };
+        if (color) roleColors[key] = color;
+        else delete roleColors[key];
+        const next = { ...base, roleColors };
+        commitState(draftRef.current, next, { coalesceKey: `roleColor:${key}` });
+    }, [commitState, customizations]);
+
     const savedHero = String((customizations as any)?.heroStyle ?? "");
     const onPickTemplate = useCallback((code: string) => {
         const tpl = templateByCode(code);
@@ -332,7 +343,7 @@ export function useEditorDraft(props: SandboxEditorProps) {
         // state
         draft, draftRef, pendingCustomizations,
         // mutators
-        setDeepDraft, setValue, replaceDraft, getValue, isBlockEnabled, toggleBlock, setThemeField, onPickTemplate,
+        setDeepDraft, setValue, replaceDraft, getValue, isBlockEnabled, toggleBlock, setThemeField, setRoleColor, onPickTemplate,
         // derived
         effectiveCustomizations, currentHeroStyle, activeFamily, currentScheme, currentFont,
         savedHero, btForTheme, selectedBucket,

--- a/lib/roleColors.ts
+++ b/lib/roleColors.ts
@@ -1,0 +1,104 @@
+/**
+ * roleColors — per-ROLE colour overrides for the website editor.
+ *
+ * The v3 editor lets an admin click an element on the canvas and recolour its
+ * whole ROLE (all primary buttons, all headings, …) rather than one element.
+ * Because every template shares the same `data-field` contract (see
+ * TEMPLATE-FAMILY-PLAYBOOK / [[filipino-template-family]]), a role maps to a
+ * fixed set of `[data-field]` selectors, so one colour recolours that role
+ * consistently across ANY template family — no per-template code.
+ *
+ * Storage:  customizations.roleColors = { "<role>:<prop>": "#rrggbb" }
+ *   prop = 'bg' (background) | 'fg' (text colour)
+ *
+ * `buildRoleColorCss()` turns that map into a CSS string, injected live into
+ * the preview iframe (SandboxEditorV3) AND appended to the built HTML in
+ * app/api/generate-website (so the colours persist on Save + Publish).
+ */
+
+export type ColorRole = 'primaryCta' | 'secondaryCta' | 'heading' | 'eyebrow' | 'link';
+export type ColorProp = 'bg' | 'fg';
+
+export interface RoleDef {
+    role: ColorRole;
+    label: string;
+    /** CSS selectors — data-field based, so they hit every template family. */
+    selectors: string[];
+    /** The property a click edits by default (the "smart default"). */
+    defaultProp: ColorProp;
+    /** Which properties the picker offers (default first). */
+    props: ColorProp[];
+}
+
+export const COLOR_ROLES: Record<ColorRole, RoleDef> = {
+    primaryCta: {
+        role: 'primaryCta', label: 'Primary buttons', defaultProp: 'bg', props: ['bg', 'fg'],
+        selectors: [
+            '[data-field="hero.cta1.text"]',
+            '[data-field="ctaBand.cta1.text"]',
+            '[data-field="ctaBand.cta.text"]',
+        ],
+    },
+    secondaryCta: {
+        role: 'secondaryCta', label: 'Secondary buttons', defaultProp: 'bg', props: ['bg', 'fg'],
+        selectors: [
+            '[data-field="hero.cta2.text"]',
+            '[data-field="hero.cta3.text"]',
+            '[data-field="ctaBand.cta2.text"]',
+            '[data-field="ctaBand.cta3.text"]',
+        ],
+    },
+    heading: {
+        role: 'heading', label: 'Headings', defaultProp: 'fg', props: ['fg'],
+        selectors: ['[data-field$=".headline"]', '[data-field^="hero.headlineLines"]'],
+    },
+    eyebrow: {
+        role: 'eyebrow', label: 'Eyebrows / tags', defaultProp: 'fg', props: ['fg'],
+        selectors: ['[data-field$=".tag"]', '[data-field="hero.kicker"]'],
+    },
+    link: {
+        role: 'link', label: 'Links', defaultProp: 'fg', props: ['fg'],
+        selectors: ['a[data-href-field]:not(.btn)'],
+    },
+};
+
+/** Map a clicked element (its data-field + whether it looks like a button) to a role. */
+export function roleForField(field: string, isButton: boolean): ColorRole {
+    const f = field || '';
+    if (isButton) {
+        if (/cta2\.text$|cta3\.text$/.test(f)) return 'secondaryCta';
+        return 'primaryCta'; // cta1 / cta.text / any other button
+    }
+    if (/\.headline$/.test(f) || /^hero\.headlineLines/.test(f)) return 'heading';
+    if (/\.tag$/.test(f) || f === 'hero.kicker') return 'eyebrow';
+    return 'link'; // plain <a> / fallback text
+}
+
+/** Storage key for a role+property. */
+export function roleColorKey(role: ColorRole, prop: ColorProp): string {
+    return `${role}:${prop}`;
+}
+
+/**
+ * Build a CSS string from a roleColors map. Returns '' when there is nothing
+ * to emit. `bg` sets background + border-color (so filled buttons recolour
+ * cleanly); `fg` sets the text colour. All rules are `!important` to beat the
+ * template's own token-driven styling.
+ */
+export function buildRoleColorCss(roleColors: Record<string, string> | undefined | null): string {
+    if (!roleColors || typeof roleColors !== 'object') return '';
+    const rules: string[] = [];
+    for (const [key, color] of Object.entries(roleColors)) {
+        if (!color || typeof color !== 'string' || !/^#[0-9a-fA-F]{3,8}$/.test(color)) continue;
+        const [role, prop] = key.split(':') as [ColorRole, ColorProp];
+        const def = COLOR_ROLES[role];
+        if (!def || (prop !== 'bg' && prop !== 'fg')) continue;
+        const sel = def.selectors.join(',');
+        if (prop === 'bg') {
+            rules.push(`${sel}{background:${color} !important;border-color:${color} !important;}`);
+        } else {
+            rules.push(`${sel}{color:${color} !important;}`);
+        }
+    }
+    return rules.join('\n');
+}


### PR DESCRIPTION
## What

Adds **click-to-recolour** to the v3 editor. Toggle the new **🎨 Colors** mode in the toolbar, then click any button / heading / text / link on the canvas — a popover recolours its **whole role** (all primary buttons, all headings, all links, …), not just that one element (per the chosen design). Smart default property (button → **fill**, text/heading/link → **text colour**) with a **Fill/Text** toggle, plus **Reset**. The picker starts from the element's current colour.

## How

Because every template shares the byte-identical `data-field` contract, a role maps to a fixed set of `[data-field]` selectors, so one colour recolours that role **consistently across any template family** — no per-template code.

- **`lib/roleColors.ts`** (shared client + server) — role defs, `roleForField()`, `buildRoleColorCss()`.
- **`editorBridge.ts`** — a colour mode: parent sends `ed:set-mode`; in colour mode a click sends `ed:color-click` (with the element's role + current colours) instead of the edit routing; crosshair cursor.
- **`useEditorDraft.ts`** — `setRoleColor()`, persisted under `customizations.roleColors` (`"<role>:<prop>": "#rrggbb"`).
- **`SandboxEditorV3.tsx`** — the Colors toggle, the popover, and live injection into the preview iframe (mirrors the existing theme-scheme injection).
- **`app/api/generate-website`** — bakes the same `buildRoleColorCss()` `<style>` into the built HTML so colours **persist on Save + Publish**.

## Verification

- `tsc --noEmit` clean.
- Role-inference (`roleForField`) + hex/CSS logic unit-checked (all cases pass).
- ⚠️ **Not browser-tested** — the editor only runs in a browser (Next build won't finish locally). Needs QA on the Vercel preview: toggle 🎨 Colors → click the "Get in touch" button → change fill → confirm all primary buttons recolour live and survive Save.

## Notes
- The existing in-canvas editing (click nav → text+link popup; click image → change) is **unchanged** — this only adds the colour layer.
- Roles covered: primary buttons, secondary buttons, headings, eyebrows/tags, links. Section backgrounds / decorative elements have no `data-field` handle, so they aren't individually recolourable (consistent with the per-role model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)