### PR TITLE
Open the owner-intake funnel: point the owner CTAs at /start

### DIFF
--- a/app/for-business/page.tsx
+++ b/app/for-business/page.tsx
@@ -67,15 +67,9 @@ function BusinessHero() {
                         <Lead className="mt-5 max-w-xl">{t("hero.lede")}</Lead>
 
                         <div className="mt-8 flex flex-wrap items-center gap-3">
-                            {/* FUNNEL CLOSED UNTIL LAUNCH. This becomes
-                                <Link href="/start"> — with the navbar, the pricing card
-                                and CtaSection — once Convex is deployed and the house
-                                creator row is seeded. /start has no invite gate, so
-                                linking it before the backend exists means an owner
-                                types for ten minutes and fails at submit. */}
-                            <a href="#pricing" className="inline-flex items-center gap-2 rounded-xl bg-ink px-6 py-3.5 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5">
+                            <Link href="/start" className="inline-flex items-center gap-2 rounded-xl bg-ink px-6 py-3.5 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5">
                                 {t("hero.ctaBusiness")} <span aria-hidden>→</span>
-                            </a>
+                            </Link>
                             <a href="#proof" className="inline-flex items-center gap-2 rounded-xl border border-ink/15 bg-white px-6 py-3.5 text-sm font-semibold text-ink transition-colors hover:border-ink/35">
                                 {t("hero.ctaProof")}
                             </a>

--- a/components/landing/BusinessPricingSection.tsx
+++ b/components/landing/BusinessPricingSection.tsx
@@ -72,11 +72,8 @@ export default function BusinessPricingSection() {
                             ))}
                         </ul>
 
-                        {/* FUNNEL CLOSED UNTIL LAUNCH — becomes "/start" with the other
-                            three CTAs once Convex is deployed and the house creator row
-                            is seeded. See components/landing/Navbar.tsx for why. */}
                         <Link
-                            href="/for-business"
+                            href="/start"
                             className="mt-8 inline-flex items-center justify-center gap-2 rounded-lg bg-ink px-5 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5"
                         >
                             {t("hero.ctaBusiness")}

--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -30,8 +30,9 @@ export default function CtaSection({
     // /for-business: this band renders at the BOTTOM of /for-business, where that
     // was a self-link — the page appeared to reload and do nothing. Same
     // destination BusinessPricingSection uses, which also renders on both pages.
-    // FUNNEL CLOSED UNTIL LAUNCH — /start once Convex is deployed and seeded.
-    const primaryHref = isBiz ? "/for-business" : "#app";
+    // The owner CTA is the entrance to the intake funnel, not a link back to the
+    // page it usually renders on.
+    const primaryHref = isBiz ? "/start" : "#app";
     const primaryLabel = isBiz ? t("hero.ctaBusiness") : t("nav.getApp");
     const secondaryLead = isBiz ? t("hero.creatorLead") : t("cta.altBizLead");
     const secondaryHref = isBiz ? "/for-creators" : "/for-business";

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -55,15 +55,11 @@ export default function Navbar() {
                         <option value="en">EN</option>
                         <option value="tl">TL</option>
                     </select>
-                    {/* FUNNEL CLOSED UNTIL LAUNCH. This becomes "/start" — together
-                        with the pricing card, CtaSection and the /for-business hero —
-                        once Convex is deployed and the house creator row is seeded.
-                        /start has no invite gate, so linking it before the backend
-                        exists means an owner types for ten minutes and fails at submit.
-                        Note this navbar also renders ON /for-business, so until then it
-                        is a self-link; that is the lesser of the two evils. */}
+                    {/* Straight into the intake funnel. This navbar also renders ON
+                        /for-business, where pointing back at /for-business was a
+                        self-link that read as a broken site. */}
                     <Link
-                        href="/for-business"
+                        href="/start"
                         className="inline-flex items-center gap-1.5 rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white transition-transform hover:-translate-y-0.5"
                     >
                         {t("hero.ctaBusiness")}


### PR DESCRIPTION
Reverses `39cbdc1`. **This is the launch.**

The Convex backend is deployed to production, the house creator row is seeded (`role: 'admin'`, `priceUnlockedAt` set — both verified), and `SELF_SERVE_CREATOR_ID` is set on `energetic-panther-693`. So `/start` now has a working backend to submit into, and this makes it reachable.

## What changes

Four `href`s, nothing else:

| Where | Was | Now |
|---|---|---|
| `components/landing/Navbar.tsx` | `/for-business` | `/start` |
| `components/landing/BusinessPricingSection.tsx` | `/for-business` | `/start` |
| `components/landing/CtaSection.tsx` (business branch) | `/for-business` | `/start` |
| `app/for-business/page.tsx` hero | `#pricing` | `/start` |

The navbar renders on every page, so this is the real entrance. It was also a **self-link on `/for-business`** — the page appeared to reload and do nothing — which this fixes.

`tsc --noEmit` clean, 323 tests.

## Verified before opening

`https://www.tendso.com/start` returns **HTTP 200** with all client chunks loading, and the production `submissions` pipeline was exercised twice on dev: `creatorPayout` 0, status `submitted`, photo roles correct with the optional portrait skipped, exactly one `leads` row, all three throttle scopes written.

## Two things to watch after merging

1. **The first real submission is the test of `GROQ_API_KEY` on Vercel.** The dev key was revoked; if the production one is the same, admins will get *"Failed to extract website content"* on Generate and submissions will collect unbuildable. Worth clicking Generate on the first one that arrives.
2. **The acknowledgement email** has never sent — no `RESEND_API_KEY` locally. If it isn't set on Vercel, an owner submits and hears nothing until the payment email, which is the gap `/start`'s copy promises to fill within 48–72 hours.

## Protections that are live

`submitOwnerIntake` revalidates everything server-side, enforces a durable throttle (per-email, per-phone, and a global daily ceiling that doubles as a **no-deploy kill switch** — set `OWNER_INTAKE_DAILY_LIMIT=0` to close the funnel in seconds), rejects business types outside the allowlist, and rejects blocked TLDs at intake rather than after payment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
