### PR TITLE
fix: "Not authenticated" on the certification quiz — stop losing the creator, and say why

### DIFF
--- a/app/certification-quiz/page.tsx
+++ b/app/certification-quiz/page.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useUser } from "@clerk/nextjs"
-import { useQuery, useMutation } from "convex/react"
+import { useQuery, useMutation, useConvexAuth } from "convex/react"
 import { api } from "@/convex/_generated/api"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
 import Logo from "@/public/tendso-logo.png"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft, Loader2, CheckCircle, XCircle, Trophy, RotateCcw, Award } from "lucide-react"
+import { ArrowLeft, Loader2, CheckCircle, XCircle, Trophy, RotateCcw, Award, AlertTriangle } from "lucide-react"
 
 const QUIZ_QUESTIONS = [
     {
@@ -117,14 +117,29 @@ export default function CertificationQuizPage() {
     // approval), matching mobile — NOT auto-certified. Admin approves in
     // /admin/pending-approvals, which sets certifiedAt and releases the gate.
     const markQuizPassed = useMutation(api.creators.markQuizPassed)
+    // markQuizPassed is identity-scoped: it throws "Not authenticated" unless the
+    // Convex socket carries a Clerk token. Clerk's own `isLoaded`/`user` say nothing
+    // about that — the socket can drop its token mid-quiz while Clerk still reports a
+    // signed-in user — so we read Convex's view of auth too. Used ONLY to explain the
+    // failure and to auto-retry; never to gate the quiz. `isAuthenticated` settles to
+    // false (not "loading") when the token pipeline is broken, so gating on it would
+    // lock every creator out of finishing instead of just failing loudly.
+    const { isAuthenticated } = useConvexAuth()
 
     const [currentQ, setCurrentQ] = useState(0)
     const [selected, setSelected] = useState<number | null>(null)
     const [answered, setAnswered] = useState(false)
     const [answers, setAnswers] = useState<number[]>([])
-    const [phase, setPhase] = useState<"quiz" | "pass" | "fail">("quiz")
+    const [phase, setPhase] = useState<"quiz" | "pass" | "fail" | "saveFailed">("quiz")
     const [certifying, setCertifying] = useState(false)
     const [passAnimated, setPassAnimated] = useState(false)
+    const [saveError, setSaveError] = useState<string | null>(null)
+
+    // Set when the save failed while the Convex socket was unauthenticated — i.e. the
+    // failure is one that reconnecting can fix. Refs, not state: they must not trigger
+    // a render, and the one-shot flag must survive the retry that reads it.
+    const failedWhileSignedOutRef = useRef(false)
+    const autoRetriedRef = useRef(false)
 
     useEffect(() => {
         if (isLoaded && !user) router.push("/login")
@@ -134,6 +149,53 @@ export default function CertificationQuizPage() {
     useEffect(() => {
         if (creator && creator.role === 'admin') router.push("/admin")
     }, [creator, router])
+
+    /**
+     * Record the pass. Only advances to the "pass" screen once the write actually
+     * lands, because `quizPassedAt` is the ONLY thing that puts a creator into the
+     * admin approval queue (creators.listPendingApproval filters on it, as does the
+     * Discord poll cron). Nothing else in the app can set it afterwards — so a
+     * swallowed failure here used to strand the creator permanently: they saw
+     * "your application is now under review", pressed Continue, and /pending bounced
+     * them straight back to /training with no explanation and no way to recover.
+     *
+     * Safe to call repeatedly — the mutation returns early if quizPassedAt or
+     * certifiedAt is already set.
+     */
+    const submitPass = useCallback(async () => {
+        if (!creator?._id) {
+            setSaveError("We couldn't load your creator profile.")
+            failedWhileSignedOutRef.current = !isAuthenticated
+            setPhase("saveFailed")
+            return
+        }
+        setCertifying(true)
+        try {
+            await markQuizPassed({ id: creator._id })
+            setSaveError(null)
+            setPhase("pass")
+            setTimeout(() => setPassAnimated(true), 50)
+        } catch (e) {
+            console.error("Marking quiz passed failed:", e)
+            setSaveError(e instanceof Error ? e.message : String(e))
+            failedWhileSignedOutRef.current = !isAuthenticated
+            setPhase("saveFailed")
+        } finally {
+            setCertifying(false)
+        }
+    }, [creator?._id, markQuizPassed, isAuthenticated])
+
+    // Self-heal the common case: the socket lost its token for a moment and gets it
+    // back a second later. Retry once, silently, so a creator who is staring at the
+    // error screen doesn't have to do anything. One-shot — if the retry also fails,
+    // the screen's own "Try again" button takes over rather than looping.
+    useEffect(() => {
+        if (phase !== "saveFailed" || certifying) return
+        if (!failedWhileSignedOutRef.current || !isAuthenticated) return
+        if (autoRetriedRef.current) return
+        autoRetriedRef.current = true
+        void submitPass()
+    }, [phase, certifying, isAuthenticated, submitPass])
 
     if (!isLoaded || creator === undefined) {
         return (
@@ -167,15 +229,7 @@ export default function CertificationQuizPage() {
         } else {
             const score = newAnswers.filter((a, i) => a === QUIZ_QUESTIONS[i].correctIndex).length
             if (score >= 4) {
-                setCertifying(true)
-                try {
-                    if (creator?._id) await markQuizPassed({ id: creator._id })
-                } catch (e) {
-                    console.error("Marking quiz passed failed:", e)
-                }
-                setCertifying(false)
-                setPhase("pass")
-                setTimeout(() => setPassAnimated(true), 50)
+                await submitPass()
             } else {
                 setPhase("fail")
             }
@@ -224,6 +278,50 @@ export default function CertificationQuizPage() {
                         Continue
                     </Button>
                 </div>
+            </div>
+        )
+    }
+
+    // ==================== SAVE-FAILED SCREEN ====================
+    // They passed, but the result never reached the server. Say so plainly instead of
+    // showing the pass screen — a creator who believes they're under review when no
+    // record exists has no way of ever finding out otherwise.
+    if (phase === "saveFailed") {
+        return (
+            <div
+                className="editorial min-h-screen flex flex-col items-center justify-center px-4 text-center"
+                style={{ background: "var(--ed-paper)", color: "var(--ed-ink)", fontFamily: "var(--ed-sans)" }}
+            >
+                <div className="w-20 h-20 bg-amber-50 rounded-full flex items-center justify-center mb-6">
+                    <AlertTriangle className="w-10 h-10 text-amber-500" />
+                </div>
+                <h1 className="text-2xl font-bold text-zinc-900 mb-2">We couldn&apos;t save your result</h1>
+                <p className="text-zinc-500 mb-4 max-w-sm">
+                    You scored <span className="font-bold text-amber-600">{finalScore}/5</span> — that&apos;s a pass. But your
+                    result didn&apos;t reach us, so your application hasn&apos;t gone for review yet.
+                </p>
+                {!isAuthenticated && (
+                    <p className="text-zinc-500 mb-4 max-w-sm text-sm">
+                        Your session isn&apos;t connected to the server right now. Trying again usually fixes it.
+                    </p>
+                )}
+                {saveError && (
+                    <p className="text-[11px] text-zinc-400 mb-8 max-w-sm break-words">{saveError}</p>
+                )}
+                <Button
+                    onClick={() => { void submitPass() }}
+                    disabled={certifying}
+                    className="w-full max-w-xs h-12 bg-amber-500 hover:bg-amber-600 text-white font-semibold rounded-xl"
+                >
+                    {certifying ? <Loader2 className="h-5 w-5 animate-spin" /> : "Try again"}
+                </Button>
+                <p className="mt-4 text-xs text-zinc-500">
+                    Still stuck?{" "}
+                    <Link href="/contact" className="underline font-medium text-zinc-700">
+                        Contact us
+                    </Link>{" "}
+                    and we&apos;ll sort it out for you.
+                </p>
             </div>
         )
     }

--- a/app/certification-quiz/page.tsx
+++ b/app/certification-quiz/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useUser } from "@clerk/nextjs"
 import { useQuery, useMutation, useConvexAuth } from "convex/react"
+import { ConvexError } from "convex/values"
 import { api } from "@/convex/_generated/api"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
@@ -177,7 +178,17 @@ export default function CertificationQuizPage() {
             setTimeout(() => setPassAnimated(true), 50)
         } catch (e) {
             console.error("Marking quiz passed failed:", e)
-            setSaveError(e instanceof Error ? e.message : String(e))
+            // Prefer ConvexError.data: it's the clean sentence the backend meant to
+            // send. `e.message` wraps it in the client's own stacktrace preamble
+            // ("[CONVEX M(creators:markQuizPassed)] [Request ID: …] … Called by
+            // client"), which is noise to a creator.
+            setSaveError(
+                e instanceof ConvexError && typeof e.data === "string"
+                    ? e.data
+                    : e instanceof Error
+                        ? e.message
+                        : String(e)
+            )
             failedWhileSignedOutRef.current = !isAuthenticated
             setPhase("saveFailed")
         } finally {

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -1,6 +1,7 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { query, mutation } from './_generated/server';
 import { internal } from './_generated/api';
+import { ADMIN_REQUIRED } from './lib/auth';
 import { PRICE_CEILING, UNLOCK_THRESHOLD } from '../lib/pricing';
 
 // Submission statuses that count as "approved or beyond" for the price-tier
@@ -461,7 +462,7 @@ export const markPaid = mutation({
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.adminId))
             .first();
-        if (!actor || actor.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!actor || actor.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         // Delegate to shared credit logic (also used by auto-payment webhook)
         await ctx.scheduler.runAfter(0, internal.payments.creditCreatorForPayment, {
@@ -663,7 +664,7 @@ export const deleteCreatorRecords = mutation({
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.adminId))
             .first();
-        if (!actor || actor.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!actor || actor.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const creator = await ctx.db.get(args.creatorId);
         if (!creator) throw new Error('Creator not found');

--- a/convex/businessOwners.ts
+++ b/convex/businessOwners.ts
@@ -1,5 +1,6 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { query, mutation, internalMutation } from './_generated/server';
+import { ADMIN_REQUIRED, NOT_AUTHENTICATED } from './lib/auth';
 import type { QueryCtx, MutationCtx } from './_generated/server';
 import type { Doc, Id } from './_generated/dataModel';
 import {
@@ -46,7 +47,7 @@ async function requireOwnership(
         .withIndex('by_submission', (q) => q.eq('submissionId', submissionId))
         .filter((q) => q.eq(q.field('businessOwnerId'), owner._id))
         .first();
-    if (!link) throw new Error('Forbidden: you do not own this website');
+    if (!link) throw new ConvexError('Forbidden: you do not own this website');
     return owner;
 }
 
@@ -145,12 +146,12 @@ export const issueClaimTokenForEmail = mutation({
     args: { submissionId: v.id('submissions') },
     handler: async (ctx, args): Promise<{ token: string }> => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
             .first();
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
         return await mintClaimToken(ctx, args.submissionId);
     },
 });

--- a/convex/creators.ts
+++ b/convex/creators.ts
@@ -1,7 +1,7 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { query, mutation, internalQuery, internalMutation } from './_generated/server';
 import { internal } from './_generated/api';
-import { requireAuth } from './lib/auth';
+import { requireAuth, ADMIN_REQUIRED, NOT_AUTHENTICATED } from './lib/auth';
 
 // ==================== QUERIES ====================
 
@@ -120,7 +120,7 @@ export const deleteAccount = mutation({
         const creator = await ctx.db.get(args.id);
         if (!creator) throw new Error('Creator not found');
         if (creator.clerkId !== identity.subject) {
-            throw new Error('Forbidden: you can only delete your own account');
+            throw new ConvexError('Forbidden: you can only delete your own account');
         }
         if (creator.isDeleted) throw new Error('Account is already deleted');
 
@@ -463,10 +463,10 @@ export const markQuizPassed = mutation({
     args: { id: v.id('creators') },
     handler: async (ctx, args) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const creator = await ctx.db.get(args.id);
         if (!creator || creator.clerkId !== identity.subject) {
-            throw new Error('Forbidden: you can only update your own account');
+            throw new ConvexError('Forbidden: you can only update your own account');
         }
         if (creator.certifiedAt) return;
         if (creator.quizPassedAt) return;
@@ -490,12 +490,12 @@ export const approveCreator = mutation({
     args: { id: v.id('creators') },
     handler: async (ctx, args) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
             .first();
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const creator = await ctx.db.get(args.id);
         if (!creator) throw new Error('Creator not found');
@@ -523,12 +523,12 @@ export const listPendingApproval = query({
     args: {},
     handler: async (ctx) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
             .first();
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const all = await ctx.db.query('creators').collect();
         return all
@@ -582,12 +582,12 @@ export const rejectCreator = mutation({
     },
     handler: async (ctx, args) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
             .first();
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const creator = await ctx.db.get(args.id);
         if (!creator) throw new Error('Creator not found');
@@ -701,10 +701,10 @@ export const requestRecertification = mutation({
     args: { id: v.id('creators') },
     handler: async (ctx, args) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const creator = await ctx.db.get(args.id);
         if (!creator || creator.clerkId !== identity.subject) {
-            throw new Error('Forbidden: you can only update your own account');
+            throw new ConvexError('Forbidden: you can only update your own account');
         }
         if (!creator.rejectedAt) {
             throw new Error('Only rejected creators can request recertification');
@@ -730,12 +730,12 @@ export const listRejected = query({
     args: {},
     handler: async (ctx) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
             .first();
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const all = await ctx.db.query('creators').collect();
         return all

--- a/convex/leadNotes.ts
+++ b/convex/leadNotes.ts
@@ -1,5 +1,6 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { query, mutation } from './_generated/server';
+import { NOT_AUTHENTICATED } from './lib/auth';
 
 // ==================== MUTATIONS ====================
 
@@ -35,7 +36,7 @@ export const add = mutation({
     },
     handler: async (ctx, args) => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const creator = await ctx.db
             .query('creators')
             .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -1,6 +1,7 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { query, mutation, action, internalQuery, internalMutation } from './_generated/server';
 import { internal } from './_generated/api';
+import { ADMIN_REQUIRED, NOT_AUTHENTICATED } from './lib/auth';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { normalizePhone } from './lib/phone';
@@ -249,7 +250,7 @@ export const getCountBySubmission = query({
 // ============================================================================
 async function requireIdentity(ctx: any) {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error('Not authenticated');
+    if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
     return identity;
 }
 
@@ -259,7 +260,7 @@ async function requireAdminIdentity(ctx: any) {
         .query('creators')
         .withIndex('by_clerk_id', (q: any) => q.eq('clerkId', identity.subject))
         .first();
-    if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+    if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
     return identity;
 }
 
@@ -839,11 +840,11 @@ export const generatePreviewImageUploadUrl = action({
         // Action-context auth: query the admin role via internal query is overkill,
         // so we resolve the calling identity + look it up directly.
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
         const me = await ctx.runQuery(internal.leads.getCreatorRoleByClerkIdInternal, {
             clerkId: identity.subject,
         });
-        if (!me || me.role !== 'admin') throw new Error('Forbidden: admin access required');
+        if (!me || me.role !== 'admin') throw new ConvexError(ADMIN_REQUIRED);
 
         const validation = validatePreviewImageUploadArgs({
             mimeType: args.mimeType,
@@ -970,7 +971,7 @@ export const geocodePendingSubmissions = action({
         failed: number;
     }> => {
         const identity = await ctx.auth.getUserIdentity();
-        if (!identity) throw new Error('Not authenticated');
+        if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
 
         // Fetch pending submissions (address but no coordinates) via an
         // internal query. We cap at `limit` to keep each invocation bounded.

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from "convex/values";
 import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
 
 /**
@@ -8,6 +9,41 @@ import type { ActionCtx, MutationCtx, QueryCtx } from "../_generated/server";
  * can't read DB directly. For action callers we hop through the Convex API
  * (`ctx.runQuery`) to look up the creator record.
  */
+
+/**
+ * Auth failures are thrown as ConvexError, never as a plain Error.
+ *
+ * A production deployment redacts the MESSAGE of every server throw — the
+ * client gets "[Request ID: …] Server Error" and nothing more. A ConvexError's
+ * `data` is the sole exception: it crosses to the client verbatim. Same note
+ * as app/start/page.tsx.
+ *
+ * This is not cosmetic. When creators:markQuizPassed hit an unauthenticated
+ * socket in prod, the mobile app could only show the creator an alert reading
+ * "Server Error" — no hint that signing out and back in would fix it. Now the
+ * reason is at least *available*, on `error.data`.
+ *
+ * Availability is not delivery, and the message stays redacted either way, so
+ * a client only benefits once it reads `.data`:
+ *
+ *     error instanceof ConvexError && typeof error.data === "string"
+ *         ? error.data
+ *         : "Something went wrong."
+ *
+ * The web reads it (app/certification-quiz/page.tsx, app/start/page.tsx). The
+ * MOBILE APP DOES NOT YET — ndm/app/(app)/certification-quiz.tsx alerts
+ * `err?.message`, and providers/AppProviders.tsx decides whether to offer its
+ * auth-recovery screen by testing /not authenticated/i against `err.message`,
+ * which on a production build is always the redacted string. Until those move
+ * to `.data`, the phone still shows "Server Error" and that recovery screen
+ * still cannot fire in prod.
+ *
+ * Keep the literal words "Not authenticated" at the START of NOT_AUTHENTICATED
+ * — that is what the mobile recovery screen matches on once it reads `.data`.
+ */
+export const NOT_AUTHENTICATED =
+    "Not authenticated — your session could not be verified. Sign out and back in, then try again.";
+export const ADMIN_REQUIRED = "Forbidden: admin access required";
 
 type AnyCtx = QueryCtx | MutationCtx | ActionCtx;
 
@@ -21,7 +57,7 @@ function isActionCtx(ctx: AnyCtx): ctx is ActionCtx {
  */
 export async function requireAuth(ctx: AnyCtx) {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+    if (!identity) throw new ConvexError(NOT_AUTHENTICATED);
     return identity;
 }
 
@@ -50,7 +86,7 @@ export async function requireAdmin(ctx: AnyCtx) {
     }
 
     if (!me || me.role !== "admin") {
-        throw new Error("Forbidden: admin access required");
+        throw new ConvexError(ADMIN_REQUIRED);
     }
     return { identity, me };
 }


### PR DESCRIPTION
## The incident

Production Convex log, deployment `energetic-panther-693`, request `923cc09faad685e0`:

```
creators:markQuizPassed   caller: SyncWorker   identityType: "unknown"
Uncaught Error: Not authenticated at handler (../convex/creators.ts:466:30)
```

A creator finished the certification quiz on the **mobile** app, tapped "Submit for review", and got an alert reading `[CONVEX M(creators:markQuizPassed)] [Request ID: 923cc09faad685e0] Server Error`.

**The server guard is correct and is unchanged.** In the same 45-minute window 248 calls carried a real identity, including one *successful* `markQuizPassed`. Nothing is misconfigured either — mobile's `production` EAS profile pairs prod Convex with `pk_live_…clerk.tendso.com`, and prod's `CLERK_JWT_ISSUER_DOMAIN` is exactly that issuer. One handset's socket lost its Clerk token. That will happen again.

Two things made it worse than it needed to be.

## 1. The web page turned a recoverable failure into a permanent one

`app/certification-quiz/page.tsx` swallowed the throw into `console.error` and showed the pass screen regardless — *"your application is now under review."* It wasn't.

`quizPassedAt` is the only thing that puts a creator in front of an admin: `listPendingApproval`, the admin badge and the Discord poll cron all filter on it, and nothing else in the app can set it. So the creator went invisible, pressed Continue, and `/pending` bounced them back to `/training` with no explanation. Un-stranding one takes a hand-edit in the Convex dashboard.

Now the pass screen is reached only once the write lands. Otherwise: keep the score on screen, say the result hasn't gone for review, offer **Try again** (the mutation returns early if `quizPassedAt`/`certifiedAt` is set, so retrying is free), retry once automatically when the socket reports itself authenticated again, and link to `/contact` if it stays broken.

`useConvexAuth` is read for the message and the retry **only, never as a gate** — it settles to `false` rather than staying pending when the token pipeline is properly broken, so gating the quiz on it would lock every creator out of finishing. Worse than the bug.

## 2. The backend destroyed the reason in transit

A production deployment redacts the message of every server throw. We threw `new Error('Not authenticated')`, so the one person who could act on it — the creator, by signing out and back in — was told `Server Error`.

A `ConvexError`'s `data` is the sole exception: it crosses verbatim. Every auth and permission throw in `convex/` is now a `ConvexError`, with the two shared messages defined once in `convex/lib/auth.ts`. **Message delivery only** — all 26 guards are byte-identical, none weakened, added, or moved. `ConvexError` was already the house pattern (`discordMembers.ts`, `outreach.ts`, `outreachAuth.ts`).

### Availability is not delivery — mobile still needs one line

The message stays redacted either way, so a client only benefits once it reads `.data`. The web quiz page now does, and `app/start` already did. **The mobile app does not**: it alerts `err?.message`, and gates its auth-recovery screen on `/not authenticated/i` against `err.message` — which in prod is always the redacted string, meaning that recovery screen has never been able to fire in production.

So the phone keeps showing `Server Error` until `ndm/app/(app)/certification-quiz.tsx` and `providers/AppProviders.tsx` switch to `.data`. One line each, tracked separately in the mobile repo. This PR is the prerequisite that gives them something to read.

## Deploying

The `convex/` half only reaches mobile after `npx convex deploy --prod`. Merging alone does not change what the phone shows.

## Verification

- `tsc --noEmit` clean (one pre-existing unrelated error: stale `.next` type for the retired `/for-business` page)
- eslint clean on every changed file; the 48 `no-explicit-any` in `admin.ts`/`leads.ts`/`lib/auth.ts` are pre-existing — this diff adds zero `any`
- Two adversarial review passes, 16 findings raised, 15 refuted. The one that survived is already folded in: it corrected an earlier claim that `ConvexError` would revive the mobile regex, which is why the "availability is not delivery" section above exists.
- **Not runtime-tested** — neither the web quiz against a live socket nor the mobile alert.

## Noticed, deliberately not fixed here

- `app/admin/submissions/[id]/page.tsx:663` discards `admin.markDeployed` as a "non-blocking audit log", then shows "Website published successfully". It is not an audit log — it sets `status='deployed'`, sets `websiteUrl`, and sends the creator the "Website is Live!" push.
- `AdminLayout.tsx:79` and five other sites subscribe to auth-throwing queries with a literal `{}` and no `"skip"`.
- The quiz pass screen still renders a "Certified Creator / You can now start earning!" certificate to someone who is only quiz-passed, not approved.
- `docs/PRODUCTION_SETUP.md:15` still names `diligent-ibex-454` (the dev deployment) as the prod Convex URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)