### PR TITLE
fix(editor): v3 lockVariant preview + instant section-hide + role-colour hover

### DIFF
--- a/components/editor/SandboxEditorV3.tsx
+++ b/components/editor/SandboxEditorV3.tsx
@@ -45,11 +45,20 @@ const VIEWPORTS: Record<string, number | null> = { desktop: null, tablet: 834, m
 
 // Inject the picked Color Scheme / Font Pairing live into the same-origin preview
 // iframe — identical to v2's applyThemeToIframe (SandboxEditorV2.tsx:30-63).
-function applyThemeToIframe(iframe: HTMLIFrameElement | null, scheme: string, font: string, businessType: string) {
+function applyThemeToIframe(iframe: HTMLIFrameElement | null, scheme: string, font: string, businessType: string, isBranded: boolean) {
     try {
         const doc = iframe?.contentDocument;
         if (!doc || !doc.body) return;
-        const resolvedScheme = !scheme || scheme === "auto" || scheme === "default" ? resolveAutoScheme(businessType) : scheme;
+        // Respect lockVariant: branded / bespoke families keep their hand-tuned
+        // palette on "auto" (the real astro build emits no override), so DON'T
+        // apply the auto-by-business-type scheme for them — only generic
+        // (recolour-ready) templates resolve an auto scheme. An EXPLICIT admin
+        // pick still overrides for any family. This keeps the live preview
+        // matching the real site (fixes branded secondary/ghost buttons
+        // rendering wrong in v3 vs v1/v2).
+        const resolvedScheme = !scheme || scheme === "auto" || scheme === "default"
+            ? (isBranded ? "" : resolveAutoScheme(businessType))
+            : scheme;
         const pairing = !font || font === "auto" || font === "default" ? "" : font;
         const fontHref = buildFontHref(pairing);
         if (fontHref && doc.head) {
@@ -136,15 +145,18 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
     const curatedSchemes = m.activeFamily ? CURATED[m.activeFamily] : COLOR_SCHEMES.map((c) => c.id).filter((id) => id !== "auto");
 
     // ── Live theme apply ──────────────────────────────────────────────────
+    // Branded (non-generic) families are lockVariant — their hand-tuned palette
+    // must survive "auto" in the live preview exactly as it does in the build.
+    const isBrandedFamily = !!m.activeFamily && m.activeFamily !== "generic";
     const applyTheme = useCallback(() => {
-        applyThemeToIframe(iframeRef.current, m.currentScheme, m.currentFont, m.btForTheme);
-    }, [m.currentScheme, m.currentFont, m.btForTheme]);
+        applyThemeToIframe(iframeRef.current, m.currentScheme, m.currentFont, m.btForTheme, isBrandedFamily);
+    }, [m.currentScheme, m.currentFont, m.btForTheme, isBrandedFamily]);
 
     const setThemeField = (field: "colorScheme" | "fontPairing", value: string) => {
         m.setThemeField(field, value);
         const nextScheme = field === "colorScheme" ? value : m.currentScheme;
         const nextFont = field === "fontPairing" ? value : m.currentFont;
-        applyThemeToIframe(iframeRef.current, nextScheme, nextFont, m.btForTheme);
+        applyThemeToIframe(iframeRef.current, nextScheme, nextFont, m.btForTheme, isBrandedFamily);
     };
 
     // ── Live text push to the iframe (sidebar edit → preview) ─────────────
@@ -235,12 +247,30 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
         applyRoleColorsToIframe(iframeRef.current, nextMap);
     }, [m]);
 
+    // ── Instant section show/hide (Blocks toggles) ────────────────────────
+    const applyBlockVisibility = useCallback(() => {
+        try {
+            const w = iframeRef.current?.contentWindow;
+            if (!w) return;
+            for (const b of ALL_BLOCKS) {
+                w.postMessage({ type: "ed:section-visibility", block: b.visKey, visible: m.isBlockEnabled(b.visKey) }, "*");
+            }
+        } catch { /* ignore */ }
+    }, [m]);
+
+    const handleToggleBlock = useCallback((visKey: string) => {
+        const nextVisible = !m.isBlockEnabled(visKey);
+        m.toggleBlock(visKey);
+        try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:section-visibility", block: visKey, visible: nextVisible }, "*"); } catch { /* ignore */ }
+    }, [m]);
+
     const handleIframeLoad = useCallback(() => {
         setupInlineEditing();
         applyTheme();
         applyRoleColors();
+        applyBlockVisibility();
         if (colorMode) { try { iframeRef.current?.contentWindow?.postMessage({ type: "ed:set-mode", mode: "color" }, "*"); } catch { /* ignore */ } }
-    }, [setupInlineEditing, applyTheme, applyRoleColors, colorMode]);
+    }, [setupInlineEditing, applyTheme, applyRoleColors, applyBlockVisibility, colorMode]);
 
     // ── ed:* click routing (from v1, adapted to the 3-panel rail) ─────────
     useEffect(() => {
@@ -525,7 +555,7 @@ export default function SandboxEditorV3(props: SandboxEditorProps) {
                                             const on = m.isBlockEnabled(b.visKey);
                                             const required = b.tag === "required";
                                             return (
-                                                <button key={b.visKey} type="button" disabled={required} onClick={() => m.toggleBlock(b.visKey)} aria-checked={on} role="switch"
+                                                <button key={b.visKey} type="button" disabled={required} onClick={() => handleToggleBlock(b.visKey)} aria-checked={on} role="switch"
                                                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${required ? "cursor-not-allowed opacity-60" : "hover:bg-neutral-100"}`}>
                                                     <span className={`relative h-4 w-7 flex-shrink-0 rounded-full transition-colors ${on ? "bg-emerald-500" : "bg-neutral-300"}`}>
                                                         <span className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform ${on ? "translate-x-3.5" : "translate-x-0.5"}`} />

--- a/components/editor/editorBridge.ts
+++ b/components/editor/editorBridge.ts
@@ -169,6 +169,19 @@ export const EDITOR_BRIDGE_SCRIPT = `
             return;
         }
 
+        // Instant section show/hide — the editor's Blocks toggles. Maps a
+        // visibility key to its section via the shared data-field prefix (no
+        // per-template markers needed) and toggles display live.
+        if (msg.type === 'ed:section-visibility') {
+            var PREFIX = { hero_section:'hero', about_section:'about', services_section:'services', why_us_block:'why', how_it_works_block:'how', testimonials_block:'testimonials', featured_section:'gallery', faq_block:'faq', service_area_block:'area', credentials_block:'credentials', location_block:'location', cta_band_block:'ctaBand', trust_block:'trust', footer_section:'footer' };
+            var pfx = PREFIX[msg.block];
+            if (!pfx) return;
+            var anchor = document.querySelector('[data-field^="' + pfx + '."]') || document.querySelector('[data-image-field^="' + pfx + '."]') || document.querySelector('[data-field="' + pfx + '"]');
+            var sec = (anchor && anchor.closest) ? anchor.closest('section,footer,header') : null;
+            if (sec) sec.style.display = msg.visible ? '' : 'none';
+            return;
+        }
+
         if (msg.type === 'ed:update') {
             var nodes = document.querySelectorAll('[data-field="' + cssEscape(msg.field) + '"]');
             nodes.forEach(function (n) {

--- a/lib/roleColors.ts
+++ b/lib/roleColors.ts
@@ -93,7 +93,15 @@ export function buildRoleColorCss(roleColors: Record<string, string> | undefined
         const [role, prop] = key.split(':') as [ColorRole, ColorProp];
         const def = COLOR_ROLES[role];
         if (!def || (prop !== 'bg' && prop !== 'fg')) continue;
-        const sel = def.selectors.join(',');
+        // Apply to base + :hover + :focus (per selector) so the picked colour
+        // holds across states instead of reverting to the template's hover
+        // colour. Appending states to the JOINED string would be wrong — each
+        // selector needs its own suffix.
+        const sel = [
+            ...def.selectors,
+            ...def.selectors.map((s) => `${s}:hover`),
+            ...def.selectors.map((s) => `${s}:focus`),
+        ].join(',');
         if (prop === 'bg') {
             rules.push(`${sel}{background:${color} !important;border-color:${color} !important;}`);
         } else {


### PR DESCRIPTION
Three v3 editor fixes from your live testing (the screenshots + the section-toggle request).

## 1. Fixes the invisible secondary / ghost button in v3
**Root cause:** v3's live preview injected the *auto-by-business-type* colour override (via `resolveAutoScheme`) **even for branded/bespoke templates** — but those are `lockVariant`, so the real astro build keeps their hand-tuned palette and emits **no** override. v1/v2 render the raw built HTML (no live override), so they looked correct; v3 forced a scheme override that remapped `--ink`/`--paper` and broke the outlined button.

**Fix:** `applyThemeToIframe` now respects `lockVariant` — a branded family on **"auto"** applies **no** override (matching the build). An explicit admin colour/font pick still overrides for any family. So the v3 preview now matches the real site.

## 2. Instant section show/hide (your #4)
Toggling a **Blocks** switch (e.g. Testimonials) now **hides/shows that section immediately** in the live preview — a new bridge message (`ed:section-visibility`) maps a block to its section through the **shared `data-field` prefix**, so it works on every template with no per-template markers. The persisted visibility still drives the real rebuild on Save (so it's baked into the published site too). Applied on iframe (re)load as well.

## 3. Colour recolour now covers hover/all states
`buildRoleColorCss` emits the picked colour on **base + `:hover` + `:focus`** (per selector), so a recoloured button no longer reverts to the template's hover colour. *(On the "left button changes the right" report: the primary/secondary selectors are disjoint (`hero.cta1.text` vs `hero.cta2.text`) — that was a side effect of the broken ghost-button render in #1; it should resolve once #1 is verified.)*

## Verification
- `tsc --noEmit` clean.
- Logic-checked the role-colour hover output + the block→section `data-field` map (caught that the gallery toggle's visKey is `featured_section`, not `gallery_section`).
- ⚠️ **Not browser-tested** — needs QA on the Vercel preview: (a) the ghost button renders correctly in v3, (b) toggling Testimonials hides it instantly, (c) recolouring a button holds on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)