### PR TITLE
Fix: one creator without a surname takes down /admin/creators

### DIFF
--- a/app/admin/creators/page.tsx
+++ b/app/admin/creators/page.tsx
@@ -20,8 +20,16 @@ type CreatorStatus = 'pending' | 'active' | 'suspended' | 'deleted'
 // routes still redirect here for any external bookmarks.
 type CreatorView = 'all' | 'pending' | 'rejected'
 
-function getInitials(first: string, last: string) {
-    return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase()
+// Both names are OPTIONAL in the schema (convex/schema.ts:45-46 — mobile allows
+// signing up with neither), so typing them as `string` here was a lie the
+// compiler believed. On 2026-08-12 a real signup arrived with a firstName and no
+// lastName and `undefined.charAt(0)` took the ENTIRE page down with a client-side
+// exception — one incomplete row, and no admin could reach the creator list at
+// all. Degrade to whatever initials exist, then to '?', and never throw.
+function getInitials(first?: string | null, last?: string | null) {
+    const a = (first ?? '').trim().charAt(0)
+    const b = (last ?? '').trim().charAt(0)
+    return `${a}${b}`.toUpperCase() || '?'
 }
 
 // Wrap the page so the useSearchParams() call inside is allowed in the


### PR DESCRIPTION
**Production outage on `/admin/creators`** — *"Application error: a client-side exception has occurred"*.

## Cause

```ts
function getInitials(first: string, last: string) {
    return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase()
}
```

Both names are **`v.optional()`** in the schema ([convex/schema.ts:45-46](convex/schema.ts#L45)) — the mobile signup allows either to be absent. The annotation says `string`, so the compiler never questioned it.

Today a real signup arrived with `firstName: "Megaworld at the Fort by Risse Atienza"` and **no lastName**. `undefined.charAt(0)` threw during render, and because it happens inside the creator list's `.map()`, React unmounted the entire route.

**One incomplete row and no admin could reach the creator list** — including the pending-approval and rejected queues, which are tabs on that same page.

## Fix

Degrades to whatever initials exist, then to `'?'`, and cannot throw.

Checked for siblings: [`[id]/page.tsx:288`](app/admin/creators/%5Bid%5D/page.tsx#L288) already guards with `(creator.firstName || 'U')`, and `/admin/payouts` guards with `(w.creatorName || '?')`. This was the only unguarded one.

## Not related to the owner-intake work

I assumed at first it was the `creators` row I seeded today — it isn't. That row has both names and was created at **04:35**; the crashing row appeared at **03:54**, forty minutes earlier.

`tsc` clean, 323 tests pass. Single file, 10 lines.

## Worth a follow-up

The mobile app can create a creator with no surname, and the web admin assumed otherwise. Either the signup should require it or every consumer should assume it's absent — right now it's neither, and the schema is the only thing telling the truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
