### PR TITLE
Point canonical at the host that actually serves the site

### DIFF
--- a/app/api/send-website-email/route.ts
+++ b/app/api/send-website-email/route.ts
@@ -5,6 +5,7 @@ import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { sendPaymentLinkEmail } from '@/lib/email/service'
 import { getPaymentConfig } from '@/lib/payment/config'
+import { SITE_URL } from '@/lib/seo'
 
 /**
  * Send payment link to business owner via email (replaces old approval email)
@@ -97,10 +98,11 @@ export async function POST(request: NextRequest) {
             const claim = await fetchMutation(api.businessOwners.issueClaimTokenForEmail, {
                 submissionId: submissionId as Id<"submissions">,
             })
-            const base = process.env.NEXT_PUBLIC_SITE_URL?.startsWith('https://')
-                ? process.env.NEXT_PUBLIC_SITE_URL.replace(/\/$/, '')
-                : 'https://tendso.com'
-            editMyWebsiteUrl = `${base}/my-business/claim?token=${claim.token}`
+            // SITE_URL, not a second hand-rolled copy of the same env read. The
+            // duplicate here had drifted to the bare apex, so a claim link mailed
+            // to a business owner spent a 308 getting to the host that would
+            // actually honour it. One definition, in lib/seo.ts, with the reason.
+            editMyWebsiteUrl = `${SITE_URL}/my-business/claim?token=${claim.token}`
         } catch (e) {
             console.error('Failed to mint owner claim token (non-fatal):', e)
         }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -5,8 +5,22 @@
  * and server components alike. Render the output with <JsonLd> (see jsonLd.tsx)
  * or a native <script type="application/ld+json">.
  *
- * CANONICAL DOMAIN: tendso.com (platform migrated 2026-06). The plan doc assumed
- * tendso.app — that's wrong; every @id/canonical here uses tendso.com.
+ * CANONICAL DOMAIN: www.tendso.com (platform migrated 2026-06; the plan doc
+ * assumed tendso.app — that's wrong).
+ *
+ * The `www` is load-bearing, not cosmetic. Vercel serves the site on
+ * www.tendso.com and 308s the bare apex to it, so www is the origin a visitor
+ * actually lands on. This fallback used to say `https://tendso.com`, which made
+ * every canonical, og:url and sitemap <loc> on the site name an address that
+ * immediately redirects somewhere else — a page served at www declaring that
+ * the real version lives at an apex that points straight back. Crawlers resolve
+ * it, but they resolve it by ignoring what we told them, and every sitemap URL
+ * costs a redirect hop to fetch.
+ *
+ * So the value here must match wherever the site is actually served. If the
+ * apex↔www decision is ever reversed in the Vercel domain settings, change this
+ * line in the same breath — nothing in the build detects the mismatch.
+ *
  * Override with NEXT_PUBLIC_SITE_URL only if it's a real https origin (the dev
  * default localhost:3000 is ignored for canonical/schema, which must be absolute
  * production URLs).
@@ -14,7 +28,7 @@
 
 const ENV_URL = process.env.NEXT_PUBLIC_SITE_URL;
 export const SITE_URL =
-    ENV_URL && ENV_URL.startsWith('https://') ? ENV_URL.replace(/\/$/, '') : 'https://tendso.com';
+    ENV_URL && ENV_URL.startsWith('https://') ? ENV_URL.replace(/\/$/, '') : 'https://www.tendso.com';
 
 export const ORG_ID = `${SITE_URL}/#organization`;
 export const WEBSITE_ID = `${SITE_URL}/#website`;


### PR DESCRIPTION
`SITE_URL` fell back to `https://tendso.com`. Vercel serves the site on **`www.tendso.com`** and 308s the bare apex to it — so the whole site was declaring an address that immediately redirects somewhere else.

`robots.ts`, `sitemap.ts` and every canonical / `og:url` read that one constant, so it was all of them at once.

## Live on production right now

```
<link rel="canonical" href="https://tendso.com">        ← page is served at www
<meta property="og:url" content="https://tendso.com">

robots.txt    Host: https://tendso.com
              Sitemap: https://tendso.com/sitemap.xml

sitemap.xml   all 11 <loc> entries on the apex — every one a 308
```

Verified with `curl`: `https://tendso.com/sitemap.xml` → `308 → https://www.tendso.com/sitemap.xml`.

A page served at www telling crawlers the canonical version lives at an apex that points straight back at www. They resolve it, but they resolve it by **ignoring what we told them** — and #288 only just made the sitemap reachable, so every URL in it became a redirect hop the moment anything started reading it.

## www was always the intent

[lib/email/templates.ts:472](../blob/main/lib/email/templates.ts#L472) already links `https://www.tendso.com/contact`. Only the SEO constant disagreed. This makes the code match where the site is actually served, and adds a note that the two must move together — nothing in the build detects the mismatch.

## Second fix: a customer-facing link

[app/api/send-website-email/route.ts](../blob/main/app/api/send-website-email/route.ts) hand-rolled its own copy of the same env read, and that copy had drifted to the apex as well. So the **"Edit my website"** claim link mailed to a business owner spent a 308 getting to the host that would honour its token. Now folded into `SITE_URL` — one definition, with the reason attached.

## ⚠️ This may be inert without a Vercel change

`NEXT_PUBLIC_SITE_URL` overrides the fallback. I couldn't check its value — the repo isn't linked to the Vercel project (`vercel env ls` errors out).

**Worth a 10-second look in the Vercel dashboard:**

| If `NEXT_PUBLIC_SITE_URL` is… | Action |
|---|---|
| unset | nothing to do — this PR fixes it |
| `https://tendso.com` | **change to `https://www.tendso.com` or delete it**, or this PR does nothing |
| `https://www.tendso.com` | already fine, this PR just makes the fallback agree |

## Also worth checking, not in this PR

`lib/services/auth.service.ts:135` falls back to `http://localhost:3000/auth/callback` when `NEXT_PUBLIC_SITE_URL` is unset. If it *is* unset in production, that fallback is live there. It looks like legacy Supabase auth (the platform is on Clerk), so it may well be dead code — but it's the one other place that reads the same variable without a production-safe default.

And if `tendso.com` is verified in Google Search Console as a **URL-prefix** property rather than a **Domain** property, the www host needs verifying too, or the sitemap's new URLs land outside the verified property.

## Verification

`npx tsc --noEmit` clean. No behavioural change beyond the URL each helper emits; both changed values were already what every other surface used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
