### PR TITLE
Stop the fabrication at its source

### DIFF
--- a/__tests__/owner/testimonialGuard.test.ts
+++ b/__tests__/owner/testimonialGuard.test.ts
@@ -486,6 +486,93 @@ describe('the guard end to end', () => {
         expect(republished.services).toHaveLength(3);
     });
 
+    // ── RE-EXTRACTION ────────────────────────────────────────────────────────
+    // The gate re-extracts when the transcript fingerprint moves, and
+    // re-extraction replaces extractedContent wholesale. The trigger is not only
+    // a deliberate transcript edit: the admin's "regenerate transcription" button
+    // re-runs Whisper, Whisper is non-deterministic, and the same audio comes
+    // back worded differently — so the fingerprint moves on its own and the wipe
+    // lands later, on the next Save.
+    //
+    // That wipe used to take the admin's typed testimonials with it, which is the
+    // guard's ENTIRE escape hatch: on the creator funnel nothing can verify a
+    // quote, so an admin who heard the recording typing the real words in is the
+    // only way a true testimonial ever reaches the page. Once wiped, the page has
+    // no quotes and no record that real ones ever existed.
+    //
+    // Mirrors preserveAdminTestimonials in app/api/generate-website/route.ts —
+    // same guard, same option, and nothing carried across when nothing provably
+    // human is left (an empty wrapper would answer the conversion-block gate and
+    // block the regeneration meant to replace it).
+    const preserveAdminTestimonials = (stored: any): any => {
+        if (stored?.testimonials == null) return undefined;
+        const { content } = stripFabricatedTestimonials(
+            { testimonials: stored.testimonials },
+            { keepAdminAuthored: true },
+        );
+        const kept = (content as any).testimonials;
+        if (Array.isArray(kept)) return kept.length > 0 ? kept : undefined;
+        if (kept && typeof kept === 'object') {
+            return Array.isArray(kept.items) && kept.items.length > 0 ? kept : undefined;
+        }
+        return undefined;
+    };
+
+    /** What the editor's "add quote" writes: the attribution key, and no `name`
+     *  or `author` — see ADMIN_ATTRIBUTION_KEY. */
+    const TYPED = { quote: 'Laging bagong luto, kahit hapon na.', who: 'Tita Malou' };
+
+    it('carries the admin typed quotes across a re-extraction', () => {
+        const stored = { testimonials: { tag: 'Reviews', items: [TYPED] } };
+        const preserved = preserveAdminTestimonials(stored);
+        // Fresh model JSON for the re-worded transcript — no testimonials in it,
+        // the extraction prompt no longer asks for any at this level.
+        const fresh = { business_name: 'Ate Beth Street Food', tagline: 'Bagong luto, gabi-gabi' };
+        const reExtracted: any = { ...fresh, testimonials: preserved };
+        expect(reExtracted.testimonials.items).toEqual([TYPED]);
+    });
+
+    it('carries nothing when the stored quotes are the invented ones', () => {
+        // Preservation must never become a way for fabricated content to survive
+        // the rewrite that would have removed it.
+        expect(preserveAdminTestimonials({ testimonials: FABRICATED })).toBeUndefined();
+        expect(preserveAdminTestimonials({ testimonials: { tag: 'Reviews', items: FABRICATED } })).toBeUndefined();
+        expect(preserveAdminTestimonials({ testimonials: 'Everyone says we are the best.' })).toBeUndefined();
+        expect(preserveAdminTestimonials({ business_name: 'X' })).toBeUndefined();
+    });
+
+    it('carries only the typed half of a half-corrected row', () => {
+        const preserved = preserveAdminTestimonials({
+            testimonials: { tag: 'Reviews', items: [...FABRICATED, TYPED] },
+        });
+        expect(preserved.items).toEqual([TYPED]);
+    });
+
+    it('the escape hatch survives the whole re-extraction, end to end', () => {
+        // The full sequence on a creator-funnel row whose transcript fingerprint
+        // moved: preserve → wholesale replace → regenerate the conversion blocks
+        // → guard the generated output → restore admin work on top.
+        const stored = {
+            business_name: 'Ate Beth Street Food',
+            testimonials: { tag: 'Reviews', items: [TYPED] },
+        };
+        const preserved = preserveAdminTestimonials(stored);
+
+        const freshExtraction = { business_name: 'Ate Beth Street Food', tagline: 'Bagong luto, gabi-gabi' };
+        let content: any = { ...freshExtraction, testimonials: preserved };
+
+        // The blocks call still runs — a restored key is not evidence this
+        // transcript's blocks have been written — and it invents three customers
+        // again, which the generation guard drops.
+        const blocks = guard({}, { testimonials: FABRICATED, faq: [{ q: 'Anong oras kayo?', a: 'From 3pm.' }] });
+        content = { ...content, ...blocks, testimonials: preserved };
+
+        // And the assembly pass, which runs on every save, keeps them too.
+        const published = assemble({}, content);
+        expect(published.testimonials.items).toEqual([TYPED]);
+        expect(published.faq).toHaveLength(1);
+    });
+
     it('saving from the editor keeps what the admin typed', () => {
         // /api/save-content persists the draft and then calls this route, so an
         // editor Save is a regenerate. If this stripped, the admin's words would

--- a/app/api/generate-website/route.ts
+++ b/app/api/generate-website/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { fetchQuery } from 'convex/nextjs'
@@ -23,6 +24,177 @@ import {
  */
 function isWrappedObject(v: any): boolean {
     return v != null && typeof v === 'object' && !Array.isArray(v)
+}
+
+/**
+ * The key on saved content that records which transcript the copy was
+ * extracted from. Nested inside `extractedContent` (`v.any()` — see
+ * convex/schema.ts:247), so it needs no schema change and no migration.
+ */
+const EXTRACTION_MARKER_KEY = 'extractedFrom'
+
+/**
+ * Fingerprint of the transcript a page's copy was written from.
+ *
+ * Not a security boundary and never compared against anything an attacker
+ * chooses — it only has to change when the transcript does, which is what
+ * separates "the owner re-did the interview" from "the admin edited a
+ * headline". Length is prefixed so two transcripts would have to collide in
+ * both to read as the same source.
+ *
+ * A missing transcript gets its own stable value rather than being skipped.
+ * "We extracted with nothing to go on" is a real state that has to converge
+ * like any other, and it has to differ from the interview the owner records a
+ * week later — otherwise the one submission that most needs re-extracting is
+ * the one that never gets it.
+ */
+function fingerprintTranscript(transcript?: string): string {
+    const text = (transcript || '').trim()
+    if (!text) return 'no-transcript'
+    return `${text.length}:${createHash('sha256').update(text).digest('hex').slice(0, 16)}`
+}
+
+/**
+ * ── What survives a re-extraction ───────────────────────────────────────────
+ *
+ * Re-extraction replaces `extractedContent` WHOLESALE, so anything not named
+ * here is destroyed. The loss is also deferred and invisible: the trigger is a
+ * changed transcript fingerprint, and the "regenerate transcription" button in
+ * app/admin/submissions/[id]/page.tsx re-runs Whisper — which is
+ * non-deterministic, so re-transcribing the same audio moves the fingerprint on
+ * its own. Nothing regenerates at that moment; the wipe lands later, on the
+ * admin's next Save, with no visible connection to the button they pressed.
+ *
+ * THE LINE, so whoever extends this has the rule rather than the list: a key
+ * belongs here when the ADMIN is the only thing that can write it, and it is
+ * therefore unrecoverable once dropped. A key any GENERATOR also writes stays
+ * OUT — its stored value may be model output about the very interview we are
+ * re-reading, and carrying that across would preserve stale fabrication instead
+ * of human work, which is this branch's own bug wearing a different hat. When
+ * the two cannot be told apart, the answer is out: losing a field the model
+ * rewrites from the new transcript costs one regenerate, keeping an invented
+ * one costs a real business its credibility.
+ *
+ * Every key a generator can emit, so the test is checkable rather than
+ * remembered: the extraction prompt below (business_name, tagline, about,
+ * services, unique_selling_points, tone, featured_headline,
+ * featured_subheadline, featured_products); generateConversionBlocks (trust,
+ * why, how, testimonials, faq, credentials, ctaBand); generateGenericSections
+ * (marquee, hero, about, services, gallery, area, location, footer,
+ * navbar_links, navCtaText, navCtaHref). None of them is in the list below.
+ */
+const ADMIN_ONLY_CONTENT_KEYS = [
+    // FACTS, never copy — the same rule the contact merge inside POST states at
+    // length. They come from the submission or from what the admin typed, and no
+    // prompt in lib/services/groq.service.ts asks a model for any of them.
+    'contact',
+    'googleMapsUrl',
+    'serviceArea',
+    'messaging',
+
+    // CHROME the admin switched off. Nothing generates `visibility`; it is
+    // written by the editor's Blocks tab and defaulted further down this file.
+    // Dropping it turns every section the admin deliberately hid back on, on a
+    // site that is already live.
+    'visibility',
+
+    // IMAGE PICKS — which photo sits in which slot. These hold storage refs and
+    // URLs, never words: the only writers are the editor's picker and this
+    // route's own resolution of the business's OWN photos, so nothing here can
+    // be a model's invention. (The picks nested inside the wrapped sections —
+    // gallery.items[].image, hero.image — are not here; see the counter-list.)
+    'images',
+    'about_images',
+    'featured_images',
+    'services_image',
+
+    // TYPED COPY for the A–O template families. Every one of these flat fields
+    // is editor-only: the extraction prompt writes `featured_*` and the flat
+    // `about`/`services`, generateGenericSections writes the NESTED
+    // `about.headline` / `services.headline`, and neither ever writes the
+    // snake_case field beside it. A value sitting on one of these keys was put
+    // there by a person.
+    'hero_badge_text',
+    'hero_cta',
+    'hero_cta_secondary',
+    'about_headline',
+    'about_description',
+    'about_tagline',
+    'about_tags',
+    'services_headline',
+    'services_subheadline',
+    'services_cta',
+    'methodology',
+    'featured_cta_text',
+    'featured_cta_link',
+    'navbar_cta_text',
+    'navbar_cta_link',
+    'navbar_headline',
+] as const
+
+/**
+ * Deliberately NOT preserved, and why. The counter-list carries as much weight
+ * as the list — each entry is a field somebody will reasonably want to add:
+ *
+ *  • `footer`, `navbar_links`, `navCtaText`/`navCtaHref`, `location`, and every
+ *    wrapped section (`hero`, `about`, `services`, `gallery`, `area`,
+ *    `marquee`) — generateGenericSections writes exactly these keys. The admin
+ *    edits leaves INSIDE the same objects the model wrote, and nothing in the
+ *    payload records which leaf came from whom. Preserving the key would carry
+ *    the model's sentences about the OLD interview onto a page rebuilt from the
+ *    new one. (These keys also answer the `hasGenericSections` gate below, so
+ *    adding one here would silently switch generic-section generation off.)
+ *
+ *  • `trust`, `why`, `how`, `faq`, `credentials`, `ctaBand` — same reason, from
+ *    generateConversionBlocks.
+ *
+ *  • `featured_products` — model-written projects. An admin's image pick inside
+ *    one is genuine work and it is lost here; there is no way to keep the pick
+ *    without keeping the invented project it hangs on.
+ *
+ *  • `hero_testimonial` — a quoted customer carried as a bare value with NO
+ *    provenance marker. `testimonials` can be split item by item because the
+ *    editor stamps ADMIN_ATTRIBUTION_KEY on anything a human touched; this
+ *    field has no such mark, so it is all-or-nothing and it is left out.
+ *
+ *    Be honest about what that buys, because it is not what it looks like: no
+ *    generator writes this key — the editor is its only writer — and
+ *    stripFabricatedTestimonials does not read it either. So excluding it does
+ *    NOT stop a fabricated hero quote republishing; an ordinary regenerate
+ *    republishes whatever is stored, untouched. What the exclusion actually
+ *    costs is an admin's typed hero quote on a transcript change, and what it
+ *    buys is only that a transcript change does not carry one forward blind.
+ *    By the rule above this key arguably qualifies for the list. It is out
+ *    because dropping it is recoverable by retyping and the wrong call here is
+ *    cheap, not because keeping it would resurrect anything.
+ */
+
+/**
+ * The admin's typed quotes, and nothing else.
+ *
+ * `testimonials` is the one key that is BOTH generated and typed into, so it can
+ * be neither preserved nor dropped wholesale. It is carried item by item, on the
+ * same provenance the assembly pass uses and THROUGH THE SAME FUNCTION — there
+ * is no second implementation of "did a human write this" here to drift from
+ * stripFabricatedTestimonials. Whatever the guard would strip on the way out is
+ * never carried across on the way in, so preservation cannot resurrect anything.
+ *
+ * Undefined when nothing provably human is left, so the caller carries no key at
+ * all: an empty array or wrapper would preserve nothing while still answering
+ * the conversion-block gate, blocking the regeneration meant to replace it.
+ */
+function preserveAdminTestimonials(stored: any): unknown | undefined {
+    if (stored?.testimonials == null) return undefined
+    const { content } = stripFabricatedTestimonials(
+        { testimonials: stored.testimonials },
+        { keepAdminAuthored: true },
+    )
+    const kept = (content as any).testimonials
+    if (Array.isArray(kept)) return kept.length > 0 ? kept : undefined
+    if (kept && typeof kept === 'object') {
+        return Array.isArray(kept.items) && kept.items.length > 0 ? kept : undefined
+    }
+    return undefined
 }
 
 export async function POST(request: NextRequest) {
@@ -102,9 +274,11 @@ export async function POST(request: NextRequest) {
         // quotable to type back in. See the JSON response at the end.
         const guardRemoved = { generated: 0, stored: 0 }
 
-        // Wrap GENERATED output — model JSON and the hardcoded default products.
-        // Stored content goes through the assembly pass further down instead,
-        // which keeps what an admin typed.
+        // Wrap GENERATED output — every piece of model JSON this run produces.
+        // (It used to wrap a hardcoded default-products block too; that block is
+        // gone, because stripping invented quotes off invented projects still left
+        // the invented projects.) Stored content goes through the assembly pass
+        // further down instead, which keeps what an admin typed.
         const guardGenerated = <T>(label: string, generated: T): T => {
             if (testimonialsAreSourced) return generated
             const { content, removed } = stripFabricatedTestimonials(generated)
@@ -144,38 +318,104 @@ export async function POST(request: NextRequest) {
             extractedContent = {
                 ...extractedContent,
                 business_name: submission.business_name,
+                // Contact details are facts, never copy: they come from the
+                // submission or from what the admin typed, and from nowhere
+                // else. The placeholders that used to sit on the end of these
+                // chains (contact@example.com, +63 900 000 0000) shipped a
+                // phone number that reaches nobody onto a paying customer's
+                // live site. Missing is recoverable; wrong is not.
                 contact: {
                     ...((extractedContent as any)?.contact || {}),
-                    email: submission.owner_email || (extractedContent as any)?.contact?.email || 'contact@example.com',
-                    phone: submission.owner_phone || (extractedContent as any)?.contact?.phone || '+63 900 000 0000',
+                    email: submission.owner_email || (extractedContent as any)?.contact?.email,
+                    phone: submission.owner_phone || (extractedContent as any)?.contact?.phone,
                     address: submission.address ? `${submission.address}, ${submission.city}` : (extractedContent as any)?.contact?.address || submission.city
                 }
             }
         }
 
-        // Validate that extractedContent has required fields
-        const hasRequiredFields = extractedContent &&
-            extractedContent.business_name &&
-            extractedContent.tagline &&
-            extractedContent.about
+        // ── When does extraction run? ─────────────────────────────────
+        // On whether it has ALREADY RUN for this transcript — never on what it
+        // returned. Every version of this gate that inspected the output looped,
+        // and had to: GROUNDING now tells the model that an empty tagline and an
+        // omitted services list are correct answers, so "re-extract when services
+        // are missing" (and the `tagline && about` check that sat beside it)
+        // asks a business that genuinely named no services to keep failing the
+        // same test forever. It burns a Groq call on every regenerate and can
+        // never succeed, because succeeding would mean the model inventing the
+        // thing the interview does not contain.
+        //
+        // The second edge is worse. Re-extraction REPLACES extractedContent
+        // wholesale, so the admin who deletes a fabricated services list — the
+        // exact cleanup the fabrication incident requires — drops the count to
+        // zero and has the list written back on the next save. An output-shaped
+        // gate cannot tell that deletion apart from a gap.
+        //
+        // So we record what we did instead of grading what came back.
+        const transcriptFingerprint = fingerprintTranscript(submission.transcript)
 
-        // For beauty/salon businesses, the new design grids need 5-6 services.
-        // If a previous extraction only produced 3 (the old prompt's target),
-        // re-extract so the page fills out properly. Same for sparse 1-2.
-        const businessTypeLowerCheck = (submission.business_type || '').toLowerCase()
-        const isBeautyCheck = /salon|spa|beauty|barber|nail|hair|lash|brow|aesthetic/.test(businessTypeLowerCheck)
-        const servicesCount = Array.isArray((extractedContent as any)?.services)
-            ? (extractedContent as any).services.length
-            : 0
-        const servicesAreSparse =
-            (isBeautyCheck && servicesCount < 5) || servicesCount < 3
+        // Read the marker off what is STORED, not off `extractedContent`: in
+        // preview mode that variable holds the admin's unsaved draft, and the
+        // editor round-trip (/api/save-content writes the draft verbatim, then
+        // calls this route) can drop a key the editor knows nothing about.
+        // Either would otherwise read as "never extracted".
+        const storedContent = (existingWebsite?.extractedContent || submission.website_content) as any
+        const lastExtraction =
+            storedContent?.[EXTRACTION_MARKER_KEY] ?? (extractedContent as any)?.[EXTRACTION_MARKER_KEY]
 
-        // Force re-extraction when content exists but doesn't meet the
-        // current grid requirements. Preserves admin-edited contact info
-        // (already merged above) by saving it as override before re-extraction.
-        const preservedContact = (extractedContent as any)?.contact
+        // Structural, not semantic: "a content object exists" is a fact about the
+        // database. "The content object has a tagline" is a fact about what a
+        // model chose to write, and we are done gating on those.
+        const hasStoredContent = !!extractedContent && Object.keys(extractedContent).length > 0
 
-        if (!extractedContent || !hasRequiredFields || (servicesAreSparse && submission.transcript)) {
+        // A missing marker NEVER means "extract". Every row written before this
+        // marker existed has none, as does any draft that lost the key on the way
+        // through the editor, and re-extracting over either is precisely the wipe
+        // this is here to stop. Absent marker = adopt what is stored (stamped
+        // below), so the row converges on the next save and a LATER transcript
+        // change is still caught.
+        const transcriptChanged = !!lastExtraction && lastExtraction.transcript !== transcriptFingerprint
+
+        // Stamped onto the saved content further down. Starts as the most this
+        // run can honestly claim, and is upgraded if extraction actually runs.
+        let extractionMarker = lastExtraction ?? {
+            transcript: transcriptFingerprint,
+            at: Date.now(),
+            // 'adopted' — this content predates the marker (or lost it in the
+            // editor round-trip). We did not write it and cannot claim we did;
+            // what we can record is which transcript it now corresponds to,
+            // which is the whole of what makes the next change detectable.
+            source: 'adopted' as const,
+        }
+
+        // Everything the admin has that the wholesale replacement below would
+        // otherwise destroy. Contact was the first member of this list and is
+        // still the only one needing a merge rather than a straight carry (see
+        // the restore inside the branch); the rule that decides membership, and
+        // the fields deliberately left out of it, are on ADMIN_ONLY_CONTENT_KEYS.
+        const preservedAdminWork: Record<string, any> = {}
+        for (const key of ADMIN_ONLY_CONTENT_KEYS) {
+            const value = (extractedContent as any)?.[key]
+            if (value !== undefined) preservedAdminWork[key] = value
+        }
+        // Split off, because this is the one key that is both generated and typed
+        // into: only the items a human provably wrote come across.
+        const preservedTestimonials = preserveAdminTestimonials(extractedContent)
+        if (preservedTestimonials !== undefined) preservedAdminWork.testimonials = preservedTestimonials
+
+        // What was ACTUALLY carried across — empty on every run that did not
+        // re-extract, which is nearly all of them. Two things below have to know
+        // the difference: the conversion-block gate (a key we just restored is
+        // not evidence this transcript's blocks have been written) and the merge
+        // under it (admin work outranks anything generated this run).
+        let restoredAdminWork: Record<string, any> = {}
+
+        // Nothing stored yet → first extraction. Transcript genuinely different
+        // from the one the copy was written from → the source of truth changed
+        // and re-extracting the COPY is the right answer: it was written about a
+        // different interview. It is not the right answer for the rest of the
+        // admin's work, which was never about the transcript at all — hence the
+        // preserve-list above.
+        if (!hasStoredContent || transcriptChanged) {
 
             // Build context from submission data
             const context = `
@@ -223,18 +463,16 @@ Generate a JSON response with the following structure:
   "tagline": "A catchy, memorable tagline (max 10 words)",
   "about": "A compelling 2-3 sentence description of the business that highlights what makes it special",
   "services": [
-    ${Array.from({ length: targetServices }, (_, i) =>
-      `{"name": "2-3 WORDS MAX", "description": "ONE single sentence, 12-20 words, no clauses, no semicolons"}`
-    ).join(',\n    ')}
+    {"name": "2-3 WORDS MAX", "description": "ONE single sentence, 12-20 words, no clauses, no semicolons"}
   ],
-  "unique_selling_points": ["USP 1", "USP 2", "USP 3", "USP 4"],
+  "unique_selling_points": ["one short phrase per difference the owner actually claimed"],
   "tone": "${isBeauty ? 'warm, refined, aspirational' : 'professional-friendly'}",
   "featured_headline": "Featured Products",
-  "featured_subheadline": "A brief description of what makes these projects special",
+  "featured_subheadline": "A brief description of the work shown below — omit this field alongside featured_products when the interview describes no specific job",
   "featured_products": [
     {
-      "title": "Project title related to the business",
-      "description": "A detailed 2-3 sentence description of this project showcasing quality work",
+      "title": "a job or piece of work the owner actually described",
+      "description": "2-3 sentences using only details the owner gave about it",
       "tags": ["Tag1", "Duration"],
       "testimonial": {
         "quote": "the customer's words as the owner reported them (2-3 sentences)"
@@ -244,16 +482,17 @@ Generate a JSON response with the following structure:
 }
 
 IMPORTANT:
+- SOURCE: every fact — services, prices, hours, years in business, guarantees, past work — comes from the interview above. Rephrase it, infer from it ("we open at 5am and close at 11pm" is opening hours), write it well. Never add one that isn't there. If the interview doesn't support a field, omit that field: an absent field is correct output, a plausible invention is not.
 - Make the tagline creative and memorable. For beauty: short, italic-ready, ends without a period.
-- Services MUST have exactly ${targetServices} items, specific to this business type. ${isBeauty ? 'Cover: cuts/styling · color · treatments · bridal/event · nails or lash · facials/skin (pick whichever fits this business).' : ''}
-- SERVICE NAMES: 2-3 words MAX. Editorial titles like "Cut & Style", "Couture Color", "Bridal & Events", "Glow Facials", "Brow & Lash Studio". NEVER full sentences or descriptions in the name.
+- Services: only the ones the owner said they offer, around ${targetServices} for a business like this. That number is a ceiling on padding, not a quota to reach: fewer is right when fewer were named, omit "services" entirely when none were, and when the owner rattled off more real ones than that — nine services named in one breath is a real menu — list every one of them. Cutting a service the shop actually sells is the same mistake as inventing one, made in the direction nobody checks. Never round the list out to fill a grid.
+- SERVICE NAMES: 2-3 words MAX, editorial rather than descriptive — the owner's own word for the thing, sharpened, or two of them joined by "&". Build every name out of what THIS owner said: their plainest word is still the right name when it is the word they used ("Labada", "Dry cleaning") — an ordinary trade has ordinary vocabulary and does not need a cleverer one. What belongs to somebody else's shop is a service they never mentioned, added because businesses of this type usually have it. NEVER full sentences or descriptions in the name.
 - SERVICE DESCRIPTIONS: ONE sentence only, 12-20 words. No clauses joined by semicolons. No "we offer" / "we provide" filler. Concrete and specific.
-- USPs should highlight what makes this business unique
+- USPs: only differences the owner actually claimed. Omit when none were.
 - Keep descriptions concise and compelling
-- Generate ${Math.min(photoCount, 3) || 3} featured_products (one for each photo if available, max 3)
+- featured_products: only work the owner actually described, at most ${Math.min(photoCount, 3) || 3}. Omit the array when the interview describes no specific job — and omit "featured_subheadline" with it, since there is then no work for it to describe.
 - Each featured project should have a unique title, description and tags
 - TESTIMONIALS: only what the owner reported customers saying, in the transcript. If it isn't there, omit "testimonial" entirely. Never invent a customer or a quote — and never output a name: nobody is ever asked who said it, so a name can only be made up.
-- Tags should include project type and estimated duration
+- Tags: the kind of work, plus how long it took only when the owner said so
 ${isBeauty ? '- For beauty businesses, lean into ritual + intimacy + the "regular client" relationship. Avoid generic "we offer..." phrasing.' : ''}
 ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no medical claims; no specific outcomes promised.' : ''}
 - Return ONLY valid JSON, no markdown or additional text`
@@ -272,15 +511,31 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
                 const cleanContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim()
                 const freshExtraction = guardGenerated('main extraction', JSON.parse(cleanContent))
 
-                // Restore admin-edited contact info that was merged above so
-                // a re-extraction doesn't clobber owner phone/email/address.
-                if (preservedContact) {
-                    freshExtraction.contact = {
+                // Put the admin's work back on top of the fresh copy. The
+                // transcript changed, so the model's SENTENCES change with it —
+                // but a hidden section, an image pick, a typed quote or an owner's
+                // phone number was never a statement about the interview, and
+                // re-reading the interview is no reason to throw them away.
+                //
+                // Contact keeps the merge it has always had rather than a straight
+                // overwrite: fresh fields fill gaps, admin/submission values win.
+                restoredAdminWork = { ...preservedAdminWork }
+                if (restoredAdminWork.contact) {
+                    restoredAdminWork.contact = {
                         ...(freshExtraction.contact || {}),
-                        ...preservedContact,
+                        ...restoredAdminWork.contact,
                     }
                 }
-                extractedContent = freshExtraction
+                extractedContent = { ...freshExtraction, ...restoredAdminWork }
+
+                // Claim only what just happened. The fingerprint is the
+                // transcript this copy was actually written from, so the next
+                // regenerate can see there is nothing new to read.
+                extractionMarker = {
+                    transcript: transcriptFingerprint,
+                    at: Date.now(),
+                    source: 'extracted' as const,
+                }
 
             } catch (error) {
                 console.error('Groq extraction error:', error)
@@ -295,10 +550,14 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
         // If transcript is missing or generation fails, per-business-type
         // defaults from lib/block-defaults.ts kick in at build time.
         const ec = extractedContent as any
-        const hasAnyConversionBlock = !!(
-            ec?.trust || ec?.why || ec?.how ||
-            ec?.testimonials || ec?.faq || ec?.credentials || ec?.ctaBand
-        )
+        // A key RESTORED a moment ago is not evidence this submission's blocks
+        // have been written. `testimonials` is the only key that is ever both
+        // restored and a conversion block, and letting the admin's carried-over
+        // quotes answer this question would skip generating the other six for a
+        // transcript nothing has read yet — the admin would keep their words and
+        // lose the whole rest of the page's conversion content instead.
+        const hasAnyConversionBlock = ['trust', 'why', 'how', 'testimonials', 'faq', 'credentials', 'ctaBand']
+            .some((key) => !(key in restoredAdminWork) && !!ec?.[key])
         if (!hasAnyConversionBlock && submission.transcript) {
             try {
                 const blocks = await groqService.generateConversionBlocks(
@@ -311,7 +570,16 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
                     }
                 )
                 if (blocks) {
-                    extractedContent = { ...extractedContent, ...guardGenerated('conversion blocks', blocks) }
+                    // Restored admin work goes on last. The model has just written
+                    // testimonials from the new transcript; the quotes a human
+                    // typed outrank them, the same order the generic-section merge
+                    // below keeps. Without this the preservation above would be
+                    // undone one call later, on the only path that triggers it.
+                    extractedContent = {
+                        ...extractedContent,
+                        ...guardGenerated('conversion blocks', blocks),
+                        ...restoredAdminWork,
+                    }
                 }
             } catch (err) {
                 console.error('Conversion-block generation failed (using defaults):', err)
@@ -375,10 +643,10 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
 
         // ── Stored content faces the same gate ────────────────────────
         // Every guard above only fires on something GENERATED this run, and a
-        // regenerate generates nothing: `servicesAreSparse` is false because the
-        // services are already populated and `hasAnyConversionBlock` is true
-        // because the testimonials already exist. So the incident row's three
-        // invented customers skip all four call sites and republish verbatim —
+        // regenerate generates nothing: the extraction gate is satisfied because
+        // this transcript has already been read, and `hasAnyConversionBlock` is
+        // true because the testimonials already exist. So the incident row's three
+        // invented customers skip every generator call site and republish verbatim —
         // and would on every future publish, forever. The strip has to run on
         // what we READ as well as on what we write.
         //
@@ -783,16 +1051,35 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
 
         // Ensure all required fields are present with fallbacks from submission data
         const contentWithContact = {
-            // Core required fields with fallbacks
+            // Core required fields with fallbacks.
+            //
+            // These three fallbacks stay, and the line they sit on the right side
+            // of is the whole point of this file: they are assembled ONLY out of
+            // what the business itself put on the submission form — its name, its
+            // category, its city. They assert no capability, no promise and no
+            // quality. Nothing below may be restored on the same reasoning: the
+            // moment a default names a service, a turnaround, a rating or a
+            // customer, it is speaking for a business that never said it.
+            //
+            // The tagline default now carries real weight. It used to be nearly
+            // dead, because a missing tagline forced a re-extraction until one
+            // appeared; that check is gone (it could not converge), so an
+            // interview that yields no tagline keeps its blank one and this is
+            // the only thing standing between it and a headless hero.
             business_name: extractedContent?.business_name || submission.business_name,
             tagline: extractedContent?.tagline || `Welcome to ${submission.business_name}`,
             about: extractedContent?.about || `${submission.business_name} is a ${submission.business_type} located in ${submission.city}.`,
-            services: extractedContent?.services || [
-                { name: 'Service 1', description: 'Quality service for our customers' },
-                { name: 'Service 2', description: 'Professional and reliable' },
-                { name: 'Service 3', description: 'Customer satisfaction guaranteed' }
-            ],
-            unique_selling_points: extractedContent?.unique_selling_points || ['Quality', 'Reliability', 'Service'],
+            // No invented menu, and no invented virtues. If the interview never
+            // named a service, this business has no service list on its site and
+            // the section self-hides — the same rule the conversion blocks already
+            // follow (lib/astro-builder.ts:439). "Customer satisfaction
+            // guaranteed" is a promise nobody here made.
+            //
+            // `?? []` rather than leaving these undefined: an empty array is
+            // truthy, so it holds the line against the `|| [...]` fallbacks that
+            // still sit downstream instead of handing them back the fabrication.
+            services: extractedContent?.services ?? [],
+            unique_selling_points: extractedContent?.unique_selling_points ?? [],
             tone: extractedContent?.tone || 'professional-friendly',
             // Optional fields
             hero_cta: extractedContent?.hero_cta,
@@ -850,17 +1137,24 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             services_headline: (extractedContent as any)?.services_headline,
             services_subheadline: (extractedContent as any)?.services_subheadline,
             services_image: resolvedServicesImage,
-            // Featured section fields - generate defaults if not present
+            // Featured section fields. The headline is a band LABEL, not a claim,
+            // so it keeps its default the way services_headline / about_headline
+            // do in the builder; everything under it must be real or absent.
             featured_headline: (extractedContent as any)?.featured_headline || 'Featured Products',
-            featured_subheadline: (extractedContent as any)?.featured_subheadline || `Take a look at some of our recent work at ${submission.business_name}`,
-            // The defaults branch is machine-written down to the customer names
-            // (see generateDefaultFeaturedProducts), so it goes through the same
-            // guard as the models do. `resolvedProducts` derives from
-            // extractedContent, which the stored-content pass above already
-            // filtered.
-            featured_products: resolvedProducts.length > 0
-                ? resolvedProducts
-                : guardGenerated('default featured products', generateDefaultFeaturedProducts(submission.business_name, submission.business_type, photos.length)),
+            // "Take a look at some of our recent work" is a claim that recent
+            // work exists and that we know what it was. Left blank, the band
+            // renders its heading over the business's own photos and says
+            // nothing it can't back.
+            featured_subheadline: (extractedContent as any)?.featured_subheadline,
+            // Real work or nothing. The removed fallback invented entire
+            // projects ("Complete Kitchen Renovation", "We transformed the heart
+            // of X") and attributed praise for them to five recycled names. The
+            // testimonial guard stripped the quotes, but only the quotes — the
+            // invented projects shipped regardless, and on a business that DID
+            // supply testimonials the guard stood down and the names shipped too.
+            // `resolvedProducts` derives from extractedContent, which the
+            // stored-content pass above has already filtered.
+            featured_products: resolvedProducts,
             featured_images: resolvedFeaturedImages.length > 0 ? resolvedFeaturedImages : undefined,
             // Featured CTA fields for style 4
             featured_cta_text: (extractedContent as any)?.featured_cta_text,
@@ -879,17 +1173,21 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             // This keeps the user's content editor choices (slot 1 = X, slot 2 = Y) intact
             // while filtering out expired Airtable URLs
             images: hasValidUserEditedImages ? userEditedImages : photos,
-            // Contact info from submission (or from existing extracted content if edited)
+            // Contact info from submission (or from existing extracted content if
+            // edited). Every field here is the submission's own — no placeholder
+            // tail, for the same reason as the merge near the top of this file: a
+            // live site is better missing a phone number than showing one that
+            // rings nowhere.
             contact: (extractedContent as any)?.contact || {
-                email: submission.owner_email || 'contact@example.com',
-                phone: submission.owner_phone || '+63 900 000 0000',
+                email: submission.owner_email,
+                phone: submission.owner_phone,
                 address: submission.address ? `${submission.address}, ${submission.city}` : submission.city
             },
-            // Footer section fields
-            footer: (extractedContent as any)?.footer || {
-                brand_blurb: `For any inquiries or to explore your vision further, we invite you to contact our professional team using the details provided below.`,
-                social_links: []
-            },
+            // Footer section fields — whatever the admin wrote, or nothing. The
+            // removed default ("explore your vision further… our professional
+            // team") was agency copy for a business we know nothing about, and it
+            // rendered as the footer blurb on every site that never set one.
+            footer: (extractedContent as any)?.footer,
             // ── New v01-spec block content (feeds Location/ServiceArea/ClickToMessage) ──
             // Coordinates: submitter-set wins; else falls back to whatever the
             // editor may have stored under extractedContent.location.
@@ -958,6 +1256,16 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
                 ? { marquee: (extractedContent as any).marquee } : {}),
             navCtaText: (extractedContent as any)?.navCtaText,
             navCtaHref: (extractedContent as any)?.navCtaHref,
+            // Not content — provenance, and the only reason the extraction gate
+            // above can converge. Nothing renders it; it rides along inside
+            // extractedContent because that is the object that survives the
+            // editor round-trip, and it has to come back to us on the next
+            // regenerate to answer "have we already read this transcript?".
+            //
+            // It lives here rather than being spread in from extractedContent
+            // because this literal is a whitelist: a key that is not named here
+            // does not reach Convex.
+            [EXTRACTION_MARKER_KEY]: extractionMarker,
         }
 
         let generatedHtml = await buildAstroSite(contentWithContact, finalCustomizations, photos)
@@ -1066,11 +1374,26 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             // Services section
             servicesHeadline: contentWithContact.services_headline,
             servicesSubheadline: contentWithContact.services_subheadline,
-            services: contentWithContact.services?.map((s: any) => ({
-                name: s.name || s.title || '',
-                description: s.description || '',
-                icon: s.icon,
-            })),
+            // The same two shapes the builder now reads (lib/astro-builder.ts
+            // servicesSection / hero.services): flat `{name, description}` from
+            // extraction, wrapped `{ tag, headline, items[] }` from
+            // generateGenericSections and the generic editor. `?.map` guards
+            // only a nullish value, so the wrapped object threw here too — and
+            // this call sits after the HTML is already stored, so the failure
+            // would have surfaced as a 500 on an otherwise successful build.
+            // The `title`/`desc` aliases are the wrapped item's own key names;
+            // dropping them would file the owner's real menu as blank rows.
+            services: (() => {
+                const s: any = contentWithContact.services
+                const list = Array.isArray(s)
+                    ? s
+                    : Array.isArray(s?.items) ? s.items : undefined
+                return list?.map((it: any) => ({
+                    name: it.name || it.title || '',
+                    description: it.description || it.desc || '',
+                    icon: it.icon,
+                }))
+            })(),
             // Featured section
             featuredHeadline: contentWithContact.featured_headline,
             featuredSubheadline: contentWithContact.featured_subheadline,
@@ -1212,56 +1535,4 @@ ${isYmyl ? '- This is a YMYL business (medical/dental/aesthetic). Be precise; no
             { status: 500 }
         )
     }
-}
-
-/**
- * Generate default featured projects based on business info
- * Used when no featured_products are provided in extractedContent
- */
-function generateDefaultFeaturedProducts(businessName: string, businessType: string, photoCount: number) {
-    const productCount = Math.min(Math.max(photoCount, 1), 3) // 1-3 projects based on photos
-
-    // Business type specific project templates
-    const productTemplates: Record<string, Array<{ title: string; description: string; tags: string[] }>> = {
-        'restaurant': [
-            { title: 'Complete Kitchen Renovation', description: `We transformed the heart of ${businessName} with a modern kitchen setup featuring state-of-the-art equipment and efficient workflow design. The result is a space that enhances productivity while maintaining the highest standards of quality.`, tags: ['Kitchen', 'Renovation'] },
-            { title: 'Dining Area Enhancement', description: `A complete refresh of the dining space at ${businessName}, creating an inviting atmosphere for guests. We focused on comfortable seating, ambient lighting, and décor that reflects the restaurant's unique character.`, tags: ['Interior', 'Design'] },
-            { title: 'Outdoor Patio Setup', description: `Expanded the dining capacity with a beautiful outdoor patio area. The space features weather-resistant furniture and ambient lighting, perfect for al fresco dining experiences.`, tags: ['Outdoor', 'Expansion'] }
-        ],
-        'retail': [
-            { title: 'Store Layout Optimization', description: `Redesigned the floor layout at ${businessName} to improve customer flow and product visibility. The new arrangement has significantly enhanced the shopping experience and increased customer engagement.`, tags: ['Retail', 'Layout'] },
-            { title: 'Display System Installation', description: `Installed custom display systems that showcase products beautifully while maximizing floor space. The modular design allows for easy reconfiguration for seasonal changes.`, tags: ['Display', 'Custom'] },
-            { title: 'Checkout Area Modernization', description: `Upgraded the checkout experience with modern POS systems and a welcoming counter design. The improvements have reduced wait times and improved customer satisfaction.`, tags: ['Technology', 'Service'] }
-        ],
-        'default': [
-            { title: 'Complete Business Setup', description: `A comprehensive project for ${businessName} that included space planning, equipment installation, and finishing touches. The result is a professional environment that perfectly serves business needs.`, tags: ['Setup', 'Complete'] },
-            { title: 'Service Area Enhancement', description: `Upgraded the main service area to improve workflow efficiency and customer experience. The modern design reflects the quality and professionalism of ${businessName}.`, tags: ['Enhancement', 'Service'] },
-            { title: 'Customer Experience Improvement', description: `Focused improvements on the customer-facing areas, creating a welcoming atmosphere that encourages return visits and positive reviews.`, tags: ['Customer', 'Experience'] }
-        ]
-    }
-
-    const templates = productTemplates[businessType.toLowerCase()] || productTemplates['default']
-
-    // Generate projects with testimonials.
-    // These names and quotes are invented — nobody named below is a customer of
-    // anything. The caller runs the result through the fabricated-testimonial
-    // guard, which strips `testimonial` outright unless the business actually
-    // supplied testimonial words, so they reach a page only when they have been
-    // replaced by real ones. Do not read them as safe defaults.
-    const testimonialAuthors = ['Maria Santos', 'Juan Dela Cruz', 'Ana Reyes', 'Carlo Mendoza', 'Lisa Garcia']
-    const testimonialQuotes = [
-        `${businessName} exceeded all our expectations. The attention to detail and professionalism was outstanding from start to finish.`,
-        `Working with ${businessName} was a pleasure. They truly understood our vision and delivered beyond what we imagined.`,
-        `The team at ${businessName} transformed our space completely. We couldn't be happier with the results and the service we received.`
-    ]
-
-    return templates.slice(0, productCount).map((template, index) => ({
-        title: template.title,
-        description: template.description,
-        tags: template.tags,
-        testimonial: {
-            quote: testimonialQuotes[index % testimonialQuotes.length],
-            author: testimonialAuthors[index % testimonialAuthors.length]
-        }
-    }))
 }

--- a/components/editor/genericContentSchema.ts
+++ b/components/editor/genericContentSchema.ts
@@ -152,8 +152,24 @@ export const GENERIC_CONTENT_SCHEMA: GroupSpec[] = [
                 hrefPath: 'hero.cta2.href',
                 placeholder: 'See services',
             },
-            { kind: 'text', label: 'Meta line 1', path: 'hero.meta1', placeholder: '★★★★★ rated on Google' },
-            { kind: 'text', label: 'Meta line 2', path: 'hero.meta2', placeholder: 'Open daily · address' },
+            // A placeholder is a suggestion, and these two suggested exactly
+            // what the extraction prompt now forbids the model to write:
+            // '★★★★★ rated on Google' asserts a review score and a Google
+            // profile nobody in this pipeline can verify, and
+            // 'Open daily · address' asserts a schedule nobody checked (it is
+            // the string just deleted from the prompt and from
+            // lib/derive-content-defaults.ts). Admin-typed content is exempt
+            // from every guard on this branch, so the greyed-out text an admin
+            // reads while typing is the last place those claims can re-enter.
+            // Show the shape of the field; name nothing we can't stand behind.
+            {
+                kind: 'text',
+                label: 'Meta line 1',
+                path: 'hero.meta1',
+                placeholder: 'A short fact — e.g. Est. 2016',
+                hint: 'Sits under the CTAs. Publish only what the business can back up.',
+            },
+            { kind: 'text', label: 'Meta line 2', path: 'hero.meta2', placeholder: 'A second short fact — e.g. the street' },
             { kind: 'text', label: 'Trust line (Stillwater)', path: 'hero.trustLine', hint: 'Used by Stillwater hero only.' },
         ],
     },
@@ -297,7 +313,18 @@ export const GENERIC_CONTENT_SCHEMA: GroupSpec[] = [
             { kind: 'text', label: 'Eyebrow tag', path: 'testimonials.tag', placeholder: 'Reviews' },
             { kind: 'text', label: 'Headline', path: 'testimonials.headline' },
             { kind: 'textarea', label: 'Big pull-quote (A/D templates)', path: 'testimonials.bigQuote' },
-            { kind: 'text', label: 'Source line', path: 'testimonials.source', placeholder: '★ Reviews on Google' },
+            // '★ Reviews on Google' was a provenance claim printed under the
+            // quotes — the one line on the page that says where they came
+            // from — suggested to the admin for a profile we never read. Same
+            // reason as hero.meta1 above: the field is for naming the real
+            // source, so the placeholder asks for one instead of supplying it.
+            {
+                kind: 'text',
+                label: 'Source line',
+                path: 'testimonials.source',
+                placeholder: 'Where these quotes came from',
+                hint: 'Only name a source the business actually gave you.',
+            },
             {
                 kind: 'list',
                 label: 'Quotes',

--- a/lib/astro-builder.ts
+++ b/lib/astro-builder.ts
@@ -325,16 +325,246 @@ async function transformToAstroData(
         ? { ...content.contact, phone: formatPhoneDisplay(content.contact.phone) || content.contact.phone }
         : content.contact
 
+    // ── Shared inputs, hoisted out of the payload literal ───────────────
+    // `d` / `derived` / `c` / mergeShallow used to be declared twice, inside
+    // the two IIFEs at the bottom. They are needed a third time now — by the
+    // anchor-liveness block below, which runs BEFORE `layout.navLinks` — and
+    // three copies of "what would this section contain" is exactly the
+    // duplication that lets two answers drift apart. One declaration, read by
+    // everything downstream.
+    const c = content as any
+    const d = defaultsFor(content.business_type)
+    const derived = deriveDefaultsFor(content, photos)
+
+    // ⚠ This is the merge that makes lib/derive-content-defaults.ts
+    // authoritative over the templates. It starts from the DERIVED
+    // object and only lets an owner value overwrite a key when it is
+    // not undefined/null/'' — so:
+    //   • a key the derived layer omits is absent from the result, the
+    //     component's `{value && …}` guard fires, and the element is
+    //     never emitted. This is how a claim gets removed.
+    //   • a key the derived layer sets to '' is still PRESENT, and
+    //     because the loop below skips '' on the owner side, an admin
+    //     who blanks that input cannot clear it — the derived '' (or
+    //     any derived string) wins forever. That asymmetry is why
+    //     removals in the derived layer must be absent, never ''.
+    // A stock sentence left in the derived layer therefore ships on
+    // every site whose owner left the field blank, no matter what the
+    // .astro fallback says: the template is never consulted.
+    const mergeShallow = <T extends object>(src: T | undefined, fb: T): T => {
+        if (!src || typeof src !== 'object') return fb
+        const out: any = { ...fb }
+        for (const [k, v] of Object.entries(src)) {
+            if (v !== undefined && v !== null && v !== '') out[k] = v
+        }
+        return out as T
+    }
+
+    // Merged section payloads that BOTH the liveness tests below and the
+    // `content` payload at the bottom read. Computed once so the nav can
+    // never disagree with the section it points at.
+    const aboutMerged = mergeShallow<any>(c.about, derived.about)
+    const whyBlock = normalizeBlock(c.why ?? derived.why, 'items', { description: 'body' })
+    const locationMerged: any = { ...derived.location, ...(content.location || {}) }
+
+    // ── Anchor liveness: which in-page targets this build actually has ──
+    // Sections auto-hide when the business supplied nothing — services,
+    // gallery, why, about and location each gate on their own content. The
+    // links that point AT them did not: lib/derive-content-defaults.ts emits
+    // the same five nav entries and the same '#services' / '#visit' CTA
+    // targets for every submission, so on a sparse site four of five nav
+    // links, the hero's secondary button and the closing band all scrolled
+    // nowhere. A link to a section that isn't on the page is the visible
+    // cost of the auto-hide work, and it is fixed here rather than at either
+    // end of the pipeline because this is the only place that knows both
+    // halves:
+    //   • lib/derive-content-defaults.ts can't — it is the browser-safe
+    //     tier-3 layer, and it never sees the AI's services/why/gallery
+    //     items or the admin's visibility toggles. Its nav list stays
+    //     complete on purpose (see the note above it): it is the canonical
+    //     menu the editor sidebar lists and edits.
+    //   • the .astro components can't — a header's own `onPage()` guard
+    //     knows which ids THIS DESIGN renders (PageA calls its services
+    //     section id="menu", PageB calls it id="classes"), not whether THIS
+    //     BUSINESS filled it.
+    // Two different truths, and they compose: the builder drops a target the
+    // DATA leaves empty, the component remaps or drops a target the DESIGN
+    // does not render.
+    //
+    // DIRECTION OF ERROR. Every predicate below proves a section is EMPTY;
+    // none of them tries to prove one is full. An anchor we don't model, a
+    // storage shape we don't recognise, a signal we don't read — all leave
+    // the link alone. Dropping a link to a section the business DID fill is
+    // the failure nobody would ever notice, so each test takes the UNION of
+    // the signals any design counts as content (a photo alone renders an
+    // About on AboutC/E; a phone alone renders a Location on LocationA–E),
+    // never the strictest gate.
+    //
+    // NOTE these are NOT the `visibility.*` flags below, and must not be
+    // folded into them. `visibility.aboutSection` / `whyUsBlock` /
+    // `locationBlock` stay pure admin toggles because that is what the editor
+    // reads back: the flag means "the admin chose to hide this", and an empty
+    // section means "there is nothing to show yet". Collapsing the two would
+    // write emptiness into the admin's own setting, so a section that was
+    // merely bare would come back OFF after the admin filled it in — and they
+    // would have no way to tell why. The components already gate themselves on
+    // content (AboutAV–AZ, WhyP and WhyBA all open with a `paragraphs.length`,
+    // `items.length` or `hasContent` test), so an empty band does not draw
+    // regardless. Nothing here changes what renders — only what may point at it.
+    const servicesSectionVisible = vis.services_section === false
+        ? false
+        : (
+            Array.isArray(c.services)
+                ? c.services.length > 0
+                : Array.isArray(c.services?.items)
+                    ? c.services.items.length > 0
+                    : false
+        )
+    const gallerySectionVisible = vis.gallery_section === false || vis.featured_section === false
+        ? false
+        : (Array.isArray(c.gallery?.items) && c.gallery.items.length > 0)
+            || photos.length > 0
+    // About: every design's `hasAbout` gate is some subset of {lead,
+    // description, signature, quote, note, tagline, paragraphs, image,
+    // tags} — so the union of all of them is the safe test. `headline` and
+    // `tag` are deliberately excluded, for the reason AboutA writes out in
+    // full: the derived layer sets `About ${name}` for every named business,
+    // so counting it would make this always-true and the test useless. The
+    // raw `content.about` string counts too — it does not currently reach
+    // the nested About section (that mapping is a known, separately-owned
+    // gap), but a business that typed an About paragraph must keep its nav
+    // link the moment that gap closes.
+    const aboutHasContent = Boolean(
+        aboutMerged.lead || aboutMerged.description || aboutMerged.signature ||
+        aboutMerged.quote || aboutMerged.note || aboutMerged.tagline ||
+        (typeof content.about === 'string' && content.about.trim()) ||
+        (Array.isArray(aboutMerged.paragraphs) && aboutMerged.paragraphs.length > 0) ||
+        (content.about_images?.length ?? 0) > 0 ||
+        (content.about_tags?.length ?? 0) > 0 ||
+        photos.length > 0,
+    )
+    const aboutSectionVisible = vis.about_section === false ? false : aboutHasContent
+    const whyBlockVisible = vis.why_us_block === false
+        ? false
+        : (whyBlock?.items?.length ?? 0) > 0
+    // Location: LocationA–E hide on `address || phone || hours || coords`;
+    // the filipino family also counts an email. Union again, and it is the
+    // reason the '#visit' target is usually alive whatever else is empty —
+    // contact comes from the submission form, not from the interview.
+    const locationBlockVisible = vis.location_block === false
+        ? false
+        : Boolean(
+            locationMerged.address || formattedContact?.address ||
+            locationMerged.phone || formattedContact?.phone ||
+            locationMerged.hours || content.footer_hours ||
+            formattedContact?.email ||
+            (typeof locationMerged.lat === 'number' && typeof locationMerged.lng === 'number'),
+        )
+
+    // Anchors we can PROVE have no section on this build. Aliases are
+    // included where a link and a section id use different names for the
+    // same content ('#gallery' is the legacy nav's name for the gallery
+    // '#work' renders under; '#location' is what several designs call
+    // '#visit') — the same two pairs each header's own ANCHOR_ALIAS maps.
+    // Design-local ids ('#menu', '#classes', '#reviews') are NOT listed:
+    // they are a design's private naming and resolving them is the
+    // component's job, not ours.
+    const deadAnchors = new Set<string>()
+    if (!servicesSectionVisible) deadAnchors.add('services')
+    if (!gallerySectionVisible) { deadAnchors.add('work'); deadAnchors.add('gallery') }
+    if (!aboutSectionVisible) deadAnchors.add('about')
+    if (!whyBlockVisible) deadAnchors.add('why')
+    if (!locationBlockVisible) { deadAnchors.add('visit'); deadAnchors.add('location') }
+    const isDeadAnchor = (href: unknown): boolean =>
+        typeof href === 'string' && href.startsWith('#') && deadAnchors.has(href.slice(1))
+
+    // A nav entry is pure navigation: its label promises a section, and with
+    // the section gone the promise is the fabrication and the link is the
+    // dead end. Drop it — there is nowhere honest to send it, and the label
+    // can't be reused for somewhere else.
+    //
+    // Dropping (rather than blanking the href) is safe for the editor: the
+    // headers assign each link's data-field index BEFORE their own filter,
+    // so indices are positional in whatever list we hand them — but
+    // navbar_links is edited from the sidebar list widget, never inline
+    // (SandboxEditorV2/V3 both put `navbar_links.*` in their inline-edit SKIP
+    // set precisely because array indices are a data-loss trap), so no field
+    // path is bound to these positions. Blanking instead would render
+    // `<a href="">` in the filipino footers' Explore column, which reloads
+    // the page — strictly worse than the anchor we're removing.
+    const filterLiveNav = (links: any): Array<{ label: string; href: string }> =>
+        (Array.isArray(links) ? links : []).filter((l: any) => l && !isDeadAnchor(l.href))
+
+    // The one contact target every "Get in touch" button aims at. When the
+    // Location section IS on the page, nothing changes (the early return in
+    // resolveContactHref keeps the original href). When it isn't, the button
+    // falls back to a channel the owner actually gave us rather than
+    // disappearing: a conversion surface with somewhere real to go beats a
+    // dead anchor, and tel:/mailto: work on every design. If they gave us
+    // neither, the href is left exactly as it was — each component's own
+    // fallback ('#book', '#location', its own tel: link) is a better guess
+    // than anything we could invent from here.
+    // Test the STRIPPED value, not the raw field. A phone can hold junk that is
+    // perfectly truthy — 'N/A', 'wala', '-' — and the strip reduces it to '' or
+    // a bare '+', leaving `tel:` behind: a button that dials nothing. That
+    // matters more here than it used to, because this href is now the fallback
+    // for every CTA whose own anchor went dead, so one dud value lands on the
+    // hero, the nav button and the CTA band at once. No digit, no phone.
+    const dialableDigits = String(formattedContact?.phone ?? '').replace(/[^0-9+]/g, '')
+    const contactChannelHref = /[0-9]/.test(dialableDigits)
+        ? `tel:${dialableDigits}`
+        : (formattedContact?.email ? `mailto:${String(formattedContact.email).trim()}` : '')
+    const CONTACT_ANCHORS = new Set(['visit', 'location'])
+    const resolveContactHref = (href: string | undefined): string | undefined => {
+        // Off-page (tel:, mailto:, https:) and non-contact anchors pass
+        // through untouched — retargeting '#services' at the phone would
+        // leave a button labelled "See services" dialling a number.
+        if (!href || !href.startsWith('#')) return href
+        const id = href.slice(1)
+        if (!CONTACT_ANCHORS.has(id) || !deadAnchors.has(id)) return href
+        return contactChannelHref || href
+    }
+
+    // The hero's SECONDARY CTA is the one button whose label names a section
+    // ("See services"). Text and href move together or not at all: retarget
+    // it and keep the old label and you have swapped a dead button for a
+    // lying one. So the fallback chain carries its own label, in
+    // browse-intent order, and only the primary's target is excluded — a
+    // second button pointing where the first one already goes is not a
+    // second conversion surface. If nothing is left to browse the key is
+    // dropped and the hero keeps its one working button; every hero renders
+    // this as `{cta2Text && …}`.
+    const BROWSE_CTA_TARGETS: Array<{ href: string; text: string }> = [
+        { href: '#services', text: 'See services' },
+        { href: '#work', text: 'See our work' },
+        { href: '#about', text: 'About us' },
+        { href: '#visit', text: 'Get in touch' },
+    ]
+    const resolveSecondaryCta = (cta: any, primaryHref: string | undefined): any => {
+        if (!cta || typeof cta !== 'object' || !isDeadAnchor(cta.href)) return cta
+        const dest = BROWSE_CTA_TARGETS.find(
+            (t) => !deadAnchors.has(t.href.slice(1)) && t.href !== primaryHref,
+        )
+        return dest ? { ...cta, ...dest } : undefined
+    }
+
     return {
         layout: {
             businessName: content.business_name,
             tagline: content.tagline,
-            navLinks: content.navbar_links || [
+            // Every header — and the filipino footers' Explore column —
+            // renders the nav from here, so this is where the dead entries
+            // have to go. The fallback list is left exactly as it was: an
+            // admin who deletes every nav link leaves `content.navbar_links`
+            // as [], and [] must stay an empty nav rather than resurrecting a
+            // menu they removed (which is why this doesn't share the
+            // `|| derived.navbar_links` fallback the copy below uses).
+            navLinks: filterLiveNav(content.navbar_links || [
                 { label: 'About', href: '#about' },
                 { label: 'Services', href: '#services' },
                 { label: 'Gallery', href: '#gallery' },
                 { label: 'Contact', href: '#contact' },
-            ],
+            ]),
             socialLinks: content.footer?.social_links || [],
             colorScheme: customizations.colorSchemeId || customizations.colorScheme || 'auto',
             fontPairing: customizations.fontPairingId || customizations.fontPairing || 'modern',
@@ -379,7 +609,7 @@ async function transformToAstroData(
             aboutImages: vis.about_images !== false,
             aboutTagline: vis.about_tagline !== false,
             aboutTags: vis.about_tags !== false,
-            servicesSection: vis.services_section !== false,
+            // (servicesSection moved below — auto-hides when empty)
             servicesBadge: vis.services_badge !== false,
             servicesHeadline: vis.services_headline !== false,
             servicesSubheadline: vis.services_subheadline !== false,
@@ -444,12 +674,28 @@ async function transformToAstroData(
                             ? (content as any).credentials.items.length > 0
                             : false
                 ),
+            // Services auto-hides on an empty menu. An empty menu is now a
+            // reachable, correct outcome — the extraction prompt no longer
+            // pads the list to fill a grid and the route no longer re-extracts
+            // until it does — so leaving this unconditional trades a
+            // fabricated service list for an "Our Services" heading over
+            // nothing, which is the same page defect one step later.
+            //
+            // Two storage shapes, both counted: Generic A–E keep the flat
+            // array extraction returns, the branded families keep
+            // `{ tag, headline, items[] }` (the split isWrappedObject handles
+            // in app/api/generate-website/route.ts). Counting only the flat
+            // one would read every branded site as having zero services and
+            // delete a section the owner filled in.
+            //
+            // Computed above, with the rest of the section-emptiness tests,
+            // because the nav filter has to reach the same verdict: a
+            // "Services" link that survives a hidden Services section is the
+            // same defect one step later.
+            servicesSection: servicesSectionVisible,
             // Gallery auto-hides when there's nothing to show (no admin
-            // gallery items AND no submission photos).
-            gallerySection: vis.gallery_section === false || vis.featured_section === false
-                ? false
-                : (Array.isArray((content as any).gallery?.items) && (content as any).gallery.items.length > 0)
-                    || photos.length > 0,
+            // gallery items AND no submission photos). Also computed above.
+            gallerySection: gallerySectionVisible,
             ctaBandBlock: vis.cta_band_block !== false,
         },
         hero: {
@@ -463,7 +709,20 @@ async function transformToAstroData(
             ctaSecondaryLabel: content.hero_cta_secondary?.label,
             ctaSecondaryLink: content.hero_cta_secondary?.link,
             photos,
-            services: content.services?.slice(0, 3),
+            // Both storage shapes, same reason as servicesSection above — and
+            // here it is not defensive, it is a crash. `?.slice` guards only a
+            // NULLISH services; on the wrapped `{ tag, headline, items[] }`
+            // object it resolves `.slice` to undefined and calls it, throwing
+            // before a single section is built. That object became reachable
+            // the moment extraction was allowed to omit `services`: the
+            // generic-section merge in app/api/generate-website/route.ts fills
+            // the now-null key with its own wrapped shape, so an interview that
+            // names no services took the whole build down with a TypeError.
+            services: Array.isArray(content.services)
+                ? content.services.slice(0, 3)
+                : Array.isArray((content as any).services?.items)
+                    ? (content as any).services.items.slice(0, 3)
+                    : undefined,
             visibility: {
                 heroHeadline: vis.hero_headline !== false,
                 heroTagline: vis.hero_tagline !== false,
@@ -512,8 +771,14 @@ async function transformToAstroData(
             // Services component gates on `items.length` / `services.length`
             // and keeps the whole section out of the document, so a business
             // that listed nothing advertises nothing — while consumers that
-            // do `services.map(...)` without a guard still get an array.
-            services: content.services || [],
+            // do `services.map(...)` without a guard still get an array — a
+            // promise `content.services || []` stopped keeping once the
+            // wrapped `{ tag, headline, items[] }` shape could reach here, an
+            // object being truthy. The wrapped menu is not translated into
+            // this legacy `{name, description}` payload: it already reaches
+            // the templates intact as `siteData.content.services`, and only
+            // that one is read.
+            services: Array.isArray(content.services) ? content.services : [],
             photos: content.services_image ? [content.services_image] : (photos.length > 0 ? [photos[0]] : []),
             ctaLabel: content.services_cta?.label,
             ctaLink: content.services_cta?.link,
@@ -622,7 +887,6 @@ async function transformToAstroData(
         // ── Conversion-cluster blocks (neutral fallback after template wipe) ──
         // Resolution order: admin-typed → generic neutral fallback.
         ...(() => {
-            const d = defaultsFor(content.business_type)
             return {
                 trust: content.trust ?? d.trust,
                 why: content.why ?? d.why,
@@ -640,9 +904,9 @@ async function transformToAstroData(
         // Existing legacy-template flows ignore this field, so it's
         // additive and doesn't affect A-O variants.
         content: (() => {
-            const d = defaultsFor(content.business_type)
-            const derived = deriveDefaultsFor(content, photos)
-            const c = content as any
+            // `d` / `derived` / `c` / mergeShallow are declared once, above
+            // the payload literal, because the anchor-liveness block needs
+            // the same merged sections this one emits.
 
             // `content.services` is "array of {name, description}" in the
             // legacy shape, "object with .items[]" in the new shape. Detect.
@@ -655,32 +919,14 @@ async function transformToAstroData(
             // Per-section "did admin/AI supply anything?" — if no, use the
             // derived defaults so the section renders coherently. Each leaf
             // still falls back individually inside the section component.
-            //
-            // ⚠ This is the merge that makes lib/derive-content-defaults.ts
-            // authoritative over the templates. It starts from the DERIVED
-            // object and only lets an owner value overwrite a key when it is
-            // not undefined/null/'' — so:
-            //   • a key the derived layer omits is absent from the result, the
-            //     component's `{value && …}` guard fires, and the element is
-            //     never emitted. This is how a claim gets removed.
-            //   • a key the derived layer sets to '' is still PRESENT, and
-            //     because the loop below skips '' on the owner side, an admin
-            //     who blanks that input cannot clear it — the derived '' (or
-            //     any derived string) wins forever. That asymmetry is why
-            //     removals in the derived layer must be absent, never ''.
-            // A stock sentence left in the derived layer therefore ships on
-            // every site whose owner left the field blank, no matter what the
-            // .astro fallback says: the template is never consulted.
-            const mergeShallow = <T extends object>(src: T | undefined, fb: T): T => {
-                if (!src || typeof src !== 'object') return fb
-                const out: any = { ...fb }
-                for (const [k, v] of Object.entries(src)) {
-                    if (v !== undefined && v !== null && v !== '') out[k] = v
-                }
-                return out as T
-            }
+            // (mergeShallow and its ⚠ note live above the payload literal.)
 
-            const heroMerged = mergeShallow<any>(c.hero, derived.hero)
+            // Copy before touching anything, for the reason spelled out in
+            // the ctaBand block below: mergeShallow RETURNS THE FALLBACK
+            // OBJECT ITSELF when the owner side is absent, so the headline
+            // backfill and the CTA resolution underneath would otherwise
+            // write straight into `derived.hero`.
+            const heroMerged: any = { ...mergeShallow<any>(c.hero, derived.hero) }
             // Headline backfills: if neither admin nor AI gave a
             // single-line headline, use derived.headline. If neither gave
             // headlineLines, fall back to splitting headline on newlines.
@@ -691,6 +937,21 @@ async function transformToAstroData(
                 if (!heroMerged.headlineLines || heroMerged.headlineLines.length === 0) {
                     heroMerged.headlineLines = derived.hero.headlineLines
                 }
+            }
+            // Hero CTAs against the sections this build actually has. cta1 is
+            // the primary "Get in touch" and only ever moves between contact
+            // targets; cta2 names a section, so it moves label-and-href
+            // together or is dropped. Both are no-ops on a site whose
+            // sections are all present.
+            const heroPrimaryHref = resolveContactHref(heroMerged.cta1?.href)
+            if (heroMerged.cta1 && heroPrimaryHref !== heroMerged.cta1.href) {
+                heroMerged.cta1 = { ...heroMerged.cta1, href: heroPrimaryHref }
+            }
+            const heroSecondary = resolveSecondaryCta(heroMerged.cta2, heroPrimaryHref)
+            if (heroSecondary === undefined) {
+                delete heroMerged.cta2
+            } else {
+                heroMerged.cta2 = heroSecondary
             }
 
             return {
@@ -716,7 +977,7 @@ async function transformToAstroData(
                 contact: formattedContact,
                 marquee: mergeShallow<any>(c.marquee, derived.marquee),
                 hero: heroMerged,
-                about: mergeShallow<any>(c.about, derived.about),
+                about: aboutMerged,
                 services: servicesNested
                     ? mergeShallow<any>(servicesNested, derived.services)
                     : derived.services,
@@ -740,7 +1001,7 @@ async function transformToAstroData(
                     return g
                 })(),
                 area: mergeShallow<any>(c.area, derived.area),
-                location: { ...derived.location, ...(content.location || {}) },
+                location: locationMerged,
                 // ── The ctaBand CTA-key contract ────────────────────────
                 // One closing CTA, emitted under every key name the ctaBand
                 // designs actually read.
@@ -761,7 +1022,14 @@ async function transformToAstroData(
                     // merged result would mutate `derived.ctaBand` in place —
                     // and the derived href read below would already be gone.
                     const band: any = { ...mergeShallow<any>(c.ctaBand, derived.ctaBand) }
-                    const derivedHref: string | undefined = derived.ctaBand.cta?.href
+                    // Both hrefs go through the contact resolver: '#visit' is
+                    // the derived target and it is the one anchor that can be
+                    // missing for a reason the owner did not choose (no
+                    // address, no phone, no hours, no coords => LocationA–E
+                    // keep themselves out of the document). Dead => the
+                    // owner's own tel:/mailto: takes over. Alive => both are
+                    // returned untouched and the contract below is unchanged.
+                    const derivedHref: string | undefined = resolveContactHref(derived.ctaBand.cta?.href)
                     const ownerBand: any =
                         c.ctaBand && typeof c.ctaBand === 'object' ? c.ctaBand : {}
                     // Whichever name the OWNER typed their CTA under wins over
@@ -782,15 +1050,27 @@ async function transformToAstroData(
                     // that scrolls nowhere — trading a missing button for a
                     // dead one. Absent href => the component's fallback fires,
                     // which is the intended contract.
-                    const ownerHref =
-                        ownerBand.cta1?.href || ownerBand.primary?.href || ownerBand.cta?.href || undefined
+                    const ownerHref = resolveContactHref(
+                        ownerBand.cta1?.href || ownerBand.primary?.href || ownerBand.cta?.href || undefined,
+                    )
+                    // …with one exception to the TRAP, and only one: an
+                    // OFF-PAGE derived href (the tel:/mailto: the resolver
+                    // hands back when '#visit' has no section) has none of the
+                    // problem the trap describes — it is not an anchor, so it
+                    // cannot miss. Every design can dial a phone. It is safe
+                    // to alias under all three names, and it is the difference
+                    // between the closing CTA working and the closing CTA
+                    // being a decoration on a page with no Location section.
+                    const derivedOffPageHref =
+                        derivedHref && !derivedHref.startsWith('#') ? derivedHref : undefined
                     if (text) {
                         for (const key of ['cta', 'cta1', 'primary'] as const) {
                             // Never clobber a key the owner set themselves —
                             // `ctaBand.cta1.text` is the data-field these
                             // designs expose to the admin editor.
                             if (ownerBand[key]?.text) continue
-                            band[key] = ownerHref ? { text, href: ownerHref } : { text }
+                            const href = ownerHref || derivedOffPageHref
+                            band[key] = href ? { text, href } : { text }
                         }
                         // `cta` is the only name that keeps a derived href, so
                         // restore it when the owner supplied none — CtaBandA–F
@@ -808,10 +1088,22 @@ async function transformToAstroData(
                 })(),
                 footer: mergeShallow<any>(c.footer, derived.footer),
                 navCtaText: c.navCtaText || 'Get in touch',
-                navCtaHref: c.navCtaHref || '#visit',
-                navbar_links: Array.isArray(c.navbar_links) && c.navbar_links.length
-                    ? c.navbar_links
-                    : derived.navbar_links,
+                // The header's own CTA is a contact button like the hero's
+                // primary — same resolver, same no-op when Location renders.
+                navCtaHref: resolveContactHref(c.navCtaHref || '#visit'),
+                // No .astro reads this copy — `layout.navLinks` is the one
+                // every header and the filipino footers' Explore column
+                // render from — but it ships in site-data.json, so it gets
+                // the same filter rather than sitting there as a second,
+                // stale answer for the next consumer to find. The editor
+                // sidebar is unaffected either way: it lists the nav from the
+                // draft and from deriveContentDefaults(), so admin still sees
+                // and edits all five entries.
+                navbar_links: filterLiveNav(
+                    Array.isArray(c.navbar_links) && c.navbar_links.length
+                        ? c.navbar_links
+                        : derived.navbar_links,
+                ),
                 // Why / How / Testimonials / FAQ / Credentials — same 3-tier
                 // resolution (admin > AI > derived) PLUS a shape normalizer
                 // because the AI / legacy paths emit flat arrays

--- a/lib/derive-content-defaults.ts
+++ b/lib/derive-content-defaults.ts
@@ -248,6 +248,13 @@ export function deriveContentDefaults(
                 || (name
                     ? (descriptor ? `Welcome to ${name} — ${descriptor}.` : `Welcome to ${name}.`)
                     : (descriptor ? asSentence(descriptor) : undefined)),
+            // Both targets are resolved against the sections this build
+            // actually renders, in lib/astro-builder.ts — see the note on
+            // navbar_links below. cta1 keeps its label and moves to the
+            // owner's own tel:/mailto: if the Location section isn't there;
+            // cta2 names a section, so label and href move together to the
+            // next live one and the button is only dropped when there is
+            // nowhere left to browse.
             cta1: { text: 'Get in touch', href: '#visit' },
             cta2: { text: 'See services', href: '#services' },
             // No meta1 default. It used to be '★★★★★ rated on Google' — a
@@ -397,6 +404,10 @@ export function deriveContentDefaults(
             // time guarantee. CtaBandA/B fall back to joining the real address
             // and phone when this key is absent, which is the honest version of
             // the same line.
+            //
+            // '#visit' is resolved in lib/astro-builder.ts like the hero's
+            // primary CTA: it survives untouched while the Location section
+            // renders, and becomes the owner's tel:/mailto: when it doesn't.
             cta: { text: 'Get in touch', href: '#visit' },
         },
         footer: {
@@ -422,6 +433,25 @@ export function deriveContentDefaults(
             // so [] renders no note row).
             notes: name ? [`© ${new Date().getFullYear()} ${name}`] : [],
         },
+        // The CANONICAL menu, complete on purpose — not the menu that ships.
+        //
+        // Corollary 2 at the top of this file says an answer may only promise
+        // what the same submission guarantees, and a nav link is a promise
+        // like any other: every entry here names a section that auto-hides
+        // when the business supplied nothing for it, so on a sparse site four
+        // of these five scrolled nowhere. They are filtered — together with
+        // `hero.cta2`'s '#services' and `ctaBand.cta`'s '#visit' — in
+        // lib/astro-builder.ts (see the anchor-liveness block in
+        // transformToAstroData), which is the only layer that can: this
+        // function is browser-safe tier 3 and never sees the AI's services /
+        // why / gallery items or the admin's visibility toggles.
+        //
+        // So the list stays whole HERE, and that is deliberate twice over:
+        // it is what the editor sidebar lists and lets admin edit (the
+        // sidebar reads this function directly), and a business that fills
+        // its sections in gets every link back with no further edit. Adding
+        // a sixth entry means teaching the builder's `deadAnchors` set about
+        // its target too, or it can only ever be dropped by the design guard.
         navbar_links: [
             { label: 'About',    href: '#about' },
             { label: 'Services', href: '#services' },

--- a/lib/services/groq.service.ts
+++ b/lib/services/groq.service.ts
@@ -70,6 +70,70 @@ ${safe}
 ${TRANSCRIPT_CLOSE}`
 }
 
+/**
+ * The grounding rule, interpolated verbatim into three of this file's four
+ * prompts: extractBusinessContent, generateConversionBlocks and
+ * generateGenericSections. `generateWebsite` is the exception — it never sees a
+ * transcript, only the already-extracted BusinessContent, so it carries its own
+ * CONTENT paragraph saying the same thing about the fields it does get. If you
+ * change the rule here, change that paragraph too; nothing enforces the pair.
+ *
+ * WHY one constant instead of a paragraph per prompt: what these prompts
+ * used to share was the failure. "If information is not mentioned, use
+ * reasonable defaults" told the model to invent, and the schema examples showed
+ * it what invented output looks like, so every downstream layer spent its time
+ * deleting content that was requested here. Stated once, the rule stays short —
+ * a bloated instruction block makes the model literal and terse, which is its
+ * own way of ruining the copy — and the prompts cannot drift apart again.
+ *
+ * The line it draws is deliberately NOT "only repeat the transcript". Inference
+ * is the job: "we also do LPG refills" is a service, "I check every order myself
+ * before it goes out" is a reason to choose them. Both examples have to be legal
+ * in every prompt that interpolates this block, which is why neither is about
+ * hours any more: the opening-hours example that used to lead here is banned
+ * outright by two of them ("NEVER reference hours of operation — Google handles
+ * those"), so the governing rule was demonstrating correct behaviour using the
+ * one thing the surrounding prompt forbids. What is banned is the unsaid — the
+ * credential, the price, the guarantee, the customer, the place, the date that
+ * nobody in this pipeline can check against reality.
+ *
+ * Hence "unsaid dates" and not "dates" in the ban list. The lead clause already
+ * scopes the whole line, but a flat noun in a ban list applies pressure of its
+ * own, and a date is the one item here the prompts openly ask for: trust.years
+ * wants a founding year, hero.meta1's own example is 'open since 2019',
+ * footer.notes wants '© year'. A business that said "we've been here since 2018"
+ * must not lose its trust line to a word.
+ *
+ * Prices, customers and service areas now sit under the same "unsaid" modifier,
+ * for the same reason and with one measurable consequence. Every one of them is
+ * also asked for somewhere: a quoted price is part of a service in the owner's
+ * own words, what regulars say is the ONLY legal source of a testimonial, and
+ * generateGenericSections asks for area.places in this very prompt. That last
+ * one is the one that renders. mergeShallow (lib/astro-builder.ts) skips only
+ * undefined/null/'', so a model that reads "no service areas" and returns
+ * `places: []` OVERRIDES derived.area.places = [city] — and a business that told
+ * us "deliver kami sa Mandaue, Lapu-Lapu, tapos minsan hanggang Consolacion"
+ * ends up with fewer places on the page than it would have had with no AI at all.
+ *
+ * The last two lines carry as much weight as the ban. A model reads an empty
+ * field as its own mistake and fills it, and a schema showing three array
+ * entries reads as a quota for three. Both have to be contradicted out loud or
+ * the model obeys the shape instead of the rule.
+ *
+ * The last line has to cut BOTH ways, and the second half of it is not padding.
+ * Collapsing those padded schema examples down to a single entry fixed the quota
+ * pressure and created the opposite one: "counts below are ceilings" read against
+ * a one-entry example says the ceiling is one, which would cap a sari-sari store
+ * that named five things it sells at one service. A rule that empties a field for
+ * a business that DID answer is the same bug as one that fills a field for a
+ * business that didn't — it just fails in the direction nobody is watching.
+ */
+const GROUNDING = `GROUNDING — the transcript is the only source:
+- INFER from what the owner said: "we also do LPG refills" is a service, "I check every order myself before it goes out" is a reason to choose them. Rephrase, condense, find their voice.
+- NEVER state what they did not say: no licences, awards, ratings, review counts or response-time promises, and no unsaid prices, customers, service areas or dates.
+- An empty field is CORRECT output, not a failure. Leave it "" or [] rather than write something plausible — the page hides what is empty.
+- Counts below are ceilings, not quotas, and a one-entry example is a shape, not a number: list every real one. Two real services beat four invented ones.`
+
 /* ────────────────────────────────────────────────────────────────────────────
  * FABRICATED-TESTIMONIAL GUARD
  *
@@ -512,24 +576,23 @@ export const groqService = {
 
 ${delimitTranscript(transcript, 'TRANSCRIPT')}
 
+${GROUNDING}
+
 Extract the following information in JSON format:
 {
-  "tagline": "A short, catchy tagline for the business (max 10 words)",
-  "about": "A compelling 2-3 sentence description of the business",
-  "services": ["Service 1", "Service 2", "Service 3"],
+  "tagline": "short tagline built from how the owner describes the place (max 10 words), or empty",
+  "about": "up to 3 sentences describing the business, drawn from the transcript",
+  "services": ["one entry per service the owner named, in their words"],
   "contact": {
-    "phone": "Phone number if mentioned",
-    "email": "Email if mentioned",
-    "address": "Physical address if mentioned"
+    "phone": "phone number if mentioned",
+    "email": "email if mentioned",
+    "address": "physical address if mentioned"
   },
-  "highlights": ["Key highlight 1", "Key highlight 2", "Key highlight 3"]
+  "highlights": ["one entry per reason the owner gives for choosing them"]
 }
 
 IMPORTANT:
-- If information is not mentioned, use reasonable defaults or leave empty
-- Make the tagline creative and memorable
-- Services should be clear and specific
-- Highlights should emphasize unique selling points
+- A tagline is memorable because it is specific to THIS business — never a line that would fit any shop of this type.
 - Return ONLY valid JSON, no additional text`
 
             const groq = getGroqClient()
@@ -561,27 +624,36 @@ IMPORTANT:
      */
     async generateWebsite(businessContent: BusinessContent, businessInfo: BusinessInfo): Promise<string> {
         try {
+            // An absent list is now valid extraction output — it is what "the owner
+            // never mentioned any" correctly looks like — and .join() on it threw
+            // before the prompt was ever built. The interface types these as
+            // required, but the value here is JSON.parse of model output.
+            const services = Array.isArray(businessContent.services) ? businessContent.services : []
+            const highlights = Array.isArray(businessContent.highlights) ? businessContent.highlights : []
+
             const prompt = `You are a professional web designer. Create a beautiful, modern, single-page website for this business.
 
 BUSINESS INFORMATION:
 Name: ${businessInfo.name}
 Type: ${businessInfo.type}
-Tagline: ${businessContent.tagline}
-About: ${businessContent.about}
-Services: ${businessContent.services.join(', ')}
-Contact: ${JSON.stringify(businessContent.contact)}
-Highlights: ${businessContent.highlights.join(', ')}
+Tagline: ${businessContent.tagline || ''}
+About: ${businessContent.about || ''}
+Services: ${services.join(', ')}
+Contact: ${JSON.stringify(businessContent.contact || {})}
+Highlights: ${highlights.join(', ')}
 
 Create a complete HTML page with:
 1. Modern, responsive design using Tailwind CSS (via CDN)
 2. Professional color scheme matching the business type
 3. Hero section with business name and tagline
-4. About section
-5. Services section with cards
-6. Highlights/Features section
+4. About section, when there is content for it
+5. Services section with cards, when services were named
+6. Highlights/Features section, when highlights were given
 7. Contact section
 8. Smooth animations and transitions
 9. Mobile-friendly layout
+
+CONTENT — the information above is the only source. A field that is blank means the business never told us: drop that section from the page rather than writing copy to fill it. A shorter true page is the goal. Never add prices, credentials, awards, guarantees, star ratings, review counts, or service areas of your own.
 
 TESTIMONIALS: only what the owner reported customers saying, in the content above. If it isn't there, leave the section out. Never invent a customer, a name, or a quote.
 
@@ -635,43 +707,25 @@ Type: ${businessInfo.type}
 Location: ${businessInfo.location}
 Owner: ${businessInfo.owner}
 
-OUTPUT — return ONLY a JSON object with these exact keys:
+${GROUNDING}
 
-For beauty/salon/spa businesses specifically, MAXIMIZE the trust block — those
-buyers vet credentials hard. Aim for 3+ licenses and 3+ memberships if even
-remotely plausible from the transcript (PRC cosmetology, DOH facility permit,
-brand-trained colourist, professional association membership, training school
-affiliation, awards). Same for credentials: 3-4 entries (Licensed · Trained
-· Insured · Awarded). Other categories can be sparser.
+Beauty/salon/spa buyers vet credentials hard, so surface every licence, permit, training or membership the owner DID mention. If they mentioned none, the trust block stays empty — that is a true answer about the business, and the page drops the block.
+
+OUTPUT — return ONLY a JSON object with these exact keys:
 
 {
   "trust": {
-    "years": "string or null (e.g. 'A house of beauty since 2018'; only if a founding year is mentioned)",
-    "licenses": ["short claim 1", "short claim 2", "short claim 3"] or [],
-    "memberships": ["short claim 1", "short claim 2"] or []
+    "years": "string or null (e.g. 'A house of beauty since 2018'; only if the owner gave a founding year)",
+    "licenses": ["short claim, one per licence or permit the owner named"] or [],
+    "memberships": ["short claim, one per membership the owner named"] or []
   },
-  "why": [
-    { "title": "5-7 word concrete claim", "body": "2 sentence proof, specific" },
-    { "title": "...", "body": "..." },
-    { "title": "...", "body": "..." }
-  ],
-  "how": [
-    { "step": "01", "title": "2-4 word step name", "body": "1-2 sentence specifics" },
-    { "step": "02", "title": "...", "body": "..." },
-    { "step": "03", "title": "...", "body": "..." },
-    { "step": "04", "title": "...", "body": "..." }
-  ],
+  "why": [up to 3 of { "title": "5-7 word concrete claim", "body": "2 sentence proof, specific" } — each resting on something the owner said] or [],
+  "how": [up to 4 of { "step": "01", "title": "2-4 word step name", "body": "1-2 sentence specifics" } — numbered "01" upward, only steps the owner described] or [],
   "testimonials": [up to 3 of { "quote": "1 sentence, the customer's words as the owner reported them", "context": "1-3 word context (e.g. 'monthly client')" }] or [],
-  "faq": [
-    { "q": "real customer question, 5-9 words", "a": "1-3 sentence direct answer" },
-    { "q": "...", "a": "..." },
-    { "q": "...", "a": "..." },
-    { "q": "...", "a": "..." },
-    { "q": "...", "a": "..." }
-  ],
+  "faq": [up to 5 of { "q": "real customer question, 5-9 words", "a": "1-3 sentence direct answer" } — ONLY questions the transcript actually answers] or [],
   "credentials": [
-    { "label": "1-3 word category", "detail": "specific credential" }
-  ],
+    { "label": "1-3 word category", "detail": "the credential the owner named" }
+  ] or [],
   "ctaBand": {
     "heading": "5-9 word closing call",
     "body": "1 sentence reinforcement",
@@ -688,7 +742,6 @@ HARD RULES (the page is one of hundreds — must stay maintenance-free):
 - NEVER name individual staff members.
 - NEVER reference hours of operation — Google handles those.
 - TESTIMONIALS: only what the owner reported customers saying, in the transcript. If it isn't there, return []. Never invent a customer or a quote — and never output a name: the owner is asked what regulars SAY, never who said it, so a name can only be made up.
-- Every claim must be supportable from the transcript — if the transcript doesn't mention licenses, return an empty array.
 - No "we offer X service" filler. Concrete, opinionated, founder-voiced.
 - Avoid emoji and exclamation marks.
 
@@ -751,52 +804,43 @@ Type: ${businessInfo.type}
 Location: ${businessInfo.location}
 Owner: ${businessInfo.owner}
 
+${GROUNDING}
+
 OUTPUT — return ONLY a JSON object with these exact keys:
 
 {
-  "marquee": { "text": "5-10 short words separated by spaces, no punctuation, evocative of this trade (e.g. 'Fresh roasted daily Single origin Pour over')" },
+  "marquee": { "text": "5-10 short words separated by spaces, no punctuation, drawn from what this business actually does (a coffee roaster's might read 'Fresh roasted daily Single origin Pour over')" },
   "hero": {
     "kicker": "12-20 char tagline (location · trade descriptor)",
     "headlineLines": ["line 1 (2-4 words)", "line 2 (2-4 words)", "line 3 (1-3 words; may include <em>highlight</em>)"],
     "sub": "1-2 sentence elevator pitch in the founder's voice",
     "cta1": { "text": "2-3 word button (e.g. 'Visit us')",        "href": "#visit" },
     "cta2": { "text": "2-3 word secondary (e.g. 'See services')", "href": "#services" },
-    "meta1": "one checkable fact from the transcript ('open since 2019', 'cash or GCash') — NEVER a star line, a rating, or a review count: nobody in this pipeline can verify one, so it can only be made up",
-    "meta2": "second meta line ('open daily · address')"
+    "meta1": "one checkable fact from the transcript ('open since 2019', 'cash or GCash'), or empty when the transcript holds none — and NEVER a star line, a rating, or a review count: nobody in this pipeline can verify one, so it can only be made up",
+    "meta2": "second checkable fact ('cash or GCash', 'parking out front', the address), or empty — the HARD RULE against hours applies here too"
   },
   "about": {
     "tag": "2-3 word eyebrow ('Our story')",
     "headline": "8-14 word headline; may include <em>highlight</em>",
     "lead": "1-2 sentence lead paragraph in the founder's voice",
-    "signature": "5-9 word signature line (e.g. 'Pour by pour, since 2014.')",
-    "paragraphs": ["1-2 sentences", "1-2 sentences"]
+    "signature": "5-9 word signature line (e.g. 'Pour by pour, every single morning.')",
+    "paragraphs": ["1-2 sentences — one entry per point the owner actually made about the place"] or []
   },
   "services": {
     "tag": "What we offer / What we do",
     "headline": "5-10 word section headline",
-    "items": [
-      { "title": "2-4 word service name", "desc": "1-2 sentence value prop", "note": "1-3 word meta (e.g. 'walk-in · to-go')" },
-      { "title": "...", "desc": "...", "note": "..." },
-      { "title": "...", "desc": "...", "note": "..." },
-      { "title": "...", "desc": "...", "note": "..." }
-    ]
+    "items": [up to 4 of { "title": "2-4 word service name", "desc": "1-2 sentence value prop", "note": "1-3 word meta (e.g. 'walk-in · to-go'), or omit" } — ONE entry per service the owner actually named, never padded to fill the grid] or []
   },
   "gallery": {
     "tag": "2-3 word eyebrow ('Inside the shop')",
     "headline": "3-6 word headline",
-    "items": [
-      { "caption": "2-4 word caption" },
-      { "caption": "..." },
-      { "caption": "..." },
-      { "caption": "..." },
-      { "caption": "..." }
-    ]
+    "items": [up to 5 of { "caption": "2-4 word caption" } — captioning only things the owner described] or []
   },
   "area": {
     "tag": "2-3 word eyebrow ('Where we serve')",
     "headline": "4-8 word headline",
-    "body": "1 sentence describing the area",
-    "places": ["neighborhood/city 1", "neighborhood/city 2", "neighborhood/city 3", "neighborhood/city 4", "neighborhood/city 5", "neighborhood/city 6"]
+    "body": "1 sentence describing the area, or empty",
+    "places": ["only neighbourhoods, cities or barangays the owner named — [] if they named none, never the ones that merely sound nearby"]
   },
   "location": {
     "tag": "2-3 word eyebrow ('Come by')",
@@ -823,7 +867,6 @@ HARD RULES:
 - NEVER reference operating hours (Google handles those).
 - Use real, opinionated copy. Avoid generic SaaS phrasing.
 - No emoji. No exclamation marks. Sparing <em>highlights</em> in headlines only.
-- Every claim must be supportable from the transcript.
 
 Return ONLY the JSON object, no markdown fence, no commentary.`
 


### PR DESCRIPTION
#289 deleted invented content from 299 template files. This deletes the thing that was asking for it.

## The prompt was the problem

`lib/services/groq.service.ts` put this in the extraction prompt's own schema example:

```json
"services": ["Service 1", "Service 2", "Service 3"],
"highlights": ["Key highlight 1", "Key highlight 2", "Key highlight 3"]
```

and then, in the rules beneath it:

> If information is not mentioned, **use reasonable defaults** or leave empty

So the step that reads a business owner's interview was *shown* placeholder output and *told* to invent. A schema example is an instruction — the model reproduces its shape and often its content.

One block went further. For salons it said to aim for **"3+ licenses and 3+ memberships if even remotely plausible from the transcript"**, and handed over the menu: *PRC cosmetology, DOH facility permit, brand-trained colourist, professional association membership*. That is regulatory credentials, invented, on a real business's live site. It contradicted a HARD RULE 50 lines below it in the same prompt.

## What replaces it

One shared `GROUNDING` constant instead of four drifting copies, net **shorter** than what it replaced — a bloated instruction block makes the model literal and terse, which ruins the copy its own way:

- **INFER** from what the owner said — *"we also do LPG refills"* is a service. Rephrase, condense, find their voice.
- **NEVER state what they did not say** — no licences, awards, ratings, review counts or response-time promises, and no unsaid prices, customers, service areas or dates.
- **An empty field is CORRECT output, not a failure.** A model reads a blank as its own mistake and fills it; that has to be contradicted out loud.
- **Counts are ceilings, not quotas.** A one-entry example is a shape, not a number.

Also deleted, all pure invention:

| Removed | What it did |
|---|---|
| `generateDefaultFeaturedProducts` | Invented entire projects — *"Complete Kitchen Renovation"*, *"We transformed the heart of X"* — and attributed praise to five recycled names. The guard stripped the quotes but **not the projects**, and on a business that *did* supply testimonials the guard stood down and the names shipped too. |
| `Service 1/2/3` + `['Quality','Reliability','Service']` | A service menu and a quality claim published for an owner who listed neither |
| `contact@example.com`, `+63 900 000 0000` | A number that reaches nobody, printed as a paying customer's own contact details |
| footer blurb, *"some of our recent work"* | Agency copy, and a claim that recent work exists |

## The counter-rule

Emptying a field for a business that **did** answer is the same bug, failing where nobody looks. Guarded deliberately:

- A salon owner who names nine services gets nine. The cap is *"a ceiling on padding, not a quota to reach"*.
- *"unsaid dates"*, not *"dates"* — a business that says **"we've been here since 2018"** keeps its trust line.
- Service names key on **provenance, not surprise**. A laundry that says *"labada, dry cleaning, at press"* keeps `Labada`; the old wording pushed it toward something cleverer and wrong.

## Three things this surfaced

**A 500.** `content.services?.slice(0, 3)` guards only a *nullish* services; on the wrapped `{tag, headline, items[]}` shape it resolved `.slice` to `undefined` and called it. Letting extraction omit `services` made that shape reachable for the first time. The throw preceded the DB write, so the transcript stayed changed and **every retry failed identically** — a permanently stuck submission. Two siblings of the same shape came with it.

**A re-extraction loop.** The old gate re-ran extraction until the model produced enough tiles to fill a grid, replacing `extractedContent` wholesale each time — so an admin who trimmed a padded list down to the truth had it re-padded on the next regenerate. The replacement can't ask *"does the output look empty"*, since `GROUNDING` makes empty legitimate; it fingerprints the transcript and asks whether we have already read **this** one. Rows with no marker **adopt** rather than re-extract, which is what makes it safe against the rows already in production.

**Silent loss of admin work.** A transcript change replaced everything but contact — including testimonials an admin typed, which carry `ADMIN_ATTRIBUTION_KEY` and are the guard's entire escape hatch. The trigger was not only a deliberate edit: *"regenerate transcription"* re-runs Whisper, and **Whisper is non-deterministic on identical audio**. The loss then landed later, on the next Save. A preserve-list now keeps what only a human can write, calling the guard's own function with `keepAdminAuthored` so it cannot resurrect model output.

Plus the visible cost of honest emptiness: sections that correctly disappear no longer leave nav links and CTAs pointing at them.

## Verification

Executed, not argued. The real exported `transformToAstroData` was driven against `origin/main`'s version with a recursive whole-object differ across 20 payloads:

- **fully-populated realistic site → byte-identical**, zero changed paths. Same for admin-rewritten nav and admin-deleted nav.
- **wrapped-services payload → `main` throws `TypeError: _x.slice is not a function`; this branch returns successfully.**
- Preserve-list traced across typed-only / machine-only / both: typed quotes survive, machine quotes carry nothing.
- Convergence traced over 8 route scenarios × 3 successive POSTs — all converge on the second and stay converged.

`npx tsc --noEmit` clean. **327/327 tests** (323 + 4 new covering the guard's escape hatch).

## Known, deliberately not fixed here

Both pre-date this branch and need a product call:

- The flat `services` array and the `about` string **never reach any template** — `mergeShallow` discards a string `about`, and a flat array yields `items: []`. Some of this branch's new wording therefore changes less on the page than it should.
- The `trust` block the prompt fills (`years`/`licenses`/`memberships`) is read by nothing; templates gate on `trust.cells`. Fails safe, but the salon-credentials case cannot work.

## After merge

This changes what a **generate** produces. It does not change what is already deployed — `publish-website` ships the HTML stored at generate time and never rebuilds. The live sites need a deliberate **regenerate + republish**, which is worth doing after this lands rather than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
